### PR TITLE
Document release-candidate gate

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,6 +26,54 @@ The packaged upload is written to:
 
 `release/simple-yt-tweaks-v<version>.zip`
 
+## Release-Candidate Gate
+
+Use this gate when the controller prepares a release-candidate branch. Routine docs, tests, and hardening PRs can use their focused checks; this gate is for versioned RCs and Web Store upload candidates.
+
+1. Confirm the candidate scope is complete and no release-blocking issue remains open.
+2. Update public release notes only after the candidate scope is known. Keep private Web Store submission notes out of the public repo.
+3. If the RC needs a version change, run:
+
+```bash
+npm run version:set -- <next-version>
+```
+
+This syncs `package.json`, `package-lock.json`, and `public/manifest.json`. Do not run it for non-release process/docs work.
+
+4. Run the stable automated gate:
+
+```bash
+npm run validate:all
+```
+
+`validate:all` is fixture-first: it runs typecheck, lint, `git diff --check`, package creation, packaged validation, and the deterministic Playwright fixture project. A passing run should produce `release/simple-yt-tweaks-v<version>.zip`.
+
+5. Run optional live smoke only when the RC changes YouTube-facing behavior, when the reviewer/controller asks for live-site confidence, or immediately before a final manual acceptance pass:
+
+```bash
+npm run test:e2e:live
+```
+
+Do not block an otherwise sound RC only because live smoke is inconclusive from consent screens, bot checks, ads, experiments, or network conditions. Record the exact reason and fall back to fixture results plus manual QA.
+
+6. Human QA is required before publishing an RC or Web Store upload. Use the manual smoke checklist below against the packaged/unpacked candidate, then tell the controller one of:
+
+```text
+Human QA passed for SYT-RC-001: <browser/version, package version, notes>
+Human QA failed for SYT-RC-001: <steps and observed problem>
+```
+
+7. The controller may tag, create a GitHub release, or prepare Web Store upload artifacts only after explicit release approval. Approval should name the version, confirm the package path, and say whether to publish, draft, or stop.
+
+For release-candidate PRs, the PR body should tell the controller:
+
+- human review requested: `yes`
+- commands run and their results
+- whether optional live smoke was run, skipped, or inconclusive
+- package path, for example `release/simple-yt-tweaks-v<version>.zip`
+- exact human QA pass/fail message expected
+- whether version bump, tag, GitHub release, and Web Store upload are approved or still blocked
+
 ## Browser Validation
 
 The project includes an isolated Playwright harness for extension smoke tests. It uses Playwright's bundled Chromium with a temporary profile and loads the unpacked `dist/` extension with `--load-extension`; it does not use your normal Brave or Chrome profile.

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019ddabc-9d77-7692-81b6-80ff60498621` / Boole | `SYT-010C` | Reviewer | Reviewing PR #16 | `swarm/syt-010c-rc-process` | repo checkout | #16 | 2026-04-29 15:31 EDT | 2026-04-29 15:31 EDT | Report Ready to Integrate / Needs Fixes / Blocked | `simple-yt-tweaks-controller-heartbeat` |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `DEVELOPMENT.md`, `docs/swarm/**` | `SYT-010C` | Reviewer Boole | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process review | Release after PR #16 is merged or abandoned |
+| `DEVELOPMENT.md`, `docs/swarm/**` | `SYT-010C` | Integrator pending | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process integration | Release after PR #16 is merged or abandoned |
 
 ## Recently Completed
 
@@ -48,12 +48,13 @@ Use this file to track who is working, where they are working, and whether the c
 | `019dd9b0-7e98-7983-88de-9463e804000e` / Hypatia | `SYT-010B` | Reviewer | Ready to Integrate, no findings | 2026-04-29 12:15 EDT | Targeted PR #14 review passed; `npm run validate`, `npm run build`, `npm run test:e2e`, and content-script module checks passed. |
 | `019dda09-c04a-7040-ab08-a641d093f545` / Helmholtz | `SYT-010B` | Integrator | Merged PR #14 | 2026-04-29 12:25 EDT | PR #14 squash-merged into `main` at `5675059`; local `main` synced; remote and local task branch cleanup completed. |
 | `019dda63-8fdc-7531-b649-2a91669070c4` / Ampere | `SYT-010C` | Planner/Runner | Opened draft PR #16 | 2026-04-29 15:30 EDT | Docs-only RC gate; `git diff --check` passed; human QA requested no. |
+| `019ddabc-9d77-7692-81b6-80ff60498621` / Boole | `SYT-010C` | Reviewer | Ready to Integrate, no findings | 2026-04-29 17:06 EDT | Docs/process review passed; `git diff --check origin/main...HEAD` passed; human QA requested no. |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010C` | Integrator | `swarm/syt-010c-rc-process` / repo checkout | PR #16 remains mergeable after controller ready-state update is pushed | `docs/swarm/handoffs/SYT-010C.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019ddabc-9d77-7692-81b6-80ff60498621` / Boole | `SYT-010C` | Reviewer | Reviewing PR #16 | `swarm/syt-010c-rc-process` | repo checkout | #16 | 2026-04-29 15:31 EDT | 2026-04-29 15:31 EDT | Report Ready to Integrate / Needs Fixes / Blocked | `simple-yt-tweaks-controller-heartbeat` |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `DEVELOPMENT.md`, `docs/swarm/**` | `SYT-010C` | Reviewer pending | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process review | Release after PR #16 is merged or abandoned |
+| `DEVELOPMENT.md`, `docs/swarm/**` | `SYT-010C` | Reviewer Boole | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process review | Release after PR #16 is merged or abandoned |
 
 ## Recently Completed
 
@@ -53,7 +53,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010C` | Reviewer | `swarm/syt-010c-rc-process` / repo checkout | PR #16 remains open and mergeable after controller review-state update is pushed | `docs/swarm/handoffs/SYT-010C.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -52,7 +52,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010C` | Planner/Runner | `swarm/syt-010c-rc-process` / repo checkout | Controller routes one docs/process runner on this branch, then records the agent id in Active Agents | `docs/swarm/handoffs/SYT-010C.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019dda63-8fdc-7531-b649-2a91669070c4` / Ampere | `SYT-010C` | Planner/Runner | RC process smoothing in progress | `swarm/syt-010c-rc-process` | repo checkout | none yet | 2026-04-29 13:55 EDT | 2026-04-29 13:55 EDT | Document RC gate, run checks, open draft PR | `simple-yt-tweaks-controller-heartbeat` |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `DEVELOPMENT.md`, `docs/swarm/**`, package scripts if needed | `SYT-010C` | Planner/Runner Ampere | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process smoothing | Release after PR is merged or abandoned |
 
 ## Recently Completed
 
@@ -52,7 +52,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010C` | Planner/Runner | `swarm/syt-010c-rc-process` / repo checkout | Controller routes one docs/process runner on this branch, then records the agent id in Active Agents | `docs/swarm/handoffs/SYT-010C.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019ddb16-4dcd-7c83-9fce-e664dfdf53a1` / Carson | `SYT-010C` | Integrator | Integrating PR #16 | `swarm/syt-010c-rc-process` | repo checkout | #16 | 2026-04-29 17:07 EDT | 2026-04-29 17:07 EDT | Run final docs checks, merge PR #16 if clean, sync `main`, report cleanup | `simple-yt-tweaks-controller-heartbeat` |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `DEVELOPMENT.md`, `docs/swarm/**` | `SYT-010C` | Integrator pending | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process integration | Release after PR #16 is merged or abandoned |
+| `DEVELOPMENT.md`, `docs/swarm/**` | `SYT-010C` | Integrator Carson | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process integration | Release after PR #16 is merged or abandoned |
 
 ## Recently Completed
 
@@ -54,7 +54,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010C` | Integrator | `swarm/syt-010c-rc-process` / repo checkout | PR #16 remains mergeable after controller ready-state update is pushed | `docs/swarm/handoffs/SYT-010C.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019dda63-8fdc-7531-b649-2a91669070c4` / Ampere | `SYT-010C` | Planner/Runner | RC process smoothing in progress | `swarm/syt-010c-rc-process` | repo checkout | none yet | 2026-04-29 13:55 EDT | 2026-04-29 13:55 EDT | Document RC gate, run checks, open draft PR | `simple-yt-tweaks-controller-heartbeat` |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `DEVELOPMENT.md`, `docs/swarm/**`, package scripts if needed | `SYT-010C` | Planner/Runner Ampere | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process smoothing | Release after PR is merged or abandoned |
+| `DEVELOPMENT.md`, `docs/swarm/**` | `SYT-010C` | Reviewer pending | `swarm/syt-010c-rc-process` / repo checkout | Release-candidate process review | Release after PR #16 is merged or abandoned |
 
 ## Recently Completed
 
@@ -47,12 +47,13 @@ Use this file to track who is working, where they are working, and whether the c
 | `019dd952-fc1f-7692-878b-cc0cbaa13d42` / Linnaeus | `SYT-010B` | Senior Runner | Opened draft PR #14 | 2026-04-29 10:38 EDT | Conservative validation hardening; `npm run validate:all`, `npm run test:e2e`, `npm run lint`, and `npm run typecheck` passed. |
 | `019dd9b0-7e98-7983-88de-9463e804000e` / Hypatia | `SYT-010B` | Reviewer | Ready to Integrate, no findings | 2026-04-29 12:15 EDT | Targeted PR #14 review passed; `npm run validate`, `npm run build`, `npm run test:e2e`, and content-script module checks passed. |
 | `019dda09-c04a-7040-ab08-a641d093f545` / Helmholtz | `SYT-010B` | Integrator | Merged PR #14 | 2026-04-29 12:25 EDT | PR #14 squash-merged into `main` at `5675059`; local `main` synced; remote and local task branch cleanup completed. |
+| `019dda63-8fdc-7531-b649-2a91669070c4` / Ampere | `SYT-010C` | Planner/Runner | Opened draft PR #16 | 2026-04-29 15:30 EDT | Docs-only RC gate; `git diff --check` passed; human QA requested no. |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010C` | Reviewer | `swarm/syt-010c-rc-process` / repo checkout | PR #16 remains open and mergeable after controller review-state update is pushed | `docs/swarm/handoffs/SYT-010C.md` |
 
 ## Side Chats
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -13,12 +13,12 @@ This file is the repo-local dynamic control plane for the controller chat and an
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `main`
-- Expected Git state: clean `main` after `SYT-010B` integration record lands
+- Current branch: `swarm/syt-010c-rc-process`
+- Expected Git state: clean task branch with pending `SYT-010C` runner launch
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: none after Helmholtz completed PR #14 integration
+- Active agents expectation: pending `SYT-010C` Planner/Runner launch
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010C` release-candidate process smoothing
+- Current priority lane: `SYT-010C` runner launch
 
 ## Controller Lease And Pacing
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,7 +16,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010c-rc-process`
 - Expected Git state: clean task branch with PR #16 open for review
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: none after Ampere completed `SYT-010C`
+- Active agents expectation: Boole reviewing PR #16
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: `SYT-010C` review
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,7 +16,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010c-rc-process`
 - Expected Git state: clean task branch with PR #16 open for review
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: none after Boole completed PR #16 review
+- Active agents expectation: Carson integrating PR #16
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: `SYT-010C` integration
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,9 +16,9 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010c-rc-process`
 - Expected Git state: clean task branch with PR #16 open for review
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: Boole reviewing PR #16
+- Active agents expectation: none after Boole completed PR #16 review
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010C` review
+- Current priority lane: `SYT-010C` integration
 
 ## Controller Lease And Pacing
 
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010C` | Review release-candidate process PR #16 | Reviewer | `swarm/syt-010c-rc-process` | Review result is Ready to Integrate / Needs Fixes / Blocked |
+| 1 | `SYT-010C` | Integrate reviewed release-candidate process PR #16 | Integrator | `swarm/syt-010c-rc-process` | PR merged, `main` synced, branch cleanup recorded |
 | 2 | `SYT-010D` | Pure helper tests | Planner/Runner | `swarm/syt-010d-helper-tests` | Scoped helper coverage lane is planned or deferred |
 | 3 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -14,11 +14,11 @@ This file is the repo-local dynamic control plane for the controller chat and an
 
 - Default branch: `main`
 - Current branch: `swarm/syt-010c-rc-process`
-- Expected Git state: clean task branch with pending `SYT-010C` runner launch
+- Expected Git state: clean task branch with PR #16 open for review
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: Ampere running `SYT-010C`
+- Active agents expectation: none after Ampere completed `SYT-010C`
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010C` runner launch
+- Current priority lane: `SYT-010C` review
 
 ## Controller Lease And Pacing
 
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010C` | Release-candidate process smoothing | Planner/Runner | `swarm/syt-010c-rc-process` | RC gate documented and automatable |
+| 1 | `SYT-010C` | Review release-candidate process PR #16 | Reviewer | `swarm/syt-010c-rc-process` | Review result is Ready to Integrate / Needs Fixes / Blocked |
 | 2 | `SYT-010D` | Pure helper tests | Planner/Runner | `swarm/syt-010d-helper-tests` | Scoped helper coverage lane is planned or deferred |
 | 3 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,7 +16,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010c-rc-process`
 - Expected Git state: clean task branch with pending `SYT-010C` runner launch
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: pending `SYT-010C` Planner/Runner launch
+- Active agents expectation: Ampere running `SYT-010C`
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: `SYT-010C` runner launch
 

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none; next safe route is `SYT-010C` Reviewer for PR #16.
+- Active subagents: Boole (`019ddabc-9d77-7692-81b6-80ff60498621`) reviewing `SYT-010C` / PR #16.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: Boole (`019ddabc-9d77-7692-81b6-80ff60498621`) reviewing `SYT-010C` / PR #16.
+- Active subagents: none; next safe route is `SYT-010C` Integrator for PR #16.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) running `SYT-010C`.
+- Active subagents: none; next safe route is `SYT-010C` Reviewer for PR #16.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none.
+- Active subagents: pending `SYT-010C` Planner/Runner launch.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: pending `SYT-010C` Planner/Runner launch.
+- Active subagents: Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) running `SYT-010C`.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none; next safe route is `SYT-010C` Integrator for PR #16.
+- Active subagents: Carson (`019ddb16-4dcd-7c83-9fce-e664dfdf53a1`) integrating `SYT-010C` / PR #16.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `SYT-010C` | `swarm/syt-010c-rc-process` | https://github.com/cryptoteatime/simple-yt-tweaks/pull/16 | Draft, Needs Review | Reviewer pending | Docs-only RC gate; human QA requested no for this PR. |
 
 ## Setup Log
 
@@ -55,3 +55,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-04-29: PR #12 squash-merged for `SYT-010A`; branch cleanup completed.
 - 2026-04-29: Opened draft PR #14 for `SYT-010B`.
 - 2026-04-29: PR #14 squash-merged for `SYT-010B`; branch cleanup completed.
+- 2026-04-29: Opened draft PR #16 for `SYT-010C`.

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `SYT-010C` | `swarm/syt-010c-rc-process` | https://github.com/cryptoteatime/simple-yt-tweaks/pull/16 | Draft, Needs Review | Reviewer pending | Docs-only RC gate; human QA requested no for this PR. |
+| `SYT-010C` | `swarm/syt-010c-rc-process` | https://github.com/cryptoteatime/simple-yt-tweaks/pull/16 | Draft, Ready to Integrate | Integrator pending | Docs-only RC gate; human QA requested no for this PR. |
 
 ## Setup Log
 

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -90,6 +90,7 @@ Human QA failed for SYT-RC-001: <steps and observed problem>
 - 2026-04-29: Added docs-only RC gate to `DEVELOPMENT.md`; kept scripts unchanged because the repo already has repeatable validation/package/live-smoke commands.
 - 2026-04-29: Opened draft PR #16 for review.
 - 2026-04-29: Controller reconciled Ampere completion and queued Reviewer for PR #16.
+- 2026-04-29: Controller routed Reviewer Boole (`019ddabc-9d77-7692-81b6-80ff60498621`) for PR #16 review.
 
 ## Human Acceptance Checklist
 

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -2,7 +2,7 @@
 
 ## State
 
-- Status: Ready to Integrate
+- Status: In Progress
 - Role: Integrator
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010c-rc-process`
@@ -93,6 +93,7 @@ Human QA failed for SYT-RC-001: <steps and observed problem>
 - 2026-04-29: Controller reconciled Ampere completion and queued Reviewer for PR #16.
 - 2026-04-29: Controller routed Reviewer Boole (`019ddabc-9d77-7692-81b6-80ff60498621`) for PR #16 review.
 - 2026-04-29: Reviewer Boole reported no findings and marked PR #16 Ready to Integrate.
+- 2026-04-29: Controller routed Integrator Carson (`019ddb16-4dcd-7c83-9fce-e664dfdf53a1`) for PR #16 integration.
 
 ## Human Acceptance Checklist
 

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -2,7 +2,7 @@
 
 ## State
 
-- Status: In Progress
+- Status: Needs Review
 - Role: Planner/Runner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010c-rc-process`
@@ -38,26 +38,71 @@ Make the next release-candidate process smoother and less dependent on ad hoc ch
 - Conflict-risk: low/medium; release docs and package scripts.
 - Shared coordination docs allowed: this handoff only unless controller assigns more.
 
+## Controller-Friendly RC Gate
+
+The release-candidate gate is now documented in `DEVELOPMENT.md` as a fixture-first sequence:
+
+1. Confirm candidate scope and release-blocking issues.
+2. Update public release notes after scope is known; keep private Web Store notes out of the repo.
+3. Run `npm run version:set -- <next-version>` only for an actual RC or Web Store candidate.
+4. Run `npm run validate:all` as the stable automated gate. This covers typecheck, lint, `git diff --check`, package creation, packaged validation, and deterministic fixture E2E.
+5. Run `npm run test:e2e:live` only for YouTube-facing behavior changes, explicit reviewer/controller live-site confidence, or final manual acceptance. Inconclusive live smoke should be recorded without replacing fixture/package validation.
+6. Require human QA before publishing an RC or Web Store upload. Expected controller messages:
+
+```text
+Human QA passed for SYT-RC-001: <browser/version, package version, notes>
+Human QA failed for SYT-RC-001: <steps and observed problem>
+```
+
+7. Require explicit release approval before tagging, creating a GitHub release, or preparing Web Store upload artifacts. Approval should name the version, package path, and publish/draft/stop direction.
+
+## Files Changed
+
+- `DEVELOPMENT.md`: Added the release-candidate gate, live-smoke rule, human QA message format, and controller PR checklist.
+- `docs/swarm/handoffs/SYT-010C.md`: Recorded the gate, decisions, verification, and next role.
+
+## Decisions Made
+
+- No script changes were needed. Existing commands already cover the repeatable gate:
+  - `npm run validate:all`
+  - `npm run package`
+  - `npm run validate:packaged`
+  - `npm run test:e2e:live`
+  - `npm run version:set -- <next-version>`
+- `npm run validate:all` remains the stable fixture-first RC baseline.
+- Live smoke remains optional and supplemental because live YouTube can be inconclusive for reasons outside the extension.
+- Human QA is required for an actual RC/release but not for this docs-only process PR.
+- Version bump, tag, GitHub release, and Web Store upload remain blocked until explicit release approval.
+
 ## Verification
 
 | Check | Result | Notes |
 | --- | --- | --- |
-| `git diff --check` | Not run for this lane yet | Required for docs-only changes. |
-| `npm run validate:all` | Not run for this lane yet | Required if scripts or release commands change. |
+| `git diff --check` | Passed | Docs-only whitespace check passed. |
+| `npm run validate:all` | Not run | Not required because no scripts/package/source files changed. |
 
 ## Work Log
 
 - 2026-04-29: Controller opened task branch `swarm/syt-010c-rc-process` for release-candidate process smoothing after `SYT-010B` integration.
 - 2026-04-29: Controller routed Planner/Runner Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) for implementation.
+- 2026-04-29: Added docs-only RC gate to `DEVELOPMENT.md`; kept scripts unchanged because the repo already has repeatable validation/package/live-smoke commands.
 
 ## Human Acceptance Checklist
 
-- Required before merge: No for process docs; yes before an actual release candidate is shipped.
+- Required before merge: No for this docs-only process PR.
+- Required before release: Yes before an actual release candidate is shipped or uploaded.
+- Expected release QA pass/fail format is documented in `DEVELOPMENT.md`.
+
+## Blockers / Risks
+
+- No blockers for review.
+- Live YouTube smoke can be inconclusive; the documented gate requires recording the reason and falling back to fixture/package validation plus human QA.
+- This lane intentionally did not validate or change Web Store submission assets.
 
 ## Next Handoff
 
-- Next role: Planner/Runner.
-- Next action: Turn current release steps into a controller-friendly RC checklist.
+- Next role: Reviewer.
+- Next action: Review docs-only process changes and PR body for controller clarity. If acceptable, mark `Ready to Integrate`.
 - Branch/worktree cleanup needed after merge: yes.
 - Copy-ready prompt:
 

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -3,11 +3,11 @@
 ## State
 
 - Status: Needs Review
-- Role: Planner/Runner
+- Role: Reviewer
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010c-rc-process`
 - PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/16
-- Owner: Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`)
+- Owner: Codex Controller
 - Created: 2026-04-29
 - Updated: 2026-04-29
 
@@ -89,6 +89,7 @@ Human QA failed for SYT-RC-001: <steps and observed problem>
 - 2026-04-29: Controller routed Planner/Runner Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) for implementation.
 - 2026-04-29: Added docs-only RC gate to `DEVELOPMENT.md`; kept scripts unchanged because the repo already has repeatable validation/package/live-smoke commands.
 - 2026-04-29: Opened draft PR #16 for review.
+- 2026-04-29: Controller reconciled Ampere completion and queued Reviewer for PR #16.
 
 ## Human Acceptance Checklist
 

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -2,11 +2,11 @@
 
 ## State
 
-- Status: Proposed
+- Status: In Progress
 - Role: Planner/Runner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010c-rc-process`
-- Owner: Unassigned
+- Owner: Codex Controller pending Planner/Runner launch
 - Created: 2026-04-29
 - Updated: 2026-04-29
 
@@ -45,13 +45,17 @@ Make the next release-candidate process smoother and less dependent on ad hoc ch
 | `git diff --check` | Not run for this lane yet | Required for docs-only changes. |
 | `npm run validate:all` | Not run for this lane yet | Required if scripts or release commands change. |
 
+## Work Log
+
+- 2026-04-29: Controller opened task branch `swarm/syt-010c-rc-process` for release-candidate process smoothing after `SYT-010B` integration.
+
 ## Human Acceptance Checklist
 
 - Required before merge: No for process docs; yes before an actual release candidate is shipped.
 
 ## Next Handoff
 
-- Next role: Planner/Runner after `SYT-010A`.
+- Next role: Planner/Runner.
 - Next action: Turn current release steps into a controller-friendly RC checklist.
 - Branch/worktree cleanup needed after merge: yes.
 - Copy-ready prompt:

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -6,6 +6,7 @@
 - Role: Planner/Runner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010c-rc-process`
+- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/16
 - Owner: Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`)
 - Created: 2026-04-29
 - Updated: 2026-04-29
@@ -80,12 +81,14 @@ Human QA failed for SYT-RC-001: <steps and observed problem>
 | --- | --- | --- |
 | `git diff --check` | Passed | Docs-only whitespace check passed. |
 | `npm run validate:all` | Not run | Not required because no scripts/package/source files changed. |
+| Draft PR | Opened | https://github.com/cryptoteatime/simple-yt-tweaks/pull/16 |
 
 ## Work Log
 
 - 2026-04-29: Controller opened task branch `swarm/syt-010c-rc-process` for release-candidate process smoothing after `SYT-010B` integration.
 - 2026-04-29: Controller routed Planner/Runner Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) for implementation.
 - 2026-04-29: Added docs-only RC gate to `DEVELOPMENT.md`; kept scripts unchanged because the repo already has repeatable validation/package/live-smoke commands.
+- 2026-04-29: Opened draft PR #16 for review.
 
 ## Human Acceptance Checklist
 

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -2,8 +2,8 @@
 
 ## State
 
-- Status: Needs Review
-- Role: Reviewer
+- Status: Ready to Integrate
+- Role: Integrator
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010c-rc-process`
 - PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/16
@@ -80,6 +80,7 @@ Human QA failed for SYT-RC-001: <steps and observed problem>
 | Check | Result | Notes |
 | --- | --- | --- |
 | `git diff --check` | Passed | Docs-only whitespace check passed. |
+| `git diff --check origin/main...HEAD` | Passed | Reviewer targeted whitespace check passed. |
 | `npm run validate:all` | Not run | Not required because no scripts/package/source files changed. |
 | Draft PR | Opened | https://github.com/cryptoteatime/simple-yt-tweaks/pull/16 |
 
@@ -91,6 +92,7 @@ Human QA failed for SYT-RC-001: <steps and observed problem>
 - 2026-04-29: Opened draft PR #16 for review.
 - 2026-04-29: Controller reconciled Ampere completion and queued Reviewer for PR #16.
 - 2026-04-29: Controller routed Reviewer Boole (`019ddabc-9d77-7692-81b6-80ff60498621`) for PR #16 review.
+- 2026-04-29: Reviewer Boole reported no findings and marked PR #16 Ready to Integrate.
 
 ## Human Acceptance Checklist
 
@@ -104,10 +106,23 @@ Human QA failed for SYT-RC-001: <steps and observed problem>
 - Live YouTube smoke can be inconclusive; the documented gate requires recording the reason and falling back to fixture/package validation plus human QA.
 - This lane intentionally did not validate or change Web Store submission assets.
 
+## Review Result
+
+- Reviewer: Boole (`019ddabc-9d77-7692-81b6-80ff60498621`)
+- Verdict: Ready to Integrate
+- Findings: none
+- Targeted checks:
+  - `gh pr view 16 --json ...`: PR open draft, base `main`, head `swarm/syt-010c-rc-process`, merge state `CLEAN`
+  - `git fetch origin main swarm/syt-010c-rc-process --prune`: passed
+  - `git diff --name-status origin/main...HEAD`: only `DEVELOPMENT.md` and swarm docs changed
+  - `git diff --check origin/main...HEAD`: passed
+  - Package scripts inspected: `validate:all` already runs typecheck, lint, `git diff --check`, package, packaged validation, and fixture Playwright
+- Human QA requested: no for this docs-only process PR
+
 ## Next Handoff
 
-- Next role: Reviewer.
-- Next action: Review docs-only process changes and PR body for controller clarity. If acceptable, mark `Ready to Integrate`.
+- Next role: Integrator.
+- Next action: confirm PR #16 is still mergeable, mark the draft PR ready if needed, merge through the GitHub PR path, sync `main`, and clean branches when safe.
 - Branch/worktree cleanup needed after merge: yes.
 - Copy-ready prompt:
 

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -6,7 +6,7 @@
 - Role: Planner/Runner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-010c-rc-process`
-- Owner: Codex Controller pending Planner/Runner launch
+- Owner: Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`)
 - Created: 2026-04-29
 - Updated: 2026-04-29
 
@@ -48,6 +48,7 @@ Make the next release-candidate process smoother and less dependent on ad hoc ch
 ## Work Log
 
 - 2026-04-29: Controller opened task branch `swarm/syt-010c-rc-process` for release-candidate process smoothing after `SYT-010B` integration.
+- 2026-04-29: Controller routed Planner/Runner Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) for implementation.
 
 ## Human Acceptance Checklist
 

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -19,7 +19,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
-| `SYT-010C` | Release-candidate process smoothing | Reviewer | Needs Review | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 |
+| `SYT-010C` | Release-candidate process smoothing | Integrator | Ready to Integrate | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Backlog
@@ -40,13 +40,13 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| `SYT-010C` | `swarm/syt-010c-rc-process` | RC gate clarity, fixture-first policy, live-smoke/human-QA/release approval boundaries, docs-only scope | docs/process review | `docs/swarm/handoffs/SYT-010C.md` |
+| none | none | none | none | none |
 
 ## Ready To Integrate
 
 | Task ID | Branch | Checks | Cleanup Plan | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010C` | `swarm/syt-010c-rc-process` | Reviewer passed; Integrator should run final docs checks before merge | Mark PR #16 ready, merge through PR path, clean branches when safe | `docs/swarm/handoffs/SYT-010C.md` |
 
 ## Human QA
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: Boole (`019ddabc-9d77-7692-81b6-80ff60498621`) reviewing `SYT-010C` / PR #16.
+- Active controller-spawned subagents: none; next safe route is `SYT-010C` Integrator for PR #16.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; `SYT-010C` is ready for review.
+- Current controller phase: Phase 4 active; `SYT-010C` is ready for integration.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: pending `SYT-010C` launch.
+- Active controller-spawned subagents: Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) running `SYT-010C`.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none; next safe route is `SYT-010C` Reviewer for PR #16.
+- Active controller-spawned subagents: Boole (`019ddabc-9d77-7692-81b6-80ff60498621`) reviewing `SYT-010C` / PR #16.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -19,7 +19,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
-| `SYT-010C` | Release-candidate process smoothing | Planner/Runner | Proposed | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
+| `SYT-010C` | Release-candidate process smoothing | Planner/Runner | In Progress | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Backlog
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none.
+- Active controller-spawned subagents: pending `SYT-010C` launch.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; next safe controller action is to route `SYT-010C` planning/runner work when capacity is available.
+- Current controller phase: Phase 4 active; routing `SYT-010C`.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -19,7 +19,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
-| `SYT-010C` | Release-candidate process smoothing | Integrator | Ready to Integrate | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 |
+| `SYT-010C` | Release-candidate process smoothing | Integrator | In Progress | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Backlog
@@ -46,7 +46,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Checks | Cleanup Plan | Handoff |
 | --- | --- | --- | --- | --- |
-| `SYT-010C` | `swarm/syt-010c-rc-process` | Reviewer passed; Integrator should run final docs checks before merge | Mark PR #16 ready, merge through PR path, clean branches when safe | `docs/swarm/handoffs/SYT-010C.md` |
+| none | none | none | none | none |
 
 ## Human QA
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none; next safe route is `SYT-010C` Integrator for PR #16.
+- Active controller-spawned subagents: Carson (`019ddb16-4dcd-7c83-9fce-e664dfdf53a1`) integrating `SYT-010C` / PR #16.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -19,7 +19,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
-| `SYT-010C` | Release-candidate process smoothing | Planner/Runner | In Progress | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | none |
+| `SYT-010C` | Release-candidate process smoothing | Reviewer | Needs Review | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Backlog
@@ -40,7 +40,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010C` | `swarm/syt-010c-rc-process` | RC gate clarity, fixture-first policy, live-smoke/human-QA/release approval boundaries, docs-only scope | docs/process review | `docs/swarm/handoffs/SYT-010C.md` |
 
 ## Ready To Integrate
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) running `SYT-010C`.
+- Active controller-spawned subagents: none; next safe route is `SYT-010C` Reviewer for PR #16.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; routing `SYT-010C`.
+- Current controller phase: Phase 4 active; `SYT-010C` is ready for review.


### PR DESCRIPTION
## Summary
- Document a controller-friendly release-candidate gate in DEVELOPMENT.md.
- Record SYT-010C decisions, verification, human QA policy, and next reviewer action in the handoff.
- Keep this lane docs-only; no version bump, scripts, product behavior, tag, release, or Web Store asset changes.

Refs #10

## How to test / what to tell the controller
Human review requested: no. This is docs-only process work; human QA is required for a future actual release candidate, not for this PR.

Commands run:
- `git diff --check`

Expected result:
- `git diff --check` exits with no output.
- Reviewer confirms the RC gate clearly describes fixture-first validation, optional live smoke, package validation, human QA gates, version/tag/release approval flow, and controller instructions.

Controller next action:
- Route this PR to Reviewer for docs/process review. If acceptable, mark `SYT-010C` Ready to Integrate.

Human feedback format:
- Not requested for this PR. For a future release candidate, use `Human QA passed for SYT-RC-001: <browser/version, package version, notes>` or `Human QA failed for SYT-RC-001: <steps and observed problem>`.
