### PR TITLE
Codex: Add Simple YT Tweaks swarm packet

### DIFF
--- a/SWARM.md
+++ b/SWARM.md
@@ -1,0 +1,77 @@
+# Simple YT Tweaks Swarm
+
+This repo uses the local Codex swarm workflow for paced controller-led work.
+
+Shared workspace instructions live at:
+
+```text
+../AGENTS.md
+```
+
+If this repo is opened outside `/Users/d4ngl/Git Repos/Codex`, use this file plus `docs/swarm/` as the repo-local source of truth.
+
+## Required Reading
+
+Before acting, read:
+
+1. `../AGENTS.md` if available
+2. `SWARM.md`
+3. `docs/swarm/controller-directives.md`
+4. `docs/swarm/project-brief.md`
+5. `docs/swarm/current-state.md`
+6. `docs/swarm/bootstrap-log.md`
+7. `docs/swarm/agent-registry.md`
+8. `docs/swarm/github.md`
+9. `docs/swarm/task-board.md`
+10. `docs/swarm/user-feedback.md`
+11. Relevant files in `docs/swarm/handoffs/`
+12. `docs/swarm/integration-log.md`
+13. Existing repo docs such as `README.md`, `DEVELOPMENT.md`, `CHANGELOG.md`, and `KNOWN_ISSUES.md`
+
+## Repo Goal
+
+Simple YT Tweaks is a Manifest V3 Chrome/Brave extension that improves YouTube usability with focused cleanup controls for home/search feeds, watch-page modes, sidebar cleanup, Sticky Player, and browser Picture-in-Picture.
+
+The current goal is post-v0.3.0 hardening: make automated verification strong enough that routine changes can move through task branches and draft PRs without requiring the user to manually retest every small patch.
+
+## Working Rules
+
+- Inspect before asking questions.
+- Preserve user work and unrelated changes.
+- Use GitHub issues as the public tracker and keep private notes out of GitHub.
+- Work on task branches named like `swarm/<task-id>-<short-slug>`.
+- Use draft PRs for issue work when useful.
+- Use PR merge as the normal path to update `main`; do not push directly to `main` except an explicitly documented emergency.
+- Every PR body must include `How to test / what to tell the controller`, human review requested (`yes` or `no`), exact commands, expected results, and feedback format when human feedback is requested.
+- Human QA is reserved for release candidates, risky browser behavior, visual/product-direction questions, or explicit reviewer/controller gates. Routine docs, tests, and scoped hardening should use agent review plus repo-owned checks.
+- Use repo-owned automated tests as the primary verification path. Prefer `npm run test:e2e` and `npm run validate:all`; live YouTube smoke and agent-browser are supplemental.
+- Prefer fixture tests by default. Do not rely on live YouTube tests unless clearly useful for a final/manual gate.
+- Keep every task scoped to a task id, branch, owner role, and handoff.
+- Planner-created task lanes must include `parallel-safe`, `serial-required`, `depends-on`, and `conflict-risk` labels before Runner dispatch.
+- Default active capacity is 1 total active subagent.
+- Keep shared coordination files controller-owned during parallel work unless a handoff explicitly assigns them: `docs/swarm/task-board.md`, `docs/swarm/current-state.md`, `docs/swarm/controller-directives.md`, and `docs/swarm/agent-registry.md`.
+- Workers normally update only their handoff, scoped source/test files, and PR body.
+- Do not reintroduce enhanced home/search hover implementation under #10; #8 is the separate future enhancement lane.
+- Do not bump version, tag, release, or update Web Store assets unless a release-candidate lane explicitly asks for it.
+
+## Repo Swarm Files
+
+- `docs/swarm/controller-directives.md`: dynamic controller mode, pacing, next actions, spawn strategy, and stop conditions
+- `docs/swarm/current-state.md`: current mission, constraints, priorities, risks, and verification status
+- `docs/swarm/project-brief.md`: durable discovery brief and milestone lane map
+- `docs/swarm/task-board.md`: active queue and task state
+- `docs/swarm/agent-registry.md`: active agents, capacity, locks, worktrees, PRs, side chats, and ownership
+- `docs/swarm/bootstrap-log.md`: resumable bootstrap phases
+- `docs/swarm/github.md`: branch, PR, merge, and human QA policy
+- `docs/swarm/user-feedback.md`: durable user steering and product direction
+- `docs/swarm/handoffs/`: per-task continuation files
+- `docs/swarm/integration-log.md`: merge and release history
+
+## Automation
+
+This repo should use a paced controller-led model:
+
+- The main repo chat acts as controller.
+- Controller passes should do only a few safe orchestration actions, then leave a clean recovery point.
+- A 90-minute active-pulse heartbeat is proposed after the swarm packet branch is merged and the worktree is clean.
+- The heartbeat prompt should stay generic and read `SWARM.md` plus `docs/swarm/controller-directives.md`; do not encode current PR lists or one-off task state in the automation prompt.

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019dd83b-c95c-7ab3-a871-ed8aa6fb941c` / Gauss | `SYT-CTL-001` | Reviewer | Reviewing PR #11 | `swarm/syt-bootstrap-controller-packet` | repo checkout | #11 | 2026-04-29 03:54 EDT | 2026-04-29 03:54 EDT | Report Ready to Integrate / Needs Fixes / Blocked | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,13 +33,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `SWARM.md`, `docs/swarm/**` | `SYT-CTL-001` | Controller/Reviewer | `swarm/syt-bootstrap-controller-packet` | Bootstrap packet review | Release after PR is merged or abandoned |
+| `SWARM.md`, `docs/swarm/**` | `SYT-CTL-001` | Controller/Integrator | `swarm/syt-bootstrap-controller-packet` | Bootstrap packet integration | Release after PR is merged or abandoned |
 
 ## Recently Completed
 
 | Agent / Thread | Task ID | Role | Result | Completed | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `019dd83b-c95c-7ab3-a871-ed8aa6fb941c` / Gauss | `SYT-CTL-001` | Reviewer | Ready to Integrate, no findings | 2026-04-29 03:54 EDT | Read-only PR #11 review passed. |
 
 ## Pending Launch
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019dd83b-c95c-7ab3-a871-ed8aa6fb941c` / Gauss | `SYT-CTL-001` | Reviewer | Reviewing PR #11 | `swarm/syt-bootstrap-controller-packet` | repo checkout | #11 | 2026-04-29 03:54 EDT | 2026-04-29 03:54 EDT | Report Ready to Integrate / Needs Fixes / Blocked | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `SWARM.md`, `docs/swarm/**` | `SYT-CTL-001` | Controller | `swarm/syt-bootstrap-controller-packet` | Bootstrap packet branch | Release after PR is merged or abandoned |
+| `SWARM.md`, `docs/swarm/**` | `SYT-CTL-001` | Controller/Reviewer | `swarm/syt-bootstrap-controller-packet` | Bootstrap packet review | Release after PR is merged or abandoned |
 
 ## Recently Completed
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -1,0 +1,63 @@
+# Agent Registry
+
+Use this file to track who is working, where they are working, and whether the controller has capacity to spawn more agents.
+
+## Capacity
+
+- Max active planners: 1
+- Max active runners: 1
+- Max active reviewers: 1
+- Max active integrators: 1
+- Max total active agents: 1
+- Capacity note: paced autonomous default. Raise capacity only for a named pass when the user explicitly wants a supervised burst.
+
+## Controller Lease
+
+| Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
+| --- | --- | --- | --- | --- | --- |
+| none | none | none | none | 90 minutes | No active lease after bootstrap turn completes. |
+
+## Active Agents
+
+| Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| none | none | none | none | none | none | none | none | none | none | none |
+
+## Paused / Stale Agents
+
+| Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Last Seen | Expected Next Step | Heartbeat |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| none | none | none | none | none | none | none | none | none | none |
+
+## Reservations / Locks
+
+| Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
+| --- | --- | --- | --- | --- | --- |
+| `SWARM.md`, `docs/swarm/**` | `SYT-CTL-001` | Controller | `swarm/syt-bootstrap-controller-packet` | Bootstrap packet branch | Release after PR is merged or abandoned |
+
+## Recently Completed
+
+| Agent / Thread | Task ID | Role | Result | Completed | Notes |
+| --- | --- | --- | --- | --- | --- |
+| none | none | none | none | none | none |
+
+## Pending Launch
+
+| Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
+| --- | --- | --- | --- | --- |
+| `SYT-010A` | Planner/Runner | `swarm/syt-010a-test-harness-audit` | Launch after `SYT-CTL-001` is merged and worktree is clean | `docs/swarm/handoffs/SYT-010A.md` |
+
+## Side Chats
+
+| Chat / Automation | Task ID | Role | Heartbeat | Status | Stop Condition |
+| --- | --- | --- | --- | --- | --- |
+| none | none | none | none | none | none |
+
+## Rules
+
+- The controller updates this registry before spawning a subagent and after receiving its result.
+- Active Agents should include only agents still expected to report.
+- Do not spawn a new agent when it would exceed capacity.
+- Do not spawn two agents with overlapping write scopes unless one is read-only.
+- Workers normally update only their own handoff and report back; the controller consolidates this registry.
+- During parallel work, the controller owns `docs/swarm/task-board.md`, `docs/swarm/current-state.md`, `docs/swarm/controller-directives.md`, and this registry unless a handoff explicitly assigns one of those files.

--- a/docs/swarm/bootstrap-log.md
+++ b/docs/swarm/bootstrap-log.md
@@ -1,0 +1,56 @@
+# Bootstrap Log
+
+Use this file to make repo bootstrap resumable across controller passes and heartbeat wakes.
+
+## Current Phase
+
+- Phase: 2 Planning
+- Status: In Progress
+- Last Updated: 2026-04-29
+- Owner: Controller
+
+## Phase Checklist
+
+| Phase | Goal | Status | Output |
+| --- | --- | --- | --- |
+| 0 Discovery | Inspect folder, Git state, remotes, scripts, docs, constraints, and project brief | Complete | Existing repo verified; preflight and issues recorded. |
+| 1 Packet | Create `SWARM.md` and `docs/swarm/` shared state files | In Progress | Repo-local swarm packet on `swarm/syt-bootstrap-controller-packet`. |
+| 2 Planning | Create initial milestone plan and task lanes | In Progress | #8/#10 lanes seeded with dependencies and verification. |
+| 3 Dispatch | Start capacity-limited first workers/reviewers | Pending | Do not dispatch until bootstrap PR is integrated. |
+| 4 Stabilize | Verify heartbeat, registry, GitHub, and first handoff loop | Pending | Propose 90-minute heartbeat after clean integration. |
+
+## Decisions
+
+- Existing repo uses existing remote; no new repo is created.
+- Existing GitHub visibility is public; do not change visibility during bootstrap.
+- Fixture Playwright tests are the default verification path.
+- Live YouTube smoke is supplemental and optional.
+- Default capacity is 1 active subagent.
+- #10 hardening runs before any #8 implementation work.
+- #8 remains a high-risk research lane because live YouTube preview lifecycle was previously fragile.
+
+## Material Questions
+
+- None blocking.
+
+## Question Gate
+
+- Status: DEFERRED
+- Asked in controller chat: NO
+- Blocking implementation: NO
+- Notes: Repo visibility and heartbeat creation timing are deferred with conservative defaults.
+
+## Last Controller Action
+
+- 2026-04-29: Read workspace bootstrap docs, inspected repo docs/Git/GitHub/scripts/tests, verified agent-browser wrapper smoke, created repo-local swarm packet branch, and ran `npm run validate:all` successfully after docs creation.
+
+## Next Controller Action
+
+- Run docs checks, commit this docs-only bootstrap packet, push `swarm/syt-bootstrap-controller-packet`, and open a draft PR with `How to test / what to tell the controller`.
+
+## GitHub Bootstrap
+
+- Owner: cryptoteatime
+- Visibility: public existing repo
+- Status: LINKED
+- Next GitHub action: open docs-only bootstrap PR.

--- a/docs/swarm/bootstrap-log.md
+++ b/docs/swarm/bootstrap-log.md
@@ -46,11 +46,11 @@ Use this file to make repo bootstrap resumable across controller passes and hear
 
 ## Next Controller Action
 
-- Run docs checks, commit this docs-only bootstrap packet, push `swarm/syt-bootstrap-controller-packet`, and open a draft PR with `How to test / what to tell the controller`.
+- Review draft PR #11, then integrate if clean. After integration, launch `SYT-010A`.
 
 ## GitHub Bootstrap
 
 - Owner: cryptoteatime
 - Visibility: public existing repo
 - Status: LINKED
-- Next GitHub action: open docs-only bootstrap PR.
+- Next GitHub action: review and integrate docs-only bootstrap PR #11.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -1,0 +1,110 @@
+# Controller Directives
+
+This file is the repo-local dynamic control plane for the controller chat and any heartbeat. Automation prompts should stay stable and read this file every pass.
+
+## Mode
+
+- Controller mode: `AUTOPILOT_WITH_HEARTBEAT`
+- Heartbeat mode: `active-pulse proposed`
+- Heartbeat automation id: `none`
+- Main controller chat: Simple YT Tweaks controller in Codex workspace
+- Last reviewed by controller: 2026-04-29 03:32 EDT
+
+## Current Source Of Truth
+
+- Default branch: `main`
+- Current branch: `swarm/syt-bootstrap-controller-packet`
+- Expected Git state: clean on `main`; this branch may contain controller-owned docs-only bootstrap changes
+- Open PR expectation: none at bootstrap start
+- Active agents expectation: none
+- Controller lease expectation: none after this bootstrap pass finishes
+- Current priority lane: `SYT-010A`
+
+## Controller Lease And Pacing
+
+- Controller lease owner: none
+- Lease started: none
+- Lease expected action: none
+- Lease stop condition: none
+- Lease stale after: 90 minutes
+- Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
+- Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
+- Active capacity: max 1 active subagent total
+- Heartbeat cadence target: 90 minutes while active
+- Next human QA gate: release-candidate lane or #8 visual/product-direction gate
+
+Heartbeat overlap rule:
+
+- If a controller lease is active and younger than 90 minutes, the heartbeat reports in-flight work and stops without editing, spawning, routing, or merging.
+- If the lease is stale, the heartbeat may do recovery-only reconciliation and then stop unless this file explicitly allows more.
+- If no lease blocks progress, the heartbeat may perform only bounded actions allowed here.
+
+## Worktree Hygiene Protocol
+
+1. Inspect `git status --short --branch`, `git diff --stat`, and relevant diffs.
+2. Classify dirty files:
+   - `controller-state`: real active agent registry/task-board state.
+   - `controller-docs`: controller-owned docs-only state repair or swarm packet updates.
+   - `active-agent`: expected changes in a registered task branch/worktree.
+   - `build-artifact`: ignored/generated output such as `dist/`, `release/`, `test-results/`, or `playwright-report/`.
+   - `user-or-unknown`: unclear ownership, source changes in the wrong checkout, or overlapping scope.
+3. Resolve before unrelated spawning:
+   - `controller-state`: reconcile real agents and avoid overlapping work.
+   - `controller-docs`: run `git diff --check`, branch if needed, commit docs, push/open PR, include `How to test / what to tell the controller`, merge only through approved policy.
+   - `active-agent`: route to the owning handoff/agent.
+   - `build-artifact`: leave ignored artifacts alone unless cleanup is explicitly safe.
+   - `user-or-unknown`: preserve first on a recovery branch or stash and stop.
+
+## Reservation Rules
+
+- A row in Active Agents must represent a real agent/thread/command expected to report.
+- A reservation without a real agent id is not active capacity.
+- If a reservation cannot launch in the same pass, release it or move it to Pending Launch notes outside Active Agents.
+- Do not leave fake `pending-spawn` rows in Active Agents across heartbeat passes.
+
+## Spawn Strategy
+
+- Read `docs/swarm/agent-registry.md` before spawning.
+- Default to 1 active subagent at a time.
+- Use low/medium effort for routine routing, docs, review, and fixture-test work.
+- Use high/xhigh only for hard browser-extension architecture, repeated test failures, merge conflicts, or #8 preview lifecycle work.
+- Spawn only when lane labels are present: `parallel-safe`, `serial-required`, `depends-on`, and `conflict-risk`.
+- Use task branches and separate worktrees for parallel work. With current capacity 1, one task branch is enough unless the user raises capacity.
+- Keep #10 hardening separate from #8 enhanced hover research.
+- Do not spawn implementation Runners until the project brief and handoff give a bounded task, branch/worktree rule, write scope, and verification tier.
+
+## GitHub Policy Reminder
+
+- Existing remote: `https://github.com/cryptoteatime/simple-yt-tweaks.git`
+- Repository visibility discovered by `gh repo view`: public.
+- GitHub issue work is approved.
+- Use task branches and draft PRs for issue work when useful.
+- Do not push directly to `main`.
+- PRs require a visible `How to test / what to tell the controller` section.
+- Human QA is not required for routine docs/test/hardening PRs unless a reviewer marks the risk high.
+- Human QA is required for release-candidate behavior and risky browser behavior.
+
+## Verification Tiers
+
+- Runner focused checks: task-specific `npm run test:e2e`, `npm run lint`, `npm run typecheck`, or targeted Playwright project as listed in the handoff.
+- Reviewer targeted checks: changed-risk checks plus PR body/handoff validation.
+- Integrator full verify: `npm run validate:all`.
+- Optional live smoke: `npm run test:e2e:live`, only for final/manual gates or when live YouTube behavior is specifically relevant.
+- Browser QA: repo-owned Playwright first; Browser Use or Chrome-for-Testing `agent-browser` only as supplemental inspection.
+
+## Current Next Actions
+
+| Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `SYT-CTL-001` | Finish swarm packet branch and open docs PR | Controller | `swarm/syt-bootstrap-controller-packet` | PR opened with validation and controller instructions |
+| 2 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 prerequisites | Planner/Runner | `swarm/syt-010a-test-harness-audit` | Fixture gaps documented or covered by tests |
+| 3 | `SYT-010B` | Settings source-of-truth/parity hardening | Senior Runner | `swarm/syt-010b-settings-hardening` | Focused checks pass and no behavior drift |
+| 4 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | `swarm/syt-010c-rc-process` | RC gate documented and automatable |
+| 5 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+
+## Dynamic Notes
+
+- `npm run validate:all` passed on 2026-04-29 during bootstrap.
+- Chrome-for-Testing-backed `agent-browser` wrapper opened and closed `about:blank` successfully.
+- The live YouTube test exists but should not be the normal gate.
+- Issue #8 is intentionally paused until #10 coverage and hardening reduce regression risk.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -1,0 +1,91 @@
+# Current State
+
+## Project
+
+- Name: Simple YT Tweaks
+- Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+- Status: existing repo, post-v0.3.0 hardening setup
+- GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
+
+## Project Brief
+
+- Brief: `docs/swarm/project-brief.md`
+- Question gate: deferred, not blocking
+- Dispatch readiness: docs-only bootstrap in progress; implementation dispatch waits for `SYT-010A`
+
+## Goal
+
+Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHub issue lanes, stronger fixture-first automated verification, and a smoother release-candidate process.
+
+## Current Focus
+
+1. Land the repo-local swarm packet.
+2. Audit Playwright fixture coverage against #8 and #10 risks.
+3. Route #10 hardening into small PRs with `validate:all` as the final gate.
+4. Keep #8 as a future high-risk research lane until tests and product direction justify it.
+
+## Success Criteria
+
+- `SWARM.md` and `docs/swarm/**` exist and are repo-local.
+- Task board maps #8 and #10 into scoped lanes with dependencies, verification commands, PR strategy, and human QA gates.
+- Repo-owned Playwright fixture tests remain the primary verification path.
+- Controller heartbeat is proposed at about 90 minutes after state is clean.
+- No product code is changed during bootstrap.
+
+## Constraints
+
+- Existing repo, not blank.
+- Use existing remote and GitHub issues.
+- Use task branches and draft PRs when useful.
+- Default to 1 active subagent at a time.
+- Do not request human QA for every small PR.
+- Do not rely on live YouTube tests as the default gate.
+- Keep private `.private/` notes off GitHub.
+- Do not bump versions, tag releases, or edit Web Store assets during hardening setup.
+
+## Known Risks
+
+- `src/content/grid-hover.ts`, `sticky-player.ts`, `sidebar.ts`, `fullscreen.ts`, and `theater.ts` are large and touch fragile YouTube DOM behavior.
+- Settings are duplicated between `src/shared/settings.ts` and `src/content/settings.ts`; validation checks parity, but refactoring could affect bundling.
+- Fixture tests do not fully simulate live YouTube hover preview overlay behavior, so #8 needs a research gate and likely human/visual QA.
+- Live YouTube smoke can be flaky due to consent, experiments, bot checks, ads, or network issues.
+
+## Recommended First Milestone
+
+`SYT-010A`: audit and harden Playwright fixture coverage so future #10 code changes can be validated without using the user's normal browser profile.
+
+## Verification Defaults
+
+- Runner focused checks: task-specific `npm run test:e2e`, `npm run lint`, or `npm run typecheck`.
+- Reviewer targeted checks: targeted Playwright tests plus source diff review.
+- Integrator full verify: `npm run validate:all`.
+- Browser QA: repo-owned Playwright first; `agent-browser`/Browser Use only as supplemental inspection.
+- Human milestone QA: release candidate, #8 live hover preview, or explicit high-risk browser behavior.
+
+## Tooling Preflight
+
+- Git: clean `main...origin/main` at discovery.
+- Remote: `origin` points to `https://github.com/cryptoteatime/simple-yt-tweaks.git`.
+- GitHub auth: `gh auth status` passed as `cryptoteatime`.
+- GitHub repo: `cryptoteatime/simple-yt-tweaks`, public, default branch `main`.
+- Runtime: Node `v25.9.0`, npm `11.12.1`.
+- Dependencies: `node_modules/` present.
+- Full verification: `npm run validate:all` passed on 2026-04-29 after the swarm docs were added.
+- Agent browser: `/opt/homebrew/bin/agent-browser`; wrapper `.codex-swarm/bin/agent-browser-cft` opened and closed `about:blank`.
+
+## Automation Notes
+
+- Controller heartbeat: proposed, not created yet.
+- Heartbeat cadence: about 90 minutes while active after docs PR integration and clean state.
+- Execution strategy: paced controller with direct subagents only after lane readiness.
+- Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
+- Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
+- Active subagents: none.
+- Agent registry: `docs/swarm/agent-registry.md`.
+- Bootstrap log: `docs/swarm/bootstrap-log.md`.
+- GitHub workflow: `docs/swarm/github.md`.
+
+## Last Updated
+
+- Date: 2026-04-29
+- By: Controller

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,8 +45,9 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `SYT-CTL-001` | `swarm/syt-bootstrap-controller-packet` | https://github.com/cryptoteatime/simple-yt-tweaks/pull/11 | Draft, needs review | Controller | Docs-only swarm packet. |
 
 ## Setup Log
 
 - 2026-04-29: Existing remote and GitHub auth verified. Open issues #8 and #10 confirmed. Repo visibility discovered as public.
+- 2026-04-29: Opened draft PR #11 for `SYT-CTL-001`.

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -1,0 +1,52 @@
+# GitHub Workflow
+
+Use this file to record the repo's GitHub status and autonomous PR policy.
+
+## Repository
+
+- Owner: cryptoteatime
+- Name: simple-yt-tweaks
+- Visibility: public
+- Remote: `https://github.com/cryptoteatime/simple-yt-tweaks.git`
+- Default branch: `main`
+- GitHub status: LINKED
+
+## Autonomy
+
+- Repo creation: not applicable, existing remote
+- Push permission: APPROVED
+- PR permission: APPROVED
+- Merge permission: APPROVED_WITH_CHECKS
+
+## Branch And PR Policy
+
+- Work happens on `swarm/<task-id>-<short-slug>` branches.
+- Runners push task branches when checks pass.
+- Runners open draft PRs for issue work when useful.
+- Every PR body must include a `How to test / what to tell the controller` section with:
+  - human review requested: `yes` or `no`
+  - local commands or preview URL(s)
+  - expected result
+  - exact feedback format when human feedback is requested
+- Reviewers review the branch/PR and report `Needs Fixes`, `Ready to Integrate`, or `Blocked`.
+- Integrators merge through PR only after checks pass, review is `Ready to Integrate`, conflicts are resolved, and any required human acceptance checklist is passed or explicitly waived here.
+- Controller-owned docs-only repair PRs may be opened and merged when the diff is docs-only, `git diff --check` passes, no human gate is required, and the PR body has controller test instructions.
+- Direct pushes to `main` are not allowed unless a repo-specific emergency is explicitly documented.
+
+## Human Acceptance Gate
+
+- Required for: release candidate, high-risk live YouTube behavior, #8 visual hover preview implementation, or explicit reviewer request.
+- Required before merge: no for routine docs/test/hardening PRs; yes for release candidates and high-risk browser behavior.
+- Who can mark passed: user for human QA; reviewer/integrator for routine agent checks.
+- Pass message format: `Human QA passed for <TASK-ID or PR URL>: <notes>`
+- Fail message format: `Human QA failed for <TASK-ID or PR URL>: <steps and observed problem>`
+
+## Active Pull Requests
+
+| Task ID | Branch | PR | Status | Owner | Notes |
+| --- | --- | --- | --- | --- | --- |
+| none | none | none | none | none | none |
+
+## Setup Log
+
+- 2026-04-29: Existing remote and GitHub auth verified. Open issues #8 and #10 confirmed. Repo visibility discovered as public.

--- a/docs/swarm/handoffs/SYT-008A.md
+++ b/docs/swarm/handoffs/SYT-008A.md
@@ -1,0 +1,73 @@
+# SYT-008A: Enhanced Home/Search Hover Research Gate
+
+## State
+
+- Status: Paused
+- Role: Planner
+- Repo: Simple YT Tweaks
+- Branch: `swarm/syt-008a-hover-research`
+- Owner: Unassigned
+- Created: 2026-04-29
+- Updated: 2026-04-29
+
+## Goal
+
+Research whether #8 can be safely revived in a future release without breaking native YouTube hover autoplay, preview overlays, or edge-card behavior.
+
+## Scope
+
+- Read GitHub #8 and prior handoff notes.
+- Identify what fixture tests can prove and what requires live/manual validation.
+- Propose a prototype plan only after #10 test hardening is in place.
+
+## Non-Scope
+
+- Do not implement enhanced home/search hover in the current hardening milestone.
+- Do not change current native home/search hover behavior.
+- Do not use live YouTube as the only validation path.
+
+## Dependencies
+
+- `SYT-010A` coverage audit complete.
+- User/product-direction gate before implementation.
+
+## Lane Metadata
+
+- Parallel-safe: no with #10 source work.
+- Serial-required: yes; live YouTube preview lifecycle is fragile.
+- Depends-on: `SYT-010A`, user/product gate.
+- Conflict-risk: high; home/search feed CSS, YouTube preview overlay lifecycle, `src/content/grid-hover.ts`.
+- Shared coordination docs allowed: this handoff only unless controller assigns more.
+
+## Verification
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `npm run test:e2e` | Not run for this lane yet | Required for any prototype. |
+| `npm run test:e2e:live` | Not run for this lane yet | Optional research smoke, not stable gate. |
+| Human QA | Not run for this lane yet | Required before merging any visual behavior change. |
+
+## Human Acceptance Checklist
+
+- Required before merge: Yes for any implementation.
+- URL(s): PR TBD
+- Who should test: User for final visual/live YouTube behavior.
+- Expected result: no flicker, no autoplay breakage, no edge clipping, independently disableable.
+- If it passes, tell the controller: `Human QA passed for SYT-008A: <notes>`
+- If it fails, tell the controller: `Human QA failed for SYT-008A: <steps and observed problem>`
+
+## Next Handoff
+
+- Next role: Planner after #10 test hardening.
+- Next action: Research only; do not implement until controller explicitly unpauses #8.
+- Branch/worktree cleanup needed after merge: yes.
+- Copy-ready prompt:
+
+```text
+Plan Simple YT Tweaks SYT-008A only after SYT-010A is integrated.
+
+Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
+Branch: swarm/syt-008a-hover-research
+
+Read GitHub #8, the swarm docs, and docs/swarm/handoffs/SYT-008A.md. Produce a research plan for enhanced home/search hover that preserves native YouTube autoplay and defines fixture/live/manual gates. Do not implement runtime hover behavior unless the controller explicitly unpauses implementation.
+```

--- a/docs/swarm/handoffs/SYT-010A.md
+++ b/docs/swarm/handoffs/SYT-010A.md
@@ -1,0 +1,109 @@
+# SYT-010A: Audit And Harden Fixture Coverage
+
+## State
+
+- Status: Ready
+- Role: Planner/Runner
+- Repo: Simple YT Tweaks
+- Branch: `swarm/syt-010a-test-harness-audit`
+- Owner: Unassigned
+- Created: 2026-04-29
+- Updated: 2026-04-29
+
+## Goal
+
+Audit the existing Playwright extension harness and add missing deterministic fixture coverage needed before #10 hardening and any future #8 research.
+
+## Scope
+
+- Inspect `tests/e2e/extension.fixture.spec.ts`, `tests/e2e/youtube-fixtures.ts`, `tests/e2e/extension-fixture.ts`, and `playwright.config.ts`.
+- Map existing tests to the current GitHub #8/#10 risks.
+- Add fixture tests only where they catch likely regressions from hardening work.
+- Update `DEVELOPMENT.md` or swarm docs if commands/coverage expectations change.
+
+## Non-Scope
+
+- Do not implement enhanced home/search hover.
+- Do not change production behavior unless a fixture bug exposes an obvious test-only issue.
+- Do not rely on live YouTube tests as the primary gate.
+
+## Dependencies
+
+- `SYT-CTL-001` merged.
+
+## Lane Metadata
+
+- Parallel-safe: yes with docs-only lanes if capacity is raised; default capacity still keeps this single-owner.
+- Serial-required: no.
+- Depends-on: `SYT-CTL-001`.
+- Conflict-risk: medium; fixture contracts and test expectations.
+- Shared coordination docs allowed: only this handoff unless controller assigns more.
+
+## Plan
+
+1. Create a task branch from current `main`.
+2. Audit fixture coverage against #10 targets: settings parity, comments visibility, popup defaults, search cleanup, home sponsored gap cleanup, sidebar hover grow, sticky player/PiP click fallback.
+3. Audit #8 prerequisites: prove current home/search native hover code is not reintroduced and identify what fixtures cannot prove.
+4. Add focused fixture coverage for missing deterministic cases.
+5. Run focused tests, then full `npm run validate:all` before PR.
+
+## Files / Areas
+
+- `tests/e2e/**`
+- `playwright.config.ts`
+- `DEVELOPMENT.md`
+- `docs/swarm/handoffs/SYT-010A.md`
+
+## Decisions
+
+- Fixture tests are the gate; live smoke is optional and non-blocking.
+- Any #8 implementation remains paused until this lane identifies a safe proof strategy.
+
+## Work Log
+
+- 2026-04-29: Lane seeded during bootstrap.
+
+## Verification
+
+- Verification tier: focused runner checks plus full gate before PR.
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `npm run test:e2e` | Not run for this lane yet | Required after fixture changes. |
+| `npm run validate:all` | Not run for this lane yet | Required before PR. |
+| `npm run test:e2e:live` | Optional | Use only if the lane explicitly needs live smoke context. |
+
+## Human Acceptance Checklist
+
+- Required before merge: No
+- URL(s): PR TBD
+- Who should test: Reviewer/Integrator
+- Steps:
+  1. Review coverage matrix.
+  2. Run `npm run validate:all`.
+  3. Confirm no human YouTube QA is requested for routine test-hardening changes.
+- Expected result: fixture suite covers the next safe #10 hardening slice and documents #8 limitations.
+- If it passes, tell the controller: `Review passed for SYT-010A: fixture coverage ready`
+- If it fails, tell the controller: `Review failed for SYT-010A: <issue>`
+
+## Blockers / Risks
+
+- Future #8 hover behavior may require live-site observation that fixtures cannot safely prove.
+
+## Next Handoff
+
+- Next role: Runner
+- Next action: Implement coverage audit and missing fixture tests.
+- Branch/worktree cleanup needed after merge: yes.
+- Copy-ready prompt:
+
+```text
+Run Simple YT Tweaks SYT-010A.
+
+Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
+Create branch: swarm/syt-010a-test-harness-audit
+
+Read ../AGENTS.md, SWARM.md, docs/swarm/controller-directives.md, docs/swarm/project-brief.md, docs/swarm/current-state.md, docs/swarm/task-board.md, docs/swarm/github.md, and docs/swarm/handoffs/SYT-010A.md.
+
+Audit Playwright fixture coverage against #8 and #10. Add deterministic fixture tests only where they will catch likely hardening regressions. Keep live YouTube smoke optional and non-blocking. Run npm run test:e2e and npm run validate:all. Update this handoff and open a draft PR with a How to test / what to tell the controller section.
+```

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -1,0 +1,100 @@
+# SYT-010B: Settings Parity And Source-Of-Truth Hardening
+
+## State
+
+- Status: Proposed
+- Role: Senior Runner
+- Repo: Simple YT Tweaks
+- Branch: `swarm/syt-010b-settings-hardening`
+- Owner: Unassigned
+- Created: 2026-04-29
+- Updated: 2026-04-29
+
+## Goal
+
+Reduce settings-maintenance risk after fixture coverage is ready.
+
+## Scope
+
+- Review duplication between `src/shared/settings.ts` and `src/content/settings.ts`.
+- Either consolidate safely or keep duplication and strengthen parity validation/tests.
+- Preserve existing defaults and popup behavior.
+
+## Non-Scope
+
+- Do not change setting defaults.
+- Do not rename user-facing settings unless a separate product decision approves it.
+- Do not edit unrelated modules.
+
+## Dependencies
+
+- `SYT-010A` should complete first so behavior coverage is stronger.
+
+## Lane Metadata
+
+- Parallel-safe: no by default.
+- Serial-required: yes; settings contracts touch popup, content, validation, and storage.
+- Depends-on: `SYT-010A`.
+- Conflict-risk: high; `src/shared/settings.ts`, `src/content/settings.ts`, popup rendering, validation script.
+- Shared coordination docs allowed: only this handoff unless controller assigns more.
+
+## Plan
+
+1. Inspect bundling constraints around shared settings in popup and content script.
+2. Decide whether true consolidation is worth the risk.
+3. If consolidation is not clean, add stronger validation or tests for parity.
+4. Run focused checks and full `npm run validate:all`.
+
+## Files / Areas
+
+- `src/shared/settings.ts`
+- `src/content/settings.ts`
+- `src/popup/popup.ts`
+- `scripts/validate-extension.mjs`
+- `tests/e2e/**` if needed
+
+## Decisions
+
+- Conservative default: strengthen parity checks before attempting a source-of-truth refactor.
+
+## Work Log
+
+- 2026-04-29: Lane seeded during bootstrap.
+
+## Verification
+
+- Verification tier: focused runner checks and full gate.
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `npm run typecheck` | Not run for this lane yet | Required. |
+| `npm run lint` | Not run for this lane yet | Required. |
+| `npm run test:e2e` | Not run for this lane yet | Required if settings or popup behavior changes. |
+| `npm run validate:all` | Not run for this lane yet | Required before PR. |
+
+## Human Acceptance Checklist
+
+- Required before merge: No, unless user-facing settings behavior changes.
+- URL(s): PR TBD
+- Who should test: Reviewer/Integrator
+- Expected result: no behavior drift, settings defaults/storage parity preserved.
+
+## Blockers / Risks
+
+- Consolidating settings may affect content-script bundling. Stop and report if that becomes unclear.
+
+## Next Handoff
+
+- Next role: Senior Runner after `SYT-010A`.
+- Next action: choose conservative parity hardening or safe consolidation.
+- Branch/worktree cleanup needed after merge: yes.
+- Copy-ready prompt:
+
+```text
+Run Simple YT Tweaks SYT-010B after SYT-010A is integrated.
+
+Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
+Create branch: swarm/syt-010b-settings-hardening
+
+Read the swarm docs and docs/swarm/handoffs/SYT-010B.md. Focus on settings parity/source-of-truth hardening. Preserve existing defaults and user-facing behavior. Prefer strengthening validation if consolidation creates bundling risk. Run npm run validate:all before PR.
+```

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -1,0 +1,66 @@
+# SYT-010C: Release-Candidate Process Smoothing
+
+## State
+
+- Status: Proposed
+- Role: Planner/Runner
+- Repo: Simple YT Tweaks
+- Branch: `swarm/syt-010c-rc-process`
+- Owner: Unassigned
+- Created: 2026-04-29
+- Updated: 2026-04-29
+
+## Goal
+
+Make the next release-candidate process smoother and less dependent on ad hoc chat memory.
+
+## Scope
+
+- Document release-candidate gates in `DEVELOPMENT.md` and swarm docs.
+- Define when to run fixture tests, live smoke, package validation, and human QA.
+- Add scripts only if a clear repeatable command is missing.
+
+## Non-Scope
+
+- Do not bump version or create a release.
+- Do not change product behavior.
+- Do not edit Web Store assets unless a future release issue explicitly asks.
+
+## Dependencies
+
+- Prefer waiting for `SYT-010A` so the RC process references accurate test coverage.
+
+## Lane Metadata
+
+- Parallel-safe: yes with source-free docs lanes if capacity is raised.
+- Serial-required: no.
+- Depends-on: `SYT-010A` preferred.
+- Conflict-risk: low/medium; release docs and package scripts.
+- Shared coordination docs allowed: this handoff only unless controller assigns more.
+
+## Verification
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `git diff --check` | Not run for this lane yet | Required for docs-only changes. |
+| `npm run validate:all` | Not run for this lane yet | Required if scripts or release commands change. |
+
+## Human Acceptance Checklist
+
+- Required before merge: No for process docs; yes before an actual release candidate is shipped.
+
+## Next Handoff
+
+- Next role: Planner/Runner after `SYT-010A`.
+- Next action: Turn current release steps into a controller-friendly RC checklist.
+- Branch/worktree cleanup needed after merge: yes.
+- Copy-ready prompt:
+
+```text
+Run Simple YT Tweaks SYT-010C after SYT-010A is integrated or when the controller asks for RC process docs.
+
+Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
+Create branch: swarm/syt-010c-rc-process
+
+Read the swarm docs and docs/swarm/handoffs/SYT-010C.md. Document a release-candidate gate that uses fixture tests first, optional live smoke only when useful, package validation, and human QA only for RC behavior. Do not bump version or release.
+```

--- a/docs/swarm/handoffs/SYT-CTL-001.md
+++ b/docs/swarm/handoffs/SYT-CTL-001.md
@@ -1,0 +1,108 @@
+# SYT-CTL-001: Bootstrap Repo-Local Swarm Packet
+
+## State
+
+- Status: In Progress
+- Role: Controller
+- Repo: Simple YT Tweaks
+- Branch: `swarm/syt-bootstrap-controller-packet`
+- Owner: Controller
+- Created: 2026-04-29
+- Updated: 2026-04-29
+
+## Goal
+
+Create the repo-owned swarm packet and seed paced controller lanes for post-v0.3.0 hardening.
+
+## Scope
+
+- `SWARM.md`
+- `docs/swarm/**`
+- Initial handoffs for #8/#10 lanes
+
+## Non-Scope
+
+- Product runtime code
+- Version bumps, tags, releases, Web Store assets
+- Live YouTube behavior changes
+
+## Dependencies
+
+- Workspace `AGENTS.md` and `.codex-swarm/prompts/REPO_BOOTSTRAP.md` read.
+- Existing repo discovery complete.
+
+## Lane Metadata
+
+- Parallel-safe: no; controller-owned docs bootstrap.
+- Serial-required: yes during bootstrap.
+- Depends-on: none.
+- Conflict-risk: low; docs only.
+- Shared coordination docs allowed: all `docs/swarm/**` for controller.
+
+## Plan
+
+1. Create repo-local swarm files.
+2. Seed #8/#10 task lanes and handoffs.
+3. Run docs checks.
+4. Commit, push, and open a draft PR with controller test instructions.
+
+## Files / Areas
+
+- `SWARM.md`
+- `docs/swarm/**`
+
+## Decisions
+
+- Record heartbeat as proposed, not active, until the docs branch is merged and the repo is clean.
+- Treat live YouTube smoke as supplemental only.
+- Route first implementation work to `SYT-010A`.
+
+## Work Log
+
+- 2026-04-29: Repo discovery and tooling preflight completed. `npm run validate:all` passed before docs edits.
+
+## Verification
+
+- Verification tier: docs-only plus full baseline preflight.
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `npm run validate:all` | PASS | Ran after docs edits. |
+| `git diff --check` | PASS | Included in `validate:all`; also ran directly before full gate. |
+
+## Human Acceptance Checklist
+
+- Required before merge: No
+- URL(s): PR TBD
+- Who should test: Reviewer/Integrator
+- Steps:
+  1. Review docs for accurate repo policy and lanes.
+  2. Run `git diff --check`.
+  3. Confirm no product code changed.
+- Expected result: docs-only bootstrap packet is accurate and mergeable.
+- If it passes, tell the controller: `Review passed for SYT-CTL-001: docs-only bootstrap ready`
+- If it fails, tell the controller: `Review failed for SYT-CTL-001: <issue>`
+
+## Blockers / Risks
+
+- None.
+
+## Next Handoff
+
+- Next role: Reviewer
+- Next action: Review docs-only bootstrap PR.
+- Branch/worktree cleanup needed after merge: yes, delete branch after merge.
+- Copy-ready prompt:
+
+```text
+Review Simple YT Tweaks SYT-CTL-001.
+
+Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
+Branch: swarm/syt-bootstrap-controller-packet
+
+Read ../AGENTS.md, SWARM.md, docs/swarm/controller-directives.md, docs/swarm/project-brief.md, docs/swarm/current-state.md, docs/swarm/task-board.md, docs/swarm/github.md, and docs/swarm/handoffs/SYT-CTL-001.md.
+
+Review only the repo-local swarm packet. Confirm the docs accurately reflect the existing repo, GitHub policy, #8/#10 lanes, verification strategy, and controller pacing. Run git diff --check. Do not change product code.
+
+Report findings first. If clean, mark Ready to Integrate.
+```

--- a/docs/swarm/handoffs/SYT-CTL-001.md
+++ b/docs/swarm/handoffs/SYT-CTL-001.md
@@ -2,7 +2,7 @@
 
 ## State
 
-- Status: In Progress
+- Status: Needs Review
 - Role: Controller
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-bootstrap-controller-packet`
@@ -73,7 +73,7 @@ Create the repo-owned swarm packet and seed paced controller lanes for post-v0.3
 ## Human Acceptance Checklist
 
 - Required before merge: No
-- URL(s): PR TBD
+- URL(s): https://github.com/cryptoteatime/simple-yt-tweaks/pull/11
 - Who should test: Reviewer/Integrator
 - Steps:
   1. Review docs for accurate repo policy and lanes.
@@ -90,7 +90,7 @@ Create the repo-owned swarm packet and seed paced controller lanes for post-v0.3
 ## Next Handoff
 
 - Next role: Reviewer
-- Next action: Review docs-only bootstrap PR.
+- Next action: Review docs-only bootstrap PR #11.
 - Branch/worktree cleanup needed after merge: yes, delete branch after merge.
 - Copy-ready prompt:
 

--- a/docs/swarm/handoffs/SYT-CTL-001.md
+++ b/docs/swarm/handoffs/SYT-CTL-001.md
@@ -2,8 +2,8 @@
 
 ## State
 
-- Status: Needs Review
-- Role: Controller
+- Status: Ready to Integrate
+- Role: Integrator
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-bootstrap-controller-packet`
 - Owner: Controller
@@ -89,8 +89,8 @@ Create the repo-owned swarm packet and seed paced controller lanes for post-v0.3
 
 ## Next Handoff
 
-- Next role: Reviewer
-- Next action: Review docs-only bootstrap PR #11.
+- Next role: Integrator
+- Next action: Mark draft PR #11 ready if needed, merge it through GitHub, sync `main`, and clean the task branch if safe.
 - Branch/worktree cleanup needed after merge: yes, delete branch after merge.
 - Copy-ready prompt:
 

--- a/docs/swarm/integration-log.md
+++ b/docs/swarm/integration-log.md
@@ -18,7 +18,7 @@ Use this file for merge decisions, conflict history, final checks, and release n
 - Target branch: `main`
 - Candidate branch(es): `swarm/syt-bootstrap-controller-packet`
 - PR(s): https://github.com/cryptoteatime/simple-yt-tweaks/pull/11
-- Decision: Pending review
+- Decision: Ready to Integrate
 - Reason: Repo-local swarm packet is being created.
 - Conflicts: none known
 - Checks:
@@ -32,5 +32,6 @@ Use this file for merge decisions, conflict history, final checks, and release n
 - Notes:
   - Existing repo is public and already released at v0.3.0.
   - Open work lanes are #8 and #10.
+  - Reviewer Gauss reported no findings and marked PR #11 Ready to Integrate.
 - Follow-ups:
   - `SYT-010A`

--- a/docs/swarm/integration-log.md
+++ b/docs/swarm/integration-log.md
@@ -1,0 +1,36 @@
+# Integration Log
+
+Use this file for merge decisions, conflict history, final checks, and release notes.
+
+## Integration Policy
+
+- Only the Integrator / Merge Captain merges.
+- Merge only when fully confident.
+- Stop and document blockers when scope, review, conflicts, or checks are unclear.
+- Delete merged remote branches and clean local task branches/worktrees only when safe.
+- Record blockers for dirty, unmerged, ambiguous, or user-owned work.
+
+## Entries
+
+### 2026-04-29: Bootstrap Baseline
+
+- Integrator: none yet
+- Target branch: `main`
+- Candidate branch(es): `swarm/syt-bootstrap-controller-packet`
+- PR(s): none yet
+- Decision: Pending
+- Reason: Repo-local swarm packet is being created.
+- Conflicts: none known
+- Checks:
+  - `npm run validate:all`: PASS after docs edits
+  - `.codex-swarm/bin/agent-browser-cft --session simple-yt-tweaks-bootstrap open about:blank`: PASS
+  - `.codex-swarm/bin/agent-browser-cft --session simple-yt-tweaks-bootstrap close --all`: PASS
+- Human acceptance: NOT_REQUIRED for docs-only bootstrap
+- Human acceptance evidence: routine controller setup; no product behavior change
+- Branch cleanup: pending PR integration
+- Worktree cleanup: pending PR integration
+- Notes:
+  - Existing repo is public and already released at v0.3.0.
+  - Open work lanes are #8 and #10.
+- Follow-ups:
+  - `SYT-010A`

--- a/docs/swarm/integration-log.md
+++ b/docs/swarm/integration-log.md
@@ -17,8 +17,8 @@ Use this file for merge decisions, conflict history, final checks, and release n
 - Integrator: none yet
 - Target branch: `main`
 - Candidate branch(es): `swarm/syt-bootstrap-controller-packet`
-- PR(s): none yet
-- Decision: Pending
+- PR(s): https://github.com/cryptoteatime/simple-yt-tweaks/pull/11
+- Decision: Pending review
 - Reason: Repo-local swarm packet is being created.
 - Conflicts: none known
 - Checks:

--- a/docs/swarm/project-brief.md
+++ b/docs/swarm/project-brief.md
@@ -1,0 +1,114 @@
+# Project Brief
+
+## Project Identity
+
+- Name: Simple YT Tweaks
+- Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+- Status: existing repo, active post-v0.3.0 hardening
+- Owner / GitHub Org: `cryptoteatime`
+- Primary Controller Chat: Simple YT Tweaks Codex controller
+
+## Vision
+
+Make Simple YT Tweaks a small, dependable Chrome/Brave extension with enough automated browser-extension verification that routine hardening and bug fixes can be handled by agents through scoped PRs instead of requiring the user to manually retest every pass.
+
+## Target Users
+
+- Primary: the repo owner using Brave/Chrome on YouTube.
+- Secondary: Chrome/Brave users who want focused YouTube cleanup without a large extension surface.
+
+## First Useful Milestone
+
+- Goal: post-v0.3.0 hardening and autonomous controller setup.
+- Success looks like: fixture tests cover current regression-prone behavior, #8/#10 are decomposed into scoped lanes, PRs include controller test instructions, and `npm run validate:all` is the normal gate.
+- Human QA required before merge: no for routine docs/test/hardening PRs; yes for release-candidate behavior and high-risk live YouTube behavior.
+
+## Non-Goals And Constraints
+
+- Do not reintroduce enhanced home/search hover under #10.
+- Do not rely on live YouTube as the primary verification gate.
+- Do not bump version, tag, release, or edit Web Store assets unless a release-candidate lane explicitly asks for it.
+- Keep private handoff notes and screenshots out of GitHub.
+- Preserve native YouTube autoplay and click behavior.
+- Keep fixture tests deterministic and repo-owned.
+
+## Existing Facts
+
+- Tech stack: Manifest V3 extension, TypeScript, Vite, Playwright, ESLint.
+- Package manager: npm with `package-lock.json`.
+- Runtime preflight: Node `v25.9.0`, npm `11.12.1`.
+- Key scripts:
+  - `npm run typecheck`
+  - `npm run lint`
+  - `npm run validate`
+  - `npm run package`
+  - `npm run test:e2e`
+  - `npm run test:e2e:live`
+  - `npm run validate:all`
+- Tests:
+  - Playwright fixture project routes local YouTube-like pages.
+  - Optional live smoke project runs against real YouTube in an isolated Chromium profile.
+- Git status at discovery: clean `main...origin/main`.
+- Remote: `https://github.com/cryptoteatime/simple-yt-tweaks.git`.
+- GitHub repository: `cryptoteatime/simple-yt-tweaks`, public, default branch `main`.
+- Open issues at discovery:
+  - #8 `Revisit enhanced home/search grid hover preview`
+  - #10 `Post-harness code hardening pass`
+- Browser tooling:
+  - Repo-owned Playwright is available and passing.
+  - Chrome-for-Testing-backed `agent-browser` wrapper opened/closed `about:blank`.
+- Validation during bootstrap:
+  - `npm run validate:all`: pass.
+
+## Assumptions
+
+- Existing public GitHub visibility is intentional; do not change repository visibility as part of bootstrap.
+- The controller may open task branches and draft PRs under the existing remote.
+- Routine test/docs/hardening PRs do not need human QA.
+- Human QA is still valuable for release candidates and visual live-site behavior where fixtures cannot prove YouTube experiment compatibility.
+
+## Material Questions
+
+No blocking material questions for the current setup. Defaults are safe:
+
+| Question | Why It Matters | Default If Unanswered | Status |
+| --- | --- | --- | --- |
+| Should repo visibility remain public? | Bootstrap template defaults private, but the existing repo is public. | Keep existing visibility unchanged. | Deferred, non-blocking |
+| Should the 90-minute heartbeat be created now? | A real automation should wait until the docs PR is merged and state is clean. | Record heartbeat as proposed, create after clean integration. | Deferred, non-blocking |
+
+## Milestone Sequence
+
+| Milestone | Goal | Human QA Gate | Notes |
+| --- | --- | --- | --- |
+| M0 | Land repo-local swarm packet | No | Docs-only PR, validates with `git diff --check`. |
+| M1 | Test harness coverage audit | No | Ensure fixtures catch #10 hardening risks and guard #8 prerequisites. |
+| M2 | Code hardening slices under #10 | No by default | Start with settings parity/source-of-truth and pure helper tests. |
+| M3 | Release-candidate workflow smoothing | Yes at final RC | Make validation/package/release checklist controller-friendly. |
+| M4 | Future #8 hover research | Yes before implementation merge | Treat as research/prototype because live YouTube preview behavior is high risk. |
+
+## Candidate Parallel Lanes
+
+| Lane | Role | Write Scope | Parallel-Safe | Serial-Required | Depends On | Conflict Risk | Can Run In Parallel With |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `SYT-CTL-001` | Controller | `SWARM.md`, `docs/swarm/**` | No, controller-owned docs | Yes during bootstrap | none | Low, docs only | none under capacity 1 |
+| `SYT-010A` | Planner/Runner | `tests/e2e/**`, `DEVELOPMENT.md`, handoff | Yes with docs-only lanes if capacity raised | No | `SYT-CTL-001` merged | Medium: fixture contracts | none by default |
+| `SYT-010B` | Senior Runner | `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, tests | No while settings contracts change | Yes | `SYT-010A` coverage decision | High: shared settings contracts | none |
+| `SYT-010C` | Planner/Runner | `DEVELOPMENT.md`, `docs/swarm/**`, package scripts if needed | Yes with source-free docs if capacity raised | No | `SYT-CTL-001`; ideally after `SYT-010A` | Low/Medium | none by default |
+| `SYT-008A` | Planner | issue #8 research notes, fixtures/prototype branch only | No with #10 source work | Yes until research gate passes | `SYT-010A`; user/product gate before implementation | High: live YouTube preview lifecycle | none |
+
+## Verification Strategy
+
+- Unit/type/static checks: `npm run typecheck`, `npm run lint`, `git diff --check`.
+- Extension validation/package: `npm run validate`, `npm run package`.
+- Integration/e2e checks: `npm run test:e2e`.
+- Full gate: `npm run validate:all`.
+- Optional live smoke: `npm run test:e2e:live` for RC or live-site risk only.
+- Browser QA: Playwright fixtures first; Browser Use or `agent-browser` only for supplemental visual/live inspection.
+- Human milestone QA: release candidates and #8 visual behavior.
+- Runner verification tier: focused task checks.
+- Reviewer verification tier: targeted checks based on changed risk.
+- Integrator verification tier: full `npm run validate:all` before merge for non-docs/checkpoint work.
+
+## Next Controller Decision
+
+Finish and publish `SYT-CTL-001` as a docs-only draft PR. After that, run `SYT-010A` before implementation hardening so the test harness becomes the safety net for #10.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -1,0 +1,70 @@
+# Task Board
+
+Use this file as the repo-local queue. Keep entries short and route details to handoff files.
+
+## Status Values
+
+`Proposed`, `Ready`, `In Progress`, `Needs Review`, `Needs Fixes`, `Ready for Human QA`, `Ready to Integrate`, `Integrated`, `Blocked`, `Paused`
+
+## Planning Gate
+
+- Project brief: Ready
+- Material questions: Deferred, not blocking
+- First milestone plan: Ready
+- Implementation dispatch: Ready after `SYT-CTL-001` lands; first implementation lane is `SYT-010A`
+
+## Active Tasks
+
+| Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `SYT-CTL-001` | Bootstrap repo-local swarm packet | Controller | In Progress | `swarm/syt-bootstrap-controller-packet` | `SWARM.md`, `docs/swarm/**` | serial-required | none | low, docs only | `docs/swarm/handoffs/SYT-CTL-001.md` | none yet |
+| `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Planner/Runner | Ready | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | none |
+| `SYT-010B` | Settings parity and source-of-truth hardening | Senior Runner | Proposed | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | none |
+| `SYT-010C` | Release-candidate process smoothing | Planner/Runner | Proposed | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
+| `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
+
+## Backlog
+
+| Task ID | Title | Reason | Notes |
+| --- | --- | --- | --- |
+| `SYT-010D` | Pure helper tests | Add fast coverage for settings normalization and selector-safe DOM helpers. | Can follow `SYT-010A` if it identifies browser-independent logic. |
+| `SYT-010E` | Large module split review | Reduce risk in large content modules only where it lowers real maintenance cost. | Do not split for aesthetics; require test coverage first. |
+| `SYT-RC-001` | Next release-candidate checklist | Make future version bump/package/release flow smoother. | Human QA required before release. |
+
+## Blocked
+
+| Task ID | Blocker | Needed From | Next Check |
+| --- | --- | --- | --- |
+| none | none | none | none |
+
+## Ready For Review
+
+| Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
+| --- | --- | --- | --- | --- |
+| none | none | none | none | none |
+
+## Ready To Integrate
+
+| Task ID | Branch | Checks | Cleanup Plan | Handoff |
+| --- | --- | --- | --- | --- |
+| none | none | none | none | none |
+
+## Human QA
+
+| Task ID | PR / URL | Status | Required Before Merge | Exact Pass/Fail Message |
+| --- | --- | --- | --- | --- |
+| `SYT-008A` | none | Not started | Yes before implementing visual hover behavior | `Human QA passed/failed for SYT-008A: <notes>` |
+| `SYT-RC-001` | none | Not started | Yes before release | `Human QA passed/failed for SYT-RC-001: <notes>` |
+
+## Controller Notes
+
+- Active controller-spawned subagents: none.
+- Active cron bursts: none; cron is a failsafe, not the normal execution path.
+- Parallel worktree root: none yet.
+- Batch dispatch policy: disabled by default because max active subagents is 1.
+- Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work.
+- Verification tiers: focused runner checks, targeted reviewer checks, full integrator/checkpoint verify.
+- Agent registry: `docs/swarm/agent-registry.md`.
+- Bootstrap log: `docs/swarm/bootstrap-log.md`.
+- GitHub workflow: `docs/swarm/github.md`.
+- Current controller phase: Phase 1/2 packet and planning.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -17,7 +17,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `SYT-CTL-001` | Bootstrap repo-local swarm packet | Controller | Needs Review | `swarm/syt-bootstrap-controller-packet` | `SWARM.md`, `docs/swarm/**` | serial-required | none | low, docs only | `docs/swarm/handoffs/SYT-CTL-001.md` | #11 |
+| `SYT-CTL-001` | Bootstrap repo-local swarm packet | Integrator | Ready to Integrate | `swarm/syt-bootstrap-controller-packet` | `SWARM.md`, `docs/swarm/**` | serial-required | none | low, docs only | `docs/swarm/handoffs/SYT-CTL-001.md` | #11 |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Planner/Runner | Ready | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | none |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Senior Runner | Proposed | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | none |
 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | Proposed | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
@@ -41,13 +41,13 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| `SYT-CTL-001` | `swarm/syt-bootstrap-controller-packet` | Docs accuracy, GitHub policy, lane scoping | docs/full baseline already run | `docs/swarm/handoffs/SYT-CTL-001.md` |
+| none | none | none | none | none |
 
 ## Ready To Integrate
 
 | Task ID | Branch | Checks | Cleanup Plan | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-CTL-001` | `swarm/syt-bootstrap-controller-packet` | Reviewer passed; `git diff --check`; `npm run validate:all` | Merge PR #11, delete branch if safe, sync `main` | `docs/swarm/handoffs/SYT-CTL-001.md` |
 
 ## Human QA
 

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -17,7 +17,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `SYT-CTL-001` | Bootstrap repo-local swarm packet | Controller | In Progress | `swarm/syt-bootstrap-controller-packet` | `SWARM.md`, `docs/swarm/**` | serial-required | none | low, docs only | `docs/swarm/handoffs/SYT-CTL-001.md` | none yet |
+| `SYT-CTL-001` | Bootstrap repo-local swarm packet | Controller | Needs Review | `swarm/syt-bootstrap-controller-packet` | `SWARM.md`, `docs/swarm/**` | serial-required | none | low, docs only | `docs/swarm/handoffs/SYT-CTL-001.md` | #11 |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Planner/Runner | Ready | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | none |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Senior Runner | Proposed | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | none |
 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | Proposed | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
@@ -41,7 +41,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-CTL-001` | `swarm/syt-bootstrap-controller-packet` | Docs accuracy, GitHub policy, lane scoping | docs/full baseline already run | `docs/swarm/handoffs/SYT-CTL-001.md` |
 
 ## Ready To Integrate
 

--- a/docs/swarm/user-feedback.md
+++ b/docs/swarm/user-feedback.md
@@ -1,0 +1,34 @@
+# User Feedback
+
+Use this file for durable human steering that should survive across controller turns, subagents, and heartbeats.
+
+## Active Steering
+
+- 2026-04-29: Use the workspace repo bootstrap flow for an existing repo, not a new project.
+- 2026-04-29: Put Simple YT Tweaks into a paced autonomous controller rhythm for hardening, issue cleanup, automated verification, and smoother release-candidate process.
+- 2026-04-29: Prefer fixture tests by default. Do not rely on live YouTube tests unless clearly useful for a final/manual gate.
+- 2026-04-29: Make repo-owned automated tests the primary verification path. Browser/agent-browser/manual QA should supplement, not replace, Playwright/extension tests.
+- 2026-04-29: Use task branches and draft PRs when useful. Include `How to test / what to tell the controller` in PR bodies.
+- 2026-04-29: Do not request human QA for every small PR. Save human QA for release candidates, risky browser behavior, or visual/product-direction questions.
+- 2026-04-29: Default to 1 active subagent at a time and a slow controller heartbeat around 90 minutes after repo state is clean.
+
+## Product Ideas
+
+| Idea | Source | Status | Routed Task |
+| --- | --- | --- | --- |
+| Revisit enhanced home/search grid hover preview | GitHub #8 / prior manual testing | Deferred | `SYT-008A` |
+| Strengthen fixture tests before hardening code | User | Planned | `SYT-010A` |
+| Smooth release-candidate validation/package flow | User | Planned | `SYT-010C` |
+
+## Human QA Notes
+
+| Date | Milestone / PR | Result | Notes |
+| --- | --- | --- | --- |
+| 2026-04-29 | v0.3.0 baseline | Passed previously | v0.3.0 released; hardening starts from passing baseline. |
+
+## Rules
+
+- Controllers and planners read this file before planning new lanes.
+- New feedback should be captured here first, then routed to `docs/swarm/task-board.md` or a handoff.
+- Human QA feedback should be specific enough for a Runner or Planner to continue without chat history.
+- Agents should keep working on other unblocked tasks when feedback is not required for the current lane.


### PR DESCRIPTION
## Summary

- Adds the repo-local swarm packet: `SWARM.md` and `docs/swarm/**`.
- Records controller pacing, GitHub workflow, test/verification defaults, and current repo state.
- Seeds scoped lanes and handoffs for #10 hardening and #8 future hover research.

Refs #10 and #8.

## Validation

- `git diff --check`
- `npm run validate:all`
- `.codex-swarm/bin/agent-browser-cft --session simple-yt-tweaks-bootstrap open about:blank`
- `.codex-swarm/bin/agent-browser-cft --session simple-yt-tweaks-bootstrap close --all`

## How to test / what to tell the controller

Human review requested: no.

Run:

```bash
git diff --check origin/main...HEAD
npm run validate:all
```

Expected result:

- Diff is docs-only (`SWARM.md` and `docs/swarm/**`).
- `validate:all` passes.
- Task board shows `SYT-010A` as the next implementation lane and keeps #8 paused behind the research gate.

Tell the controller:

```text
Review passed for SYT-CTL-001: docs-only bootstrap ready
```

If it fails:

```text
Review failed for SYT-CTL-001: <specific doc/policy/check issue>
```