### PR TITLE
Harden settings parity validation

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019dd9b0-7e98-7983-88de-9463e804000e` / Hypatia | `SYT-010B` | Reviewer | Reviewing PR #14 | `swarm/syt-010b-settings-hardening` | repo checkout | #14 | 2026-04-29 10:38 EDT | 2026-04-29 10:38 EDT | Report Ready to Integrate / Needs Fixes / Blocked | `simple-yt-tweaks-controller-heartbeat` |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Reviewer Hypatia | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth review | Release after PR #14 is merged or abandoned |
+| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Integrator pending | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth integration | Release after PR #14 is merged or abandoned |
 
 ## Recently Completed
 
@@ -45,12 +45,13 @@ Use this file to track who is working, where they are working, and whether the c
 | `019dd89b-89b0-79f3-bf62-b64b3cb0ae6f` / Mendel | `SYT-010A` | Reviewer | Ready to Integrate, no findings | 2026-04-29 07:12 EDT | Targeted PR #12 review passed; `npm run test:e2e` and `git diff --check origin/main...HEAD` passed. |
 | `019dd8f8-d696-7f82-a403-c1f7b70e2716` / McClintock | `SYT-010A` | Integrator | Merged PR #12 | 2026-04-29 07:25 EDT | PR #12 squash-merged into `main` at `59ec975`; local task branch deleted and remote branch already removed. |
 | `019dd952-fc1f-7692-878b-cc0cbaa13d42` / Linnaeus | `SYT-010B` | Senior Runner | Opened draft PR #14 | 2026-04-29 10:38 EDT | Conservative validation hardening; `npm run validate:all`, `npm run test:e2e`, `npm run lint`, and `npm run typecheck` passed. |
+| `019dd9b0-7e98-7983-88de-9463e804000e` / Hypatia | `SYT-010B` | Reviewer | Ready to Integrate, no findings | 2026-04-29 12:15 EDT | Targeted PR #14 review passed; `npm run validate`, `npm run build`, `npm run test:e2e`, and content-script module checks passed. |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010B` | Integrator | `swarm/syt-010b-settings-hardening` / repo checkout | PR #14 remains mergeable after controller ready-state update is pushed | `docs/swarm/handoffs/SYT-010B.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -49,7 +49,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010B` | Senior Runner | `swarm/syt-010b-settings-hardening` / repo checkout | Controller routes one runner on this branch, then records the agent id in Active Agents | `docs/swarm/handoffs/SYT-010B.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019dda09-c04a-7040-ab08-a641d093f545` / Helmholtz | `SYT-010B` | Integrator | Integrating PR #14 | `swarm/syt-010b-settings-hardening` | repo checkout | #14 | 2026-04-29 12:16 EDT | 2026-04-29 12:16 EDT | Run `npm run validate:all`, merge PR #14 if clean, sync `main`, report cleanup | `simple-yt-tweaks-controller-heartbeat` |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Integrator pending | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth integration | Release after PR #14 is merged or abandoned |
+| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Integrator Helmholtz | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth integration | Release after PR #14 is merged or abandoned |
 
 ## Recently Completed
 
@@ -51,7 +51,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010B` | Integrator | `swarm/syt-010b-settings-hardening` / repo checkout | PR #14 remains mergeable after controller ready-state update is pushed | `docs/swarm/handoffs/SYT-010B.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019dd952-fc1f-7692-878b-cc0cbaa13d42` / Linnaeus | `SYT-010B` | Senior Runner | Settings hardening in progress | `swarm/syt-010b-settings-hardening` | repo checkout | none yet | 2026-04-29 08:57 EDT | 2026-04-29 08:57 EDT | Implement narrow parity/source-of-truth hardening, run checks, open draft PR | `simple-yt-tweaks-controller-heartbeat` |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Senior Runner Linnaeus | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth hardening | Release after PR is merged or abandoned |
 
 ## Recently Completed
 
@@ -49,7 +49,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010B` | Senior Runner | `swarm/syt-010b-settings-hardening` / repo checkout | Controller routes one runner on this branch, then records the agent id in Active Agents | `docs/swarm/handoffs/SYT-010B.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019dd9b0-7e98-7983-88de-9463e804000e` / Hypatia | `SYT-010B` | Reviewer | Reviewing PR #14 | `swarm/syt-010b-settings-hardening` | repo checkout | #14 | 2026-04-29 10:38 EDT | 2026-04-29 10:38 EDT | Report Ready to Integrate / Needs Fixes / Blocked | `simple-yt-tweaks-controller-heartbeat` |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Reviewer pending | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth review | Release after PR #14 is merged or abandoned |
+| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Reviewer Hypatia | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth review | Release after PR #14 is merged or abandoned |
 
 ## Recently Completed
 
@@ -50,7 +50,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010B` | Reviewer | `swarm/syt-010b-settings-hardening` / repo checkout | PR #14 remains open and mergeable after controller review-state update is pushed | `docs/swarm/handoffs/SYT-010B.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019dd952-fc1f-7692-878b-cc0cbaa13d42` / Linnaeus | `SYT-010B` | Senior Runner | Settings hardening in progress | `swarm/syt-010b-settings-hardening` | repo checkout | none yet | 2026-04-29 08:57 EDT | 2026-04-29 08:57 EDT | Implement narrow parity/source-of-truth hardening, run checks, open draft PR | `simple-yt-tweaks-controller-heartbeat` |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Senior Runner Linnaeus | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth hardening | Release after PR is merged or abandoned |
+| `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, `tests/e2e/**`, `docs/swarm/handoffs/SYT-010B.md` | `SYT-010B` | Reviewer pending | `swarm/syt-010b-settings-hardening` / repo checkout | Settings parity/source-of-truth review | Release after PR #14 is merged or abandoned |
 
 ## Recently Completed
 
@@ -44,12 +44,13 @@ Use this file to track who is working, where they are working, and whether the c
 | `019dd841-965d-7cf2-be3b-d79b0f2e0595` / Beauvoir | `SYT-010A` | Runner | Opened draft PR #12 | 2026-04-29 05:37 EDT | `npm run test:e2e`, `npm run validate:all`, and `git diff --check` passed. |
 | `019dd89b-89b0-79f3-bf62-b64b3cb0ae6f` / Mendel | `SYT-010A` | Reviewer | Ready to Integrate, no findings | 2026-04-29 07:12 EDT | Targeted PR #12 review passed; `npm run test:e2e` and `git diff --check origin/main...HEAD` passed. |
 | `019dd8f8-d696-7f82-a403-c1f7b70e2716` / McClintock | `SYT-010A` | Integrator | Merged PR #12 | 2026-04-29 07:25 EDT | PR #12 squash-merged into `main` at `59ec975`; local task branch deleted and remote branch already removed. |
+| `019dd952-fc1f-7692-878b-cc0cbaa13d42` / Linnaeus | `SYT-010B` | Senior Runner | Opened draft PR #14 | 2026-04-29 10:38 EDT | Conservative validation hardening; `npm run validate:all`, `npm run test:e2e`, `npm run lint`, and `npm run typecheck` passed. |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010B` | Reviewer | `swarm/syt-010b-settings-hardening` / repo checkout | PR #14 remains open and mergeable after controller review-state update is pushed | `docs/swarm/handoffs/SYT-010B.md` |
 
 ## Side Chats
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,7 +16,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010b-settings-hardening`
 - Expected Git state: clean task branch with PR #14 open and mergeable
 - Open PR expectation: PR #14 open for `SYT-010B`
-- Active agents expectation: none after Hypatia completed PR #14 review
+- Active agents expectation: Helmholtz integrating PR #14
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: `SYT-010B` integration
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -14,11 +14,11 @@ This file is the repo-local dynamic control plane for the controller chat and an
 
 - Default branch: `main`
 - Current branch: `swarm/syt-010b-settings-hardening`
-- Expected Git state: clean task branch with pending `SYT-010B` runner launch
-- Open PR expectation: none for `SYT-010A`
-- Active agents expectation: Linnaeus running `SYT-010B`
+- Expected Git state: clean task branch with PR #14 open and mergeable
+- Open PR expectation: PR #14 open for `SYT-010B`
+- Active agents expectation: none after Linnaeus completed `SYT-010B`
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010B` runner launch
+- Current priority lane: `SYT-010B` review
 
 ## Controller Lease And Pacing
 
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010B` | Settings source-of-truth/parity hardening | Senior Runner | `swarm/syt-010b-settings-hardening` | Focused checks pass and no behavior drift |
+| 1 | `SYT-010B` | Review settings source-of-truth/parity hardening PR #14 | Reviewer | `swarm/syt-010b-settings-hardening` | Review result is Ready to Integrate / Needs Fixes / Blocked |
 | 2 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | `swarm/syt-010c-rc-process` | RC gate documented and automatable |
 | 3 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
@@ -108,3 +108,4 @@ Heartbeat overlap rule:
 - Issue #8 is intentionally paused until #10 coverage and hardening reduce regression risk.
 - PR #11 merged; PR #12 squash-merged into `main` at `59ec975`.
 - `SYT-010A` remote and local task branches were cleaned after merge.
+- PR #14 is open for `SYT-010B`; runner validation passed and no human QA was requested.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,7 +16,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010b-settings-hardening`
 - Expected Git state: clean task branch with PR #14 open and mergeable
 - Open PR expectation: PR #14 open for `SYT-010B`
-- Active agents expectation: none after Linnaeus completed `SYT-010B`
+- Active agents expectation: Hypatia reviewing PR #14
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: `SYT-010B` review
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,7 +16,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010b-settings-hardening`
 - Expected Git state: clean task branch with pending `SYT-010B` runner launch
 - Open PR expectation: none for `SYT-010A`
-- Active agents expectation: pending `SYT-010B` Senior Runner launch
+- Active agents expectation: Linnaeus running `SYT-010B`
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: `SYT-010B` runner launch
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -13,12 +13,12 @@ This file is the repo-local dynamic control plane for the controller chat and an
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `main`
-- Expected Git state: clean `main` after SYT-010A integration record is merged
+- Current branch: `swarm/syt-010b-settings-hardening`
+- Expected Git state: clean task branch with pending `SYT-010B` runner launch
 - Open PR expectation: none for `SYT-010A`
-- Active agents expectation: none
+- Active agents expectation: pending `SYT-010B` Senior Runner launch
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: controller may route `SYT-010B` when ready
+- Current priority lane: `SYT-010B` runner launch
 
 ## Controller Lease And Pacing
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,9 +16,9 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010b-settings-hardening`
 - Expected Git state: clean task branch with PR #14 open and mergeable
 - Open PR expectation: PR #14 open for `SYT-010B`
-- Active agents expectation: Hypatia reviewing PR #14
+- Active agents expectation: none after Hypatia completed PR #14 review
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010B` review
+- Current priority lane: `SYT-010B` integration
 
 ## Controller Lease And Pacing
 
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010B` | Review settings source-of-truth/parity hardening PR #14 | Reviewer | `swarm/syt-010b-settings-hardening` | Review result is Ready to Integrate / Needs Fixes / Blocked |
+| 1 | `SYT-010B` | Integrate reviewed settings parity hardening PR #14 | Integrator | `swarm/syt-010b-settings-hardening` | PR merged, `main` synced, branch cleanup recorded |
 | 2 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | `swarm/syt-010c-rc-process` | RC gate documented and automatable |
 | 3 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
@@ -108,4 +108,4 @@ Heartbeat overlap rule:
 - Issue #8 is intentionally paused until #10 coverage and hardening reduce regression risk.
 - PR #11 merged; PR #12 squash-merged into `main` at `59ec975`.
 - `SYT-010A` remote and local task branches were cleaned after merge.
-- PR #14 is open for `SYT-010B`; runner validation passed and no human QA was requested.
+- PR #14 is open for `SYT-010B`; runner and reviewer validation passed and no human QA was requested.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: pending `SYT-010B` Senior Runner launch.
+- Active subagents: Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) running `SYT-010B`.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`) reviewing `SYT-010B` / PR #14.
+- Active subagents: none; next safe route is `SYT-010B` Integrator for PR #14.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none; next safe route is `SYT-010B` Reviewer for PR #14.
+- Active subagents: Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`) reviewing `SYT-010B` / PR #14.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) running `SYT-010B`.
+- Active subagents: none; next safe route is `SYT-010B` Reviewer for PR #14.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none.
+- Active subagents: pending `SYT-010B` Senior Runner launch.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none; next safe route is `SYT-010B` Integrator for PR #14.
+- Active subagents: Helmholtz (`019dda09-c04a-7040-ab08-a641d093f545`) integrating `SYT-010B` / PR #14.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `SYT-010B` | `swarm/syt-010b-settings-hardening` | https://github.com/cryptoteatime/simple-yt-tweaks/pull/14 | Draft, Needs Review | Reviewer pending | Conservative settings parity validation hardening; human QA requested no. |
+| `SYT-010B` | `swarm/syt-010b-settings-hardening` | https://github.com/cryptoteatime/simple-yt-tweaks/pull/14 | Draft, Ready to Integrate | Integrator pending | Conservative settings parity validation hardening; human QA requested no. |
 
 ## Setup Log
 

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `SYT-010B` | `swarm/syt-010b-settings-hardening` | https://github.com/cryptoteatime/simple-yt-tweaks/pull/14 | Draft, Needs Review | Reviewer pending | Conservative settings parity validation hardening; human QA requested no. |
 
 ## Setup Log
 
@@ -53,3 +53,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-04-29: Opened draft PR #11 for `SYT-CTL-001`.
 - 2026-04-29: PR #11 squash-merged for `SYT-CTL-001`.
 - 2026-04-29: PR #12 squash-merged for `SYT-010A`; branch cleanup completed.
+- 2026-04-29: Opened draft PR #14 for `SYT-010B`.

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -2,7 +2,7 @@
 
 ## State
 
-- Status: Ready to Integrate
+- Status: In Progress
 - Role: Integrator
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010b-settings-hardening`
@@ -69,6 +69,7 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 - 2026-04-29: Implemented type-level settings source-of-truth hardening and stronger validation checks; no settings defaults, storage keys, labels, or user-facing behavior changed.
 - 2026-04-29: Controller routed Reviewer Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`) for PR #14 review.
 - 2026-04-29: Reviewer Hypatia reported no findings and marked PR #14 Ready to Integrate.
+- 2026-04-29: Controller routed Integrator Helmholtz (`019dda09-c04a-7040-ab08-a641d093f545`) for PR #14 integration.
 
 ## Verification
 

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -82,7 +82,7 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 ## Human Acceptance Checklist
 
 - Required before merge: No, unless user-facing settings behavior changes.
-- URL(s): PR TBD
+- URL(s): https://github.com/cryptoteatime/simple-yt-tweaks/pull/14
 - Who should test: Reviewer/Integrator
 - Expected result: no behavior drift, settings defaults/storage parity preserved.
 

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -2,11 +2,11 @@
 
 ## State
 
-- Status: Needs Review
-- Role: Senior Runner
+- Status: Ready to Integrate
+- Role: Integrator
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010b-settings-hardening`
-- Owner: Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`)
+- Owner: Codex Controller
 - Created: 2026-04-29
 - Updated: 2026-04-29
 
@@ -68,6 +68,7 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 - 2026-04-29: Controller routed Senior Runner Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) for implementation.
 - 2026-04-29: Implemented type-level settings source-of-truth hardening and stronger validation checks; no settings defaults, storage keys, labels, or user-facing behavior changed.
 - 2026-04-29: Controller routed Reviewer Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`) for PR #14 review.
+- 2026-04-29: Reviewer Hypatia reported no findings and marked PR #14 Ready to Integrate.
 
 ## Verification
 
@@ -79,6 +80,9 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 | `npm run lint` | Passed | Focused check after settings/validation edits. |
 | `npm run test:e2e` | Passed | 8 fixture tests passed after conservative type-only sharing adjustment. A prior full runtime consolidation attempt failed fixture E2E and was abandoned. |
 | `npm run validate:all` | Passed | Includes typecheck, lint, `git diff --check`, package validation, packaged validation, and 8 fixture tests. |
+| `npm run validate` | Passed | Reviewer targeted check. |
+| `npm run build` | Passed | Reviewer verified content build emitted only `dist/content/content.js` for the content script. |
+| `rg "^\\s*(import\|export)\\s\|shared/settings" dist/content/content.js` | Passed | Reviewer found no runtime module import/export or shared settings reference. |
 
 ## Human Acceptance Checklist
 
@@ -92,10 +96,23 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 - Full runtime consolidation is not safe with the current Vite chunking setup unless build config changes also guarantee a self-contained content script.
 - Remaining duplication is intentional runtime duplication for content-script bundling safety; validation now guards parity.
 
+## Review Result
+
+- Reviewer: Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`)
+- Verdict: Ready to Integrate
+- Findings: none
+- Targeted checks:
+  - `git diff --check origin/main...HEAD`: passed
+  - `npm run validate`: passed
+  - `npm run build`: passed
+  - `rg "^\\s*(import\|export)\\s\|shared/settings" dist/content/content.js`: no runtime module import/export or shared settings reference found
+  - `npm run test:e2e`: passed, 8 fixture tests
+- Human QA requested: no
+
 ## Next Handoff
 
-- Next role: Reviewer.
-- Next action: review the validation hardening and type-only content settings consolidation, then mark `Ready to Integrate` or route fixes.
+- Next role: Integrator.
+- Next action: confirm PR #14 is still mergeable, run `npm run validate:all`, mark the draft PR ready if needed, merge through the GitHub PR path, sync `main`, and clean branches when safe.
 - Branch/worktree cleanup needed after merge: yes.
 - Copy-ready prompt:
 

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -6,7 +6,7 @@
 - Role: Senior Runner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010b-settings-hardening`
-- Owner: Codex Controller pending Senior Runner launch
+- Owner: Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`)
 - Created: 2026-04-29
 - Updated: 2026-04-29
 
@@ -61,6 +61,7 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 
 - 2026-04-29: Lane seeded during bootstrap.
 - 2026-04-29: Controller opened task branch `swarm/syt-010b-settings-hardening` for runner launch after `SYT-010A` integration.
+- 2026-04-29: Controller routed Senior Runner Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) for implementation.
 
 ## Verification
 

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -2,7 +2,7 @@
 
 ## State
 
-- Status: In Progress
+- Status: Needs Review
 - Role: Senior Runner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010b-settings-hardening`
@@ -55,13 +55,18 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 
 ## Decisions
 
-- Conservative default: strengthen parity checks before attempting a source-of-truth refactor.
+- Chose conservative validation hardening with type-level consolidation only.
+- Tried full runtime consolidation of content settings onto `src/shared/settings.ts`; fixture E2E exposed the expected bundling risk because Vite emitted a shared `dist/assets/settings.js` chunk and the content script stopped behaving as a self-contained extension script. Reverted that approach before finalizing.
+- Kept content runtime defaults, `SETTING_KEYS`, `loadSettings`, and `normalizeSettings` local to preserve self-contained content-script output.
+- Removed duplicated content type unions by re-exporting/importing shared setting types only; TypeScript erases these imports from the content bundle.
+- Strengthened `scripts/validate-extension.mjs` so validation now checks shared setting definitions against defaults, verifies parent keys/options, enforces the `floatingMiniPlayer` alias behavior, requires content type re-exports from shared, and keeps content runtime defaults/keys in parity with shared settings.
 
 ## Work Log
 
 - 2026-04-29: Lane seeded during bootstrap.
 - 2026-04-29: Controller opened task branch `swarm/syt-010b-settings-hardening` for runner launch after `SYT-010A` integration.
 - 2026-04-29: Controller routed Senior Runner Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) for implementation.
+- 2026-04-29: Implemented type-level settings source-of-truth hardening and stronger validation checks; no settings defaults, storage keys, labels, or user-facing behavior changed.
 
 ## Verification
 
@@ -69,10 +74,10 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 
 | Check | Result | Notes |
 | --- | --- | --- |
-| `npm run typecheck` | Not run for this lane yet | Required. |
-| `npm run lint` | Not run for this lane yet | Required. |
-| `npm run test:e2e` | Not run for this lane yet | Required if settings or popup behavior changes. |
-| `npm run validate:all` | Not run for this lane yet | Required before PR. |
+| `npm run typecheck` | Passed | Focused check after settings/validation edits. |
+| `npm run lint` | Passed | Focused check after settings/validation edits. |
+| `npm run test:e2e` | Passed | 8 fixture tests passed after conservative type-only sharing adjustment. A prior full runtime consolidation attempt failed fixture E2E and was abandoned. |
+| `npm run validate:all` | Passed | Includes typecheck, lint, `git diff --check`, package validation, packaged validation, and 8 fixture tests. |
 
 ## Human Acceptance Checklist
 
@@ -83,12 +88,13 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 
 ## Blockers / Risks
 
-- Consolidating settings may affect content-script bundling. Stop and report if that becomes unclear.
+- Full runtime consolidation is not safe with the current Vite chunking setup unless build config changes also guarantee a self-contained content script.
+- Remaining duplication is intentional runtime duplication for content-script bundling safety; validation now guards parity.
 
 ## Next Handoff
 
-- Next role: Senior Runner.
-- Next action: inspect settings duplication and choose conservative parity hardening or safe consolidation.
+- Next role: Reviewer.
+- Next action: review the validation hardening and type-only content settings consolidation, then mark `Ready to Integrate` or route fixes.
 - Branch/worktree cleanup needed after merge: yes.
 - Copy-ready prompt:
 

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -2,11 +2,11 @@
 
 ## State
 
-- Status: Proposed
+- Status: In Progress
 - Role: Senior Runner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010b-settings-hardening`
-- Owner: Unassigned
+- Owner: Codex Controller pending Senior Runner launch
 - Created: 2026-04-29
 - Updated: 2026-04-29
 
@@ -60,6 +60,7 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 ## Work Log
 
 - 2026-04-29: Lane seeded during bootstrap.
+- 2026-04-29: Controller opened task branch `swarm/syt-010b-settings-hardening` for runner launch after `SYT-010A` integration.
 
 ## Verification
 
@@ -85,8 +86,8 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 
 ## Next Handoff
 
-- Next role: Senior Runner after `SYT-010A`.
-- Next action: choose conservative parity hardening or safe consolidation.
+- Next role: Senior Runner.
+- Next action: inspect settings duplication and choose conservative parity hardening or safe consolidation.
 - Branch/worktree cleanup needed after merge: yes.
 - Copy-ready prompt:
 

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -67,6 +67,7 @@ Reduce settings-maintenance risk after fixture coverage is ready.
 - 2026-04-29: Controller opened task branch `swarm/syt-010b-settings-hardening` for runner launch after `SYT-010A` integration.
 - 2026-04-29: Controller routed Senior Runner Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) for implementation.
 - 2026-04-29: Implemented type-level settings source-of-truth hardening and stronger validation checks; no settings defaults, storage keys, labels, or user-facing behavior changed.
+- 2026-04-29: Controller routed Reviewer Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`) for PR #14 review.
 
 ## Verification
 

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -18,7 +18,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
-| `SYT-010B` | Settings parity and source-of-truth hardening | Senior Runner | Proposed | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | none |
+| `SYT-010B` | Settings parity and source-of-truth hardening | Senior Runner | In Progress | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | none |
 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | Proposed | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none.
+- Active controller-spawned subagents: pending `SYT-010B` launch.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 stabilized after `SYT-010A`; next safe controller action is to route `SYT-010B` when ready.
+- Current controller phase: Phase 4 active; routing `SYT-010B`.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -18,7 +18,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
-| `SYT-010B` | Settings parity and source-of-truth hardening | Reviewer | Needs Review | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 |
+| `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Ready to Integrate | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 |
 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | Proposed | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
@@ -40,13 +40,13 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| `SYT-010B` | `swarm/syt-010b-settings-hardening` | Settings parity validation, content-script bundling safety, no behavior/default drift | targeted source and validation review | `docs/swarm/handoffs/SYT-010B.md` |
+| none | none | none | none | none |
 
 ## Ready To Integrate
 
 | Task ID | Branch | Checks | Cleanup Plan | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010B` | `swarm/syt-010b-settings-hardening` | Reviewer passed; Integrator should run `npm run validate:all` before merge | Mark PR #14 ready, merge through PR path, clean branches when safe | `docs/swarm/handoffs/SYT-010B.md` |
 
 ## Human QA
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`) reviewing `SYT-010B` / PR #14.
+- Active controller-spawned subagents: none; next safe route is `SYT-010B` Integrator for PR #14.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; `SYT-010B` is ready for review.
+- Current controller phase: Phase 4 active; `SYT-010B` is ready for integration.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: pending `SYT-010B` launch.
+- Active controller-spawned subagents: Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) running `SYT-010B`.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none; next safe route is `SYT-010B` Reviewer for PR #14.
+- Active controller-spawned subagents: Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`) reviewing `SYT-010B` / PR #14.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -18,7 +18,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
-| `SYT-010B` | Settings parity and source-of-truth hardening | Senior Runner | In Progress | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | none |
+| `SYT-010B` | Settings parity and source-of-truth hardening | Reviewer | Needs Review | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 |
 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | Proposed | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
@@ -40,7 +40,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010B` | `swarm/syt-010b-settings-hardening` | Settings parity validation, content-script bundling safety, no behavior/default drift | targeted source and validation review | `docs/swarm/handoffs/SYT-010B.md` |
 
 ## Ready To Integrate
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) running `SYT-010B`.
+- Active controller-spawned subagents: none; next safe route is `SYT-010B` Reviewer for PR #14.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; routing `SYT-010B`.
+- Current controller phase: Phase 4 active; `SYT-010B` is ready for review.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -18,7 +18,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
-| `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Ready to Integrate | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 |
+| `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | In Progress | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 |
 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | Proposed | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
@@ -46,7 +46,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Checks | Cleanup Plan | Handoff |
 | --- | --- | --- | --- | --- |
-| `SYT-010B` | `swarm/syt-010b-settings-hardening` | Reviewer passed; Integrator should run `npm run validate:all` before merge | Mark PR #14 ready, merge through PR path, clean branches when safe | `docs/swarm/handoffs/SYT-010B.md` |
+| none | none | none | none | none |
 
 ## Human QA
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none; next safe route is `SYT-010B` Integrator for PR #14.
+- Active controller-spawned subagents: Helmholtz (`019dda09-c04a-7040-ab08-a641d093f545`) integrating `SYT-010B` / PR #14.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/scripts/validate-extension.mjs
+++ b/scripts/validate-extension.mjs
@@ -101,11 +101,38 @@ function extractFeedColumns(source) {
     .sort((a, b) => a - b);
 }
 
-function extractDefaultSettings(source) {
-  const match = source.match(/DEFAULT_SETTINGS:\s*Settings\s*=\s*{([\s\S]*?)};/);
-  if (!match) return null;
+function extractExportedConstBlock(source, constName, opener, closer) {
+  const marker = `export const ${constName}`;
+  const markerIndex = source.indexOf(marker);
+  if (markerIndex === -1) return null;
 
-  const entries = match[1]
+  const assignmentIndex = source.indexOf('=', markerIndex);
+  if (assignmentIndex === -1) return null;
+
+  const startIndex = source.indexOf(opener, assignmentIndex);
+  if (startIndex === -1) return null;
+
+  let depth = 0;
+  for (let index = startIndex; index < source.length; index += 1) {
+    const character = source[index];
+    if (character === opener) {
+      depth += 1;
+    } else if (character === closer) {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(startIndex + 1, index);
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractDefaultSettings(source) {
+  const block = extractExportedConstBlock(source, 'DEFAULT_SETTINGS', '{', '}');
+  if (!block) return null;
+
+  const entries = block
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
@@ -131,6 +158,72 @@ function extractDefaultSettings(source) {
   return settings;
 }
 
+function assertUniqueValues(values, label) {
+  const duplicates = values.filter((value, index) => values.indexOf(value) !== index);
+  if (duplicates.length > 0) {
+    fail(`${label} contains duplicate values: ${[...new Set(duplicates)].join(', ')}`);
+  }
+}
+
+function assertSameValues(actual, expected, label) {
+  const sortedActual = [...actual].sort();
+  const sortedExpected = [...expected].sort();
+  if (JSON.stringify(sortedActual) !== JSON.stringify(sortedExpected)) {
+    fail(`${label} must be ${sortedExpected.join(', ')}`);
+  }
+}
+
+function extractSharedSettingsReexports(source) {
+  const reexportMatch = source.match(/export\s*{([\s\S]*?)}\s*from\s*['"]\.\.\/shared\/settings['"]/);
+  if (!reexportMatch) return [];
+
+  return reexportMatch[1]
+    .split(',')
+    .map((entry) => entry.trim().replace(/^type\s+/, ''))
+    .filter(Boolean);
+}
+
+function assertSharedSettingsDefinitions(sharedSource, sharedBooleanKeys, sharedFeedColumns, sharedDefaults) {
+  const definitionsBlock = extractExportedConstBlock(sharedSource, 'SETTING_DEFINITIONS', '[', ']');
+  if (!definitionsBlock) {
+    fail('Shared SETTING_DEFINITIONS must be an exported array');
+    return;
+  }
+
+  const definitionKeys = [...definitionsBlock.matchAll(/key:\s*'([^']+)'/g)].map((match) => match[1]);
+  const parentKeys = [...definitionsBlock.matchAll(/parentKey:\s*'([^']+)'/g)].map((match) => match[1]);
+  const optionValues = [...definitionsBlock.matchAll(/value:\s*(\d+)/g)]
+    .map((match) => Number.parseInt(match[1], 10))
+    .sort((a, b) => a - b);
+  const defaultKeys = Object.keys(sharedDefaults);
+  const userFacingKeys = defaultKeys.filter((key) => key !== 'floatingMiniPlayer');
+
+  assertUniqueValues(definitionKeys, 'Shared SETTING_DEFINITIONS keys');
+  assertSameValues(definitionKeys, userFacingKeys, 'Shared SETTING_DEFINITIONS keys');
+
+  for (const parentKey of parentKeys) {
+    if (!defaultKeys.includes(parentKey)) {
+      fail(`Shared SETTING_DEFINITIONS parentKey is not a setting key: ${parentKey}`);
+    }
+  }
+
+  if (JSON.stringify(optionValues) !== JSON.stringify(sharedFeedColumns)) {
+    fail('Shared generalFeedColumns options must match FeedColumnCount values');
+  }
+
+  if (!sharedBooleanKeys.includes('floatingMiniPlayer') || sharedDefaults.floatingMiniPlayer !== true) {
+    fail('Shared settings must keep floatingMiniPlayer as a boolean legacy alias defaulting to true');
+  }
+
+  if (!/settings\.floatingMiniPlayer\s*=\s*settings\.pipButton/.test(sharedSource)) {
+    fail('Shared normalizeSettings must keep floatingMiniPlayer synchronized to pipButton');
+  }
+
+  if (!/export\s+const\s+SETTING_KEYS\s*=\s*Object\.keys\(DEFAULT_SETTINGS\)\s+as\s+SettingKey\[\];/.test(sharedSource)) {
+    fail('Shared SETTING_KEYS must be derived from DEFAULT_SETTINGS');
+  }
+}
+
 function assertSettingsParity() {
   assertExists(sharedSettingsPath, 'Shared settings module');
   assertExists(contentSettingsPath, 'Content settings module');
@@ -140,26 +233,63 @@ function assertSettingsParity() {
   const contentSource = readFileSync(contentSettingsPath, 'utf8');
 
   const sharedBooleanKeys = extractQuotedLiterals(extractTypeBlock(sharedSource, 'BooleanSettingKey') ?? '');
-  const contentBooleanKeys = extractQuotedLiterals(extractTypeBlock(contentSource, 'BooleanSettingKey') ?? '');
+  const sharedFeedColumns = extractFeedColumns(sharedSource);
+  const sharedDefaults = extractDefaultSettings(sharedSource);
+  if (!sharedFeedColumns || !sharedDefaults) {
+    fail('Could not parse FeedColumnCount or DEFAULT_SETTINGS from shared settings module');
+    return;
+  }
+
+  assertSharedSettingsDefinitions(sharedSource, sharedBooleanKeys, sharedFeedColumns, sharedDefaults);
+
+  const requiredContentTypeReexports = [
+    'BooleanSettingKey',
+    'FeedColumnCount',
+    'SettingKey',
+    'Settings',
+  ];
+  const contentReexports = extractSharedSettingsReexports(contentSource);
+
+  if (contentReexports.length > 0) {
+    for (const requiredExport of requiredContentTypeReexports) {
+      if (!contentReexports.includes(requiredExport)) {
+        fail(`Content settings must re-export ${requiredExport} from shared settings`);
+      }
+    }
+
+    for (const localDefinition of ['BooleanSettingKey', 'FeedColumnCount', 'SettingKey', 'Settings']) {
+      if (new RegExp(`export\\s+type\\s+${localDefinition}\\b`).test(contentSource)) {
+        fail(`Content settings must not duplicate shared ${localDefinition}`);
+      }
+    }
+  }
+
+  const contentBooleanKeys = contentReexports.includes('BooleanSettingKey')
+    ? sharedBooleanKeys
+    : extractQuotedLiterals(extractTypeBlock(contentSource, 'BooleanSettingKey') ?? '');
   if (JSON.stringify(sharedBooleanKeys) !== JSON.stringify(contentBooleanKeys)) {
     fail('Content and shared BooleanSettingKey definitions must match');
   }
 
-  const sharedFeedColumns = extractFeedColumns(sharedSource);
-  const contentFeedColumns = extractFeedColumns(contentSource);
+  const contentFeedColumns = contentReexports.includes('FeedColumnCount')
+    ? sharedFeedColumns
+    : extractFeedColumns(contentSource);
   if (JSON.stringify(sharedFeedColumns) !== JSON.stringify(contentFeedColumns)) {
     fail('Content and shared FeedColumnCount values must match');
   }
 
-  const sharedDefaults = extractDefaultSettings(sharedSource);
   const contentDefaults = extractDefaultSettings(contentSource);
-  if (!sharedDefaults || !contentDefaults) {
-    fail('Could not parse DEFAULT_SETTINGS from shared or content settings module');
+  if (!contentDefaults) {
+    fail('Could not parse DEFAULT_SETTINGS from content settings module');
     return;
   }
 
   if (JSON.stringify(sharedDefaults) !== JSON.stringify(contentDefaults)) {
     fail('Content and shared DEFAULT_SETTINGS must match');
+  }
+
+  if (!/export\s+const\s+SETTING_KEYS\s*=\s*Object\.keys\(DEFAULT_SETTINGS\)\s+as\s+SettingKey\[\];/.test(contentSource)) {
+    fail('Content SETTING_KEYS must be derived from DEFAULT_SETTINGS');
   }
 }
 

--- a/src/content/settings.ts
+++ b/src/content/settings.ts
@@ -1,51 +1,11 @@
-export type FeedColumnCount = 2 | 3 | 4;
+export {
+  type BooleanSettingKey,
+  type FeedColumnCount,
+  type SettingKey,
+  type Settings,
+} from '../shared/settings';
 
-export type BooleanSettingKey =
-  | 'generalHideSponsoredPosts'
-  | 'generalHideEndScreenCards'
-  | 'generalHideShorts'
-  | 'generalApplyFeedColumnsToSearch'
-  | 'generalStickyPlayer'
-  | 'generalSidebarCleanup'
-  | 'generalHideSidebar'
-  | 'generalHideSidebarHome'
-  | 'generalHideSidebarShorts'
-  | 'generalHideSidebarSubscriptions'
-  | 'generalHideSidebarYou'
-  | 'generalHideSidebarExplore'
-  | 'generalHideSidebarMoreFromYouTube'
-  | 'generalHideSidebarReportHistory'
-  | 'generalHideSidebarFooter'
-  | 'enhancedTheaterMode'
-  | 'theaterHideHeader'
-  | 'theaterShowHeaderOnHover'
-  | 'theaterHidePlayerUI'
-  | 'theaterHideScrollbarOnScroll'
-  | 'theaterHideRecommendations'
-  | 'theaterRecommendedHoverGrow'
-  | 'theaterHideComments'
-  | 'theaterHideMetadata'
-  | 'theaterShowPrimaryMetadata'
-  | 'theaterHideLiveChat'
-  | 'theaterShowLiveChatOverlay'
-  | 'defaultHideRecommendations'
-  | 'defaultRecommendedHoverGrow'
-  | 'defaultHideComments'
-  | 'defaultHideMetadata'
-  | 'defaultShowPrimaryMetadata'
-  | 'defaultHideLiveChat'
-  | 'fullscreenHideTitleOverlay'
-  | 'fullscreenHidePlayerUI'
-  | 'fullscreenHideRecommendationOverlays'
-  | 'fullscreenHideActionOverlay'
-  | 'pipButton'
-  | 'floatingMiniPlayer';
-
-export type SettingKey = BooleanSettingKey | 'generalFeedColumns';
-
-export type Settings = Record<BooleanSettingKey, boolean> & {
-  generalFeedColumns: FeedColumnCount;
-};
+import type { BooleanSettingKey, FeedColumnCount, SettingKey, Settings } from '../shared/settings';
 
 export const DEFAULT_SETTINGS: Settings = {
   generalHideSponsoredPosts: true,
@@ -92,7 +52,7 @@ export const DEFAULT_SETTINGS: Settings = {
 
 export const SETTING_KEYS = Object.keys(DEFAULT_SETTINGS) as SettingKey[];
 
-export function isFeedColumnCount(value: unknown): value is FeedColumnCount {
+function isFeedColumnCount(value: unknown): value is FeedColumnCount {
   return value === 2 || value === 3 || value === 4;
 }
 


### PR DESCRIPTION
## Summary

- Keep content runtime settings local so the Manifest V3 content script remains self-contained.
- Re-export/import shared setting types from `src/content/settings.ts` to remove duplicated type unions without changing runtime behavior.
- Strengthen extension validation so shared setting definitions, content defaults, parent keys, feed-column options, and the `floatingMiniPlayer` alias stay in parity.

Refs #10.

## How to test / what to tell the controller

Human review requested: no.

Commands run:
- `npm run typecheck`
- `npm run lint`
- `npm run test:e2e`
- `npm run validate:all`

Expected result: all commands pass; generated `dist/content/content.js` remains self-contained with no module import/export statements; popup/content settings defaults and storage keys remain unchanged.

Feedback format: `SYT-010B review result: Ready to Integrate` or `SYT-010B review result: Needs Fixes - <specific finding>`.
