### PR TITLE
Add helper unit tests

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,7 +15,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | 90 minutes | No active lease after bootstrap turn completes. |
+| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-29 18:51 EDT | Prepare and launch `SYT-010D` | Stop after one Planner/Runner is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
 
 ## Active Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Pending Planner/Runner launch | `swarm/syt-010d-helper-tests` | Helper-test lane prep | Release when task PR is reviewed/integrated or lane is deferred. |
 
 ## Recently Completed
 
@@ -55,7 +55,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010D` | Planner/Runner | `swarm/syt-010d-helper-tests` | Controller docs branch prepared and capacity available | `docs/swarm/handoffs/SYT-010D.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-29 18:51 EDT | Prepare and launch `SYT-010D` | Stop after one Planner/Runner is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
+| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-010D` and stopped with capacity full. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019ddb72-af51-7372-8146-43d5ead7148a` / Dirac | `SYT-010D` | Planner/Runner | In Progress | `swarm/syt-010d-helper-tests` | forked workspace | none | 2026-04-29 18:54 EDT | 2026-04-29 18:54 EDT | Add or defer helper-test lane, update handoff, push branch, open draft PR if reviewable | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Pending Planner/Runner launch | `swarm/syt-010d-helper-tests` | Helper-test lane prep | Release when task PR is reviewed/integrated or lane is deferred. |
+| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) | `swarm/syt-010d-helper-tests` | Helper-test lane implementation | Release when task PR is reviewed/integrated or lane is deferred. |
 
 ## Recently Completed
 
@@ -55,7 +55,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010D` | Planner/Runner | `swarm/syt-010d-helper-tests` | Controller docs branch prepared and capacity available | `docs/swarm/handoffs/SYT-010D.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-010D` and stopped with capacity full. |
+| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-29 20:28 EDT | Reconcile `SYT-010D` Runner and route review | Stop after one Reviewer is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019ddb72-af51-7372-8146-43d5ead7148a` / Dirac | `SYT-010D` | Planner/Runner | In Progress | `swarm/syt-010d-helper-tests` | forked workspace | none | 2026-04-29 18:54 EDT | 2026-04-29 18:54 EDT | Add or defer helper-test lane, update handoff, push branch, open draft PR if reviewable | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) | `swarm/syt-010d-helper-tests` | Helper-test lane implementation | Release when task PR is reviewed/integrated or lane is deferred. |
+| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Pending Reviewer launch | `swarm/syt-010d-helper-tests` | Helper-test lane review | Release when task PR is reviewed/integrated or lane is deferred. |
 
 ## Recently Completed
 
@@ -50,12 +50,13 @@ Use this file to track who is working, where they are working, and whether the c
 | `019dda63-8fdc-7531-b649-2a91669070c4` / Ampere | `SYT-010C` | Planner/Runner | Opened draft PR #16 | 2026-04-29 15:30 EDT | Docs-only RC gate; `git diff --check` passed; human QA requested no. |
 | `019ddabc-9d77-7692-81b6-80ff60498621` / Boole | `SYT-010C` | Reviewer | Ready to Integrate, no findings | 2026-04-29 17:06 EDT | Docs/process review passed; `git diff --check origin/main...HEAD` passed; human QA requested no. |
 | `019ddb16-4dcd-7c83-9fce-e664dfdf53a1` / Carson | `SYT-010C` | Integrator | Merged PR #16 | 2026-04-29 17:14 EDT | PR #16 squash-merged into `main` at `0fca6c3`; remote and local task branch cleanup completed; integration-record docs landed through follow-up PR policy. |
+| `019ddb72-af51-7372-8146-43d5ead7148a` / Dirac | `SYT-010D` | Planner/Runner | Opened draft PR #18 | 2026-04-29 20:28 EDT | Added Playwright unit project and helper tests; `npm run test:unit`, `typecheck`, `lint`, and `validate:all` passed. |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010D` | Reviewer | `swarm/syt-010d-helper-tests` | Runner completed with PR #18 clean/draft | `docs/swarm/handoffs/SYT-010D.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-29 20:28 EDT | Reconcile `SYT-010D` Runner and route review | Stop after one Reviewer is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
+| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-010D` review and stopped with capacity full. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019ddbcb-2d65-76c1-982c-54abedb730cc` / Ptolemy | `SYT-010D` | Reviewer | In Progress | `swarm/syt-010d-helper-tests` | forked workspace | #18 | 2026-04-29 20:30 EDT | 2026-04-29 20:30 EDT | Review PR #18 and report Ready to Integrate, Needs Fixes, or Blocked | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Pending Reviewer launch | `swarm/syt-010d-helper-tests` | Helper-test lane review | Release when task PR is reviewed/integrated or lane is deferred. |
+| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) | `swarm/syt-010d-helper-tests` | Helper-test lane review | Release when task PR is reviewed/integrated or lane is deferred. |
 
 ## Recently Completed
 
@@ -56,7 +56,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010D` | Reviewer | `swarm/syt-010d-helper-tests` | Runner completed with PR #18 clean/draft | `docs/swarm/handoffs/SYT-010D.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-010D` review and stopped with capacity full. |
+| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-29 22:03 EDT | Reconcile `SYT-010D` review and route integration | Stop after one Integrator is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019ddbcb-2d65-76c1-982c-54abedb730cc` / Ptolemy | `SYT-010D` | Reviewer | In Progress | `swarm/syt-010d-helper-tests` | forked workspace | #18 | 2026-04-29 20:30 EDT | 2026-04-29 20:30 EDT | Review PR #18 and report Ready to Integrate, Needs Fixes, or Blocked | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) | `swarm/syt-010d-helper-tests` | Helper-test lane review | Release when task PR is reviewed/integrated or lane is deferred. |
+| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Pending Integrator launch | `swarm/syt-010d-helper-tests` | Helper-test lane integration | Release when task PR is integrated or blocked. |
 
 ## Recently Completed
 
@@ -51,12 +51,13 @@ Use this file to track who is working, where they are working, and whether the c
 | `019ddabc-9d77-7692-81b6-80ff60498621` / Boole | `SYT-010C` | Reviewer | Ready to Integrate, no findings | 2026-04-29 17:06 EDT | Docs/process review passed; `git diff --check origin/main...HEAD` passed; human QA requested no. |
 | `019ddb16-4dcd-7c83-9fce-e664dfdf53a1` / Carson | `SYT-010C` | Integrator | Merged PR #16 | 2026-04-29 17:14 EDT | PR #16 squash-merged into `main` at `0fca6c3`; remote and local task branch cleanup completed; integration-record docs landed through follow-up PR policy. |
 | `019ddb72-af51-7372-8146-43d5ead7148a` / Dirac | `SYT-010D` | Planner/Runner | Opened draft PR #18 | 2026-04-29 20:28 EDT | Added Playwright unit project and helper tests; `npm run test:unit`, `typecheck`, `lint`, and `validate:all` passed. |
+| `019ddbcb-2d65-76c1-982c-54abedb730cc` / Ptolemy | `SYT-010D` | Reviewer | Ready to Integrate, no findings | 2026-04-29 22:03 EDT | PR #18 review passed; `npm run test:unit`, `git diff --check origin/main...HEAD`, `npm run validate:all`, and `git diff --check` passed. |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010D` | Integrator | `swarm/syt-010d-helper-tests` | Reviewer marked PR #18 Ready to Integrate and branch is clean | `docs/swarm/handoffs/SYT-010D.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-29 22:03 EDT | Reconcile `SYT-010D` review and route integration | Stop after one Integrator is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
+| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-010D` integration and stopped with capacity full. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019ddc21-c7bb-75a2-94f6-e8d84b8f4489` / Planck | `SYT-010D` | Integrator | In Progress | `swarm/syt-010d-helper-tests` | forked workspace | #18 | 2026-04-29 22:05 EDT | 2026-04-29 22:05 EDT | Recheck PR #18, run final verification, merge if safe, record integration | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Pending Integrator launch | `swarm/syt-010d-helper-tests` | Helper-test lane integration | Release when task PR is integrated or blocked. |
+| `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules if needed | `SYT-010D` | Planck (`019ddc21-c7bb-75a2-94f6-e8d84b8f4489`) | `swarm/syt-010d-helper-tests` | Helper-test lane integration | Release when task PR is integrated or blocked. |
 
 ## Recently Completed
 
@@ -57,7 +57,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010D` | Integrator | `swarm/syt-010d-helper-tests` | Reviewer marked PR #18 Ready to Integrate and branch is clean | `docs/swarm/handoffs/SYT-010D.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 20:28 EDT
+- Last reviewed by controller: 2026-04-29 20:30 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-010d-helper-tests`
-- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` PR #18 ready for review
+- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` review active in a forked workspace
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: none until `SYT-010D` Reviewer is launched
-- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
-- Current priority lane: route `SYT-010D` review
+- Active agents expectation: Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) is reviewing `SYT-010D`
+- Controller lease expectation: none between bounded heartbeat passes
+- Current priority lane: await `SYT-010D` review result
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
-- Lease started: 2026-04-29 20:28 EDT
-- Lease expected action: route `SYT-010D` review
-- Lease stop condition: `SYT-010D` Reviewer launched or blocker recorded
+- Controller lease owner: none
+- Lease started: none
+- Lease expected action: none
+- Lease stop condition: none
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010D` | Review PR #18 helper unit tests | Reviewer | `swarm/syt-010d-helper-tests` | Review reports Ready to Integrate, Needs Fixes, or Blocked |
+| 1 | `SYT-010D` | Await PR #18 helper unit test review | Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) | `swarm/syt-010d-helper-tests` | Review reports Ready to Integrate, Needs Fixes, or Blocked |
 | 2 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 17:14 EDT
+- Last reviewed by controller: 2026-04-29 18:51 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `main`
-- Expected Git state: clean `main` synced to `origin/main`; SYT-010C integration-record branch may exist only while this docs update is being landed
+- Current branch: `swarm/syt-010d-helper-tests`
+- Expected Git state: task branch with controller-owned docs prep for `SYT-010D`; clean after prep commit/push
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: none after Carson merged PR #16
-- Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010D` planning/runner decision
+- Active agents expectation: none until `SYT-010D` Planner/Runner is launched
+- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
+- Current priority lane: `SYT-010D` Planner/Runner launch
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: none
-- Lease started: none
-- Lease expected action: none
-- Lease stop condition: none
+- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
+- Lease started: 2026-04-29 18:51 EDT
+- Lease expected action: prepare and launch `SYT-010D`
+- Lease stop condition: `SYT-010D` Planner/Runner launched or blocker recorded
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010D` | Pure helper tests | Planner/Runner | `swarm/syt-010d-helper-tests` | Scoped helper coverage lane is planned or deferred |
+| 1 | `SYT-010D` | Launch pure helper tests lane | Planner/Runner | `swarm/syt-010d-helper-tests` | One Planner/Runner is launched or the lane is deferred |
 | 2 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 22:03 EDT
+- Last reviewed by controller: 2026-04-29 22:05 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-010d-helper-tests`
-- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` PR #18 ready to integrate
+- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` integration active in a forked workspace
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: none until `SYT-010D` Integrator is launched
-- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
-- Current priority lane: route `SYT-010D` integration
+- Active agents expectation: Planck (`019ddc21-c7bb-75a2-94f6-e8d84b8f4489`) is integrating `SYT-010D`
+- Controller lease expectation: none between bounded heartbeat passes
+- Current priority lane: await `SYT-010D` integration result
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
-- Lease started: 2026-04-29 22:03 EDT
-- Lease expected action: route `SYT-010D` integration
-- Lease stop condition: `SYT-010D` Integrator launched or blocker recorded
+- Controller lease owner: none
+- Lease started: none
+- Lease expected action: none
+- Lease stop condition: none
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010D` | Integrate PR #18 helper unit tests | Integrator | `swarm/syt-010d-helper-tests` | PR #18 merged or blocker recorded |
+| 1 | `SYT-010D` | Await PR #18 helper unit test integration | Planck (`019ddc21-c7bb-75a2-94f6-e8d84b8f4489`) | `swarm/syt-010d-helper-tests` | PR #18 merged or blocker recorded |
 | 2 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 18:51 EDT
+- Last reviewed by controller: 2026-04-29 18:54 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-010d-helper-tests`
-- Expected Git state: task branch with controller-owned docs prep for `SYT-010D`; clean after prep commit/push
+- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` active in a forked workspace
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: none until `SYT-010D` Planner/Runner is launched
-- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
-- Current priority lane: `SYT-010D` Planner/Runner launch
+- Active agents expectation: Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) is working `SYT-010D`
+- Controller lease expectation: none between bounded heartbeat passes
+- Current priority lane: await `SYT-010D` result
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
-- Lease started: 2026-04-29 18:51 EDT
-- Lease expected action: prepare and launch `SYT-010D`
-- Lease stop condition: `SYT-010D` Planner/Runner launched or blocker recorded
+- Controller lease owner: none
+- Lease started: none
+- Lease expected action: none
+- Lease stop condition: none
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010D` | Launch pure helper tests lane | Planner/Runner | `swarm/syt-010d-helper-tests` | One Planner/Runner is launched or the lane is deferred |
+| 1 | `SYT-010D` | Await pure helper tests result | Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) | `swarm/syt-010d-helper-tests` | Agent reports Needs Review, Blocked, or Deferred |
 | 2 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 20:30 EDT
+- Last reviewed by controller: 2026-04-29 22:03 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-010d-helper-tests`
-- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` review active in a forked workspace
+- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` PR #18 ready to integrate
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) is reviewing `SYT-010D`
-- Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: await `SYT-010D` review result
+- Active agents expectation: none until `SYT-010D` Integrator is launched
+- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
+- Current priority lane: route `SYT-010D` integration
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: none
-- Lease started: none
-- Lease expected action: none
-- Lease stop condition: none
+- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
+- Lease started: 2026-04-29 22:03 EDT
+- Lease expected action: route `SYT-010D` integration
+- Lease stop condition: `SYT-010D` Integrator launched or blocker recorded
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010D` | Await PR #18 helper unit test review | Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) | `swarm/syt-010d-helper-tests` | Review reports Ready to Integrate, Needs Fixes, or Blocked |
+| 1 | `SYT-010D` | Integrate PR #18 helper unit tests | Integrator | `swarm/syt-010d-helper-tests` | PR #18 merged or blocker recorded |
 | 2 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 18:54 EDT
+- Last reviewed by controller: 2026-04-29 20:28 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-010d-helper-tests`
-- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` active in a forked workspace
+- Expected Git state: clean `swarm/syt-010d-helper-tests` with `SYT-010D` PR #18 ready for review
 - Open PR expectation: none for `SYT-010B`
-- Active agents expectation: Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) is working `SYT-010D`
-- Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: await `SYT-010D` result
+- Active agents expectation: none until `SYT-010D` Reviewer is launched
+- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
+- Current priority lane: route `SYT-010D` review
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: none
-- Lease started: none
-- Lease expected action: none
-- Lease stop condition: none
+- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
+- Lease started: 2026-04-29 20:28 EDT
+- Lease expected action: route `SYT-010D` review
+- Lease stop condition: `SYT-010D` Reviewer launched or blocker recorded
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010D` | Await pure helper tests result | Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) | `swarm/syt-010d-helper-tests` | Agent reports Needs Review, Blocked, or Deferred |
+| 1 | `SYT-010D` | Review PR #18 helper unit tests | Reviewer | `swarm/syt-010d-helper-tests` | Review reports Ready to Integrate, Needs Fixes, or Blocked |
 | 2 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -11,7 +11,7 @@
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; `SYT-010C` release-candidate process PR #16 is merged
+- Dispatch readiness: swarm packet integrated; `SYT-010D` helper-test lane is being launched
 
 ## Goal
 
@@ -51,7 +51,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-010C` is integrated. The next safe milestone is `SYT-010D`: pure helper tests, keeping product/runtime behavior unchanged unless that lane explicitly expands it.
+`SYT-010D` is the next safe milestone: pure helper tests, keeping product/runtime behavior unchanged unless that lane explicitly expands it.
 
 ## Verification Defaults
 
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none.
+- Active subagents: none yet; `SYT-010D` Planner/Runner is pending launch.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
@@ -88,4 +88,4 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 ## Last Updated
 
 - Date: 2026-04-29
-- By: Integrator
+- By: Controller heartbeat

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -11,7 +11,7 @@
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; `SYT-010D` helper-test lane is being launched
+- Dispatch readiness: swarm packet integrated; `SYT-010D` helper-test lane is ready for review
 
 ## Goal
 
@@ -51,7 +51,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-010D` is the next safe milestone: pure helper tests, keeping product/runtime behavior unchanged unless that lane explicitly expands it.
+`SYT-010D` is ready for review: pure helper tests and Playwright unit-project wiring.
 
 ## Verification Defaults
 
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) on `SYT-010D`.
+- Active subagents: none; `SYT-010D` Reviewer pending launch.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none; `SYT-010D` Reviewer pending launch.
+- Active subagents: Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) reviewing `SYT-010D`.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none yet; `SYT-010D` Planner/Runner is pending launch.
+- Active subagents: Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) on `SYT-010D`.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -11,7 +11,7 @@
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; `SYT-010D` helper-test lane is ready for review
+- Dispatch readiness: swarm packet integrated; `SYT-010D` helper-test lane is ready to integrate
 
 ## Goal
 
@@ -51,7 +51,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-010D` is ready for review: pure helper tests and Playwright unit-project wiring.
+`SYT-010D` is ready to integrate: pure helper tests and Playwright unit-project wiring passed review.
 
 ## Verification Defaults
 
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) reviewing `SYT-010D`.
+- Active subagents: none; `SYT-010D` Integrator pending launch.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none; `SYT-010D` Integrator pending launch.
+- Active subagents: Planck (`019ddc21-c7bb-75a2-94f6-e8d84b8f4489`) integrating `SYT-010D`.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/handoffs/SYT-010D.md
+++ b/docs/swarm/handoffs/SYT-010D.md
@@ -1,0 +1,111 @@
+# SYT-010D Handoff: Pure Helper Tests
+
+## Task
+
+- Task id: `SYT-010D`
+- Title: Pure helper tests
+- Assigned role: Planner/Runner
+- Current state: In Progress - pending Runner launch
+- Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+- Branch: `swarm/syt-010d-helper-tests`
+
+## Goal
+
+Add fast helper-level coverage where it provides real regression value for post-v0.3.0 hardening, especially settings normalization and selector-safe DOM helpers. If a helper-level test lane would add more maintenance cost than value, document a narrow deferral instead of forcing a brittle test layer.
+
+## Scope
+
+- Audit browser-independent or low-browser-coupling helpers such as:
+  - `src/content/settings.ts`: `normalizeSettings`, `isFeatureEnabled`, settings fallback behavior.
+  - `src/content/dom.ts`: `normalizeLabel`, `labelMatchesEntry`, `elementMatchesAnyLabel`, `query`, and `queryAll`.
+  - `src/shared/settings.ts` only if needed to assert default/parity behavior.
+- Prefer existing tooling. Playwright is already available and can run TypeScript tests; avoid new dependencies unless clearly justified.
+- If adding a unit/helper project, keep it small and obvious, such as `tests/unit/**`, `playwright.config.ts`, and `package.json` scripts.
+- Keep product/runtime behavior unchanged unless a tiny export or testability adjustment is necessary and low risk.
+
+## Non-Scope
+
+- No version bump, tag, release, or Web Store asset change.
+- No enhanced home/search hover implementation; #8 remains a future research lane.
+- No broad module splitting or architecture refactor.
+- No live YouTube dependency for this lane.
+- No popup/user-facing behavior changes.
+
+## Dependencies
+
+- Depends on: `SYT-010A`, `SYT-010B`, `SYT-010C`
+- Blocks: none directly; improves confidence before future `SYT-010E` module review or `SYT-008A` research.
+
+## Parallelization
+
+- parallel-safe: yes, if limited to tests/config/helper exports and no other active source tasks exist.
+- serial-required: no, under current max capacity 1.
+- depends-on: integrated `SYT-010A`, `SYT-010B`, and `SYT-010C`.
+- conflict-risk: low/medium. Low for tests-only; medium if helper exports or shared settings contracts are touched.
+
+## Suggested Implementation Plan
+
+1. Inspect existing Playwright config, scripts, and helper exports.
+2. Decide whether a `tests/unit` Playwright project is worthwhile.
+3. Add narrow tests for settings normalization and DOM helper behavior, or document why the lane should be deferred.
+4. Keep `npm run validate:all` as the final gate if config/source/package files change.
+5. Push the branch and open a draft PR with a `How to test / what to tell the controller` section.
+
+## Verification Tier
+
+- Verification tier: focused runner checks, full if config/source/package changes.
+- Minimum checks if tests/config/source/package change:
+  - `npm run typecheck`
+  - `npm run lint`
+  - focused new helper test command or targeted Playwright project
+  - `npm run validate:all`
+- Minimum checks if docs-only deferral:
+  - `git diff --check`
+
+## GitHub Actions Allowed
+
+- Push branch: yes.
+- Open draft PR: yes, if implementation or documented deferral is useful to review.
+- Merge: no.
+- Human QA: no, unless runtime behavior changes unexpectedly.
+
+## Files Or Areas Touched
+
+- Pending.
+
+## Commands Run
+
+- Pending.
+
+## Decisions Made
+
+- Keep this lane separate from #8 enhanced hover research and `SYT-010E` module splitting.
+- Do not add dependencies unless the existing Playwright/TypeScript stack cannot cover the helper behavior cleanly.
+
+## Blockers Or Risks
+
+- If helpers are not safely importable without extension/browser globals, prefer a narrow testability refactor only when it keeps runtime behavior unchanged.
+- If helper-level tests require too much config churn, document the deferral and recommend a smaller future lane.
+
+## Next Recommended Role
+
+- Planner/Runner should implement or defer the helper-test lane, update this handoff, push the branch, and open a draft PR if there is a reviewable change.
+
+## Copy-Ready Runner Prompt
+
+```text
+You are the Planner/Runner for Simple YT Tweaks task SYT-010D.
+
+Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
+Branch: swarm/syt-010d-helper-tests
+
+Read ../AGENTS.md, SWARM.md, docs/swarm/controller-directives.md, docs/swarm/task-board.md, docs/swarm/agent-registry.md, docs/swarm/github.md, and docs/swarm/handoffs/SYT-010D.md before editing.
+
+Scope: add fast helper-level coverage for settings normalization and selector-safe DOM helpers, or document a narrow deferral if the test layer would be more costly than useful. Prefer existing Playwright/TypeScript tooling. Avoid new dependencies unless clearly justified. Do not change product/runtime behavior except for tiny low-risk testability exports if needed. Do not work on #8 enhanced hover, releases, version bumps, tags, live YouTube behavior, or broad module splitting.
+
+Allowed GitHub actions: push the task branch and open a draft PR with a visible "How to test / what to tell the controller" section. Do not merge.
+
+Verification: if tests/config/source/package files change, run npm run typecheck, npm run lint, a focused helper test command or targeted Playwright project, and npm run validate:all. If the lane is docs-only deferral, run git diff --check.
+
+Update docs/swarm/handoffs/SYT-010D.md with files touched, commands/results, decisions, blockers, and next role. Report Needs Review when complete.
+```

--- a/docs/swarm/handoffs/SYT-010D.md
+++ b/docs/swarm/handoffs/SYT-010D.md
@@ -4,8 +4,8 @@
 
 - Task id: `SYT-010D`
 - Title: Pure helper tests
-- Assigned role: Planner/Runner
-- Current state: In Progress - pending Runner launch
+- Assigned role: Planner/Runner - Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`)
+- Current state: In Progress
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Branch: `swarm/syt-010d-helper-tests`
 
@@ -71,11 +71,20 @@ Add fast helper-level coverage where it provides real regression value for post-
 
 ## Files Or Areas Touched
 
-- Pending.
+- Controller prep:
+  - `docs/swarm/handoffs/SYT-010D.md`
+  - `docs/swarm/task-board.md`
+  - `docs/swarm/agent-registry.md`
+  - `docs/swarm/current-state.md`
+  - `docs/swarm/controller-directives.md`
+- Runner implementation: pending.
 
 ## Commands Run
 
-- Pending.
+- Controller prep:
+  - `git diff --check`: PASS
+  - `git push -u origin swarm/syt-010d-helper-tests`: PASS
+- Runner implementation: pending.
 
 ## Decisions Made
 
@@ -89,7 +98,7 @@ Add fast helper-level coverage where it provides real regression value for post-
 
 ## Next Recommended Role
 
-- Planner/Runner should implement or defer the helper-test lane, update this handoff, push the branch, and open a draft PR if there is a reviewable change.
+- Dirac should implement or defer the helper-test lane, update this handoff, push the branch, and open a draft PR if there is a reviewable change.
 
 ## Copy-Ready Runner Prompt
 

--- a/docs/swarm/handoffs/SYT-010D.md
+++ b/docs/swarm/handoffs/SYT-010D.md
@@ -5,7 +5,7 @@
 - Task id: `SYT-010D`
 - Title: Pure helper tests
 - Assigned role: Planner/Runner - Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`)
-- Current state: Needs Review
+- Current state: Ready to Integrate
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Branch: `swarm/syt-010d-helper-tests`
 
@@ -93,6 +93,10 @@ Add fast helper-level coverage where it provides real regression value for post-
   - `npm run typecheck`: PASS.
   - `npm run lint`: PASS.
   - `npm run validate:all`: PASS, including package validation, 8 unit tests, and 8 fixture tests.
+- Reviewer:
+  - `npm run test:unit`: PASS, 8 unit tests passed.
+  - `git diff --check origin/main...HEAD`: PASS.
+  - `npm run validate:all`: PASS, including package validation, 8 unit tests, and 8 fixture tests.
 
 ## Decisions Made
 
@@ -107,13 +111,19 @@ Add fast helper-level coverage where it provides real regression value for post-
 - No blockers.
 - Residual risk: unit tests use fake roots/elements for selector-safe DOM helpers rather than a real DOM. This is intentional to keep the lane fast and dependency-free; browser fixture coverage remains responsible for integrated DOM behavior.
 
+## Review Result
+
+- Status: Ready to Integrate.
+- Findings: none.
+- Review notes: PR #18 is scoped to docs, Playwright unit-project wiring, package scripts, and new helper tests. No product/runtime source files changed, no #8 hover/release/version work was introduced, and the PR body includes the required controller test section with human review requested: no.
+
 ## Pull Request
 
 - Draft PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/18
 
 ## Next Recommended Role
 
-- Reviewer should inspect the helper-test coverage, Playwright project config, and `validate:all` script change. If satisfied, mark `SYT-010D` Ready to Integrate. Human review requested: no.
+- Integrator should merge PR #18 if required checks remain green and the branch is still clean. Human review requested: no.
 
 ## Copy-Ready Runner Prompt
 

--- a/docs/swarm/handoffs/SYT-010D.md
+++ b/docs/swarm/handoffs/SYT-010D.md
@@ -5,7 +5,7 @@
 - Task id: `SYT-010D`
 - Title: Pure helper tests
 - Assigned role: Planner/Runner - Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`)
-- Current state: In Progress
+- Current state: Needs Review
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Branch: `swarm/syt-010d-helper-tests`
 
@@ -77,28 +77,43 @@ Add fast helper-level coverage where it provides real regression value for post-
   - `docs/swarm/agent-registry.md`
   - `docs/swarm/current-state.md`
   - `docs/swarm/controller-directives.md`
-- Runner implementation: pending.
+- Runner implementation:
+  - `package.json`
+  - `playwright.config.ts`
+  - `tests/unit/dom.unit.spec.ts`
+  - `tests/unit/settings.unit.spec.ts`
 
 ## Commands Run
 
 - Controller prep:
   - `git diff --check`: PASS
   - `git push -u origin swarm/syt-010d-helper-tests`: PASS
-- Runner implementation: pending.
+- Runner implementation:
+  - `npm run test:unit`: PASS, 8 unit tests passed.
+  - `npm run typecheck`: PASS.
+  - `npm run lint`: PASS.
+  - `npm run validate:all`: PASS, including package validation, 8 unit tests, and 8 fixture tests.
 
 ## Decisions Made
 
 - Keep this lane separate from #8 enhanced hover research and `SYT-010E` module splitting.
 - Do not add dependencies unless the existing Playwright/TypeScript stack cannot cover the helper behavior cleanly.
+- Added a small Playwright `unit` project instead of introducing a new unit-test dependency.
+- Added `npm run test:unit` and included the unit project in `npm run validate:all` so helper coverage runs in the full repo gate.
+- Kept runtime/source behavior unchanged; no helper exports or source refactors were needed.
 
 ## Blockers Or Risks
 
-- If helpers are not safely importable without extension/browser globals, prefer a narrow testability refactor only when it keeps runtime behavior unchanged.
-- If helper-level tests require too much config churn, document the deferral and recommend a smaller future lane.
+- No blockers.
+- Residual risk: unit tests use fake roots/elements for selector-safe DOM helpers rather than a real DOM. This is intentional to keep the lane fast and dependency-free; browser fixture coverage remains responsible for integrated DOM behavior.
+
+## Pull Request
+
+- Draft PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/18
 
 ## Next Recommended Role
 
-- Dirac should implement or defer the helper-test lane, update this handoff, push the branch, and open a draft PR if there is a reviewable change.
+- Reviewer should inspect the helper-test coverage, Playwright project config, and `validate:all` script change. If satisfied, mark `SYT-010D` Ready to Integrate. Human review requested: no.
 
 ## Copy-Ready Runner Prompt
 

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none yet; `SYT-010D` pending launch on this branch.
+- Active controller-spawned subagents: Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) on `SYT-010D`.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none; `SYT-010D` Reviewer pending launch.
+- Active controller-spawned subagents: Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) reviewing `SYT-010D`.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: Active; `SYT-010C` is integrated and `SYT-010D` is the next safe lane
+- Implementation dispatch: Active; `SYT-010C` is integrated and `SYT-010D` is being launched as the next safe lane
 
 ## Active Tasks
 
@@ -20,13 +20,13 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
 | `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
+| `SYT-010D` | Pure helper tests | Planner/Runner | In Progress | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | none |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Backlog
 
 | Task ID | Title | Reason | Notes |
 | --- | --- | --- | --- |
-| `SYT-010D` | Pure helper tests | Add fast coverage for settings normalization and selector-safe DOM helpers. | Can follow `SYT-010A` if it identifies browser-independent logic. |
 | `SYT-010E` | Large module split review | Reduce risk in large content modules only where it lowers real maintenance cost. | Do not split for aesthetics; require test coverage first. |
 | `SYT-RC-001` | Next release-candidate checklist | Make future version bump/package/release flow smoother. | Human QA required before release. |
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none.
+- Active controller-spawned subagents: none yet; `SYT-010D` pending launch on this branch.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; `SYT-010D` is the next safe planning/runner lane.
+- Current controller phase: Phase 4 active; `SYT-010D` is the active planning/runner lane.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none; `SYT-010D` Integrator pending launch.
+- Active controller-spawned subagents: Planck (`019ddc21-c7bb-75a2-94f6-e8d84b8f4489`) integrating `SYT-010D`.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: Active; `SYT-010D` is ready for review
+- Implementation dispatch: Active; `SYT-010D` is ready to integrate
 
 ## Active Tasks
 
@@ -20,7 +20,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
 | `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
-| `SYT-010D` | Pure helper tests | Reviewer | Needs Review | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 |
+| `SYT-010D` | Pure helper tests | Integrator | Ready to Integrate | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Backlog
@@ -40,13 +40,13 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| `SYT-010D` | `swarm/syt-010d-helper-tests` | Helper-test coverage, Playwright unit project config, `validate:all` script, PR body/handoff accuracy | targeted review plus focused checks | `docs/swarm/handoffs/SYT-010D.md` |
+| none | none | none | none | none |
 
 ## Ready To Integrate
 
 | Task ID | Branch | Checks | Cleanup Plan | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010D` | `swarm/syt-010d-helper-tests` | Reviewer passed; integrator should recheck merge state and run final verification per policy | Merge PR #18, clean branch/worktree, record integration | `docs/swarm/handoffs/SYT-010D.md` |
 
 ## Human QA
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`) reviewing `SYT-010D`.
+- Active controller-spawned subagents: none; `SYT-010D` Integrator pending launch.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; `SYT-010D` is the active review lane.
+- Current controller phase: Phase 4 active; `SYT-010D` is the active integration lane.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: Active; `SYT-010C` is integrated and `SYT-010D` is being launched as the next safe lane
+- Implementation dispatch: Active; `SYT-010D` is ready for review
 
 ## Active Tasks
 
@@ -20,7 +20,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
 | `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
-| `SYT-010D` | Pure helper tests | Planner/Runner | In Progress | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | none |
+| `SYT-010D` | Pure helper tests | Reviewer | Needs Review | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Backlog
@@ -40,7 +40,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010D` | `swarm/syt-010d-helper-tests` | Helper-test coverage, Playwright unit project config, `validate:all` script, PR body/handoff accuracy | targeted review plus focused checks | `docs/swarm/handoffs/SYT-010D.md` |
 
 ## Ready To Integrate
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`) on `SYT-010D`.
+- Active controller-spawned subagents: none; `SYT-010D` Reviewer pending launch.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; `SYT-010D` is the active planning/runner lane.
+- Current controller phase: Phase 4 active; `SYT-010D` is the active review lane.

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "validate": "node scripts/validate-extension.mjs",
     "validate:packaged": "node scripts/validate-extension.mjs --packaged",
     "package": "npm run build && npm run validate && node scripts/package-extension.mjs && npm run validate:packaged",
+    "test:unit": "playwright test --project=unit",
     "test:e2e": "npm run build && playwright test --project=fixtures",
     "test:e2e:live": "npm run build && SIMPLE_YT_TWEAKS_LIVE=1 playwright test --project=live",
-    "validate:all": "npm run typecheck && npm run lint && git diff --check && npm run package && playwright test --project=fixtures"
+    "validate:all": "npm run typecheck && npm run lint && git diff --check && npm run package && playwright test --project=unit && playwright test --project=fixtures"
   },
   "keywords": [
     "chrome-extension",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests/e2e',
-  outputDir: './test-results/e2e',
+  testDir: './tests',
+  outputDir: './test-results',
   fullyParallel: false,
   workers: 1,
   reporter: [['list'], ['html', { open: 'never' }]],
@@ -15,6 +15,10 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   projects: [
+    {
+      name: 'unit',
+      testMatch: /.*\.unit\.spec\.ts/,
+    },
     {
       name: 'fixtures',
       testMatch: /.*\.fixture\.spec\.ts/,

--- a/tests/unit/dom.unit.spec.ts
+++ b/tests/unit/dom.unit.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  elementMatchesAnyLabel,
+  labelMatchesEntry,
+  normalizeLabel,
+  query,
+  queryAll,
+} from '../../src/content/dom';
+
+type SelectorRoot = Pick<ParentNode, 'querySelector' | 'querySelectorAll'>;
+
+function makeRoot(matches: Element[]): ParentNode {
+  const root: SelectorRoot = {
+    querySelector: <T extends Element = Element>(selector: string): T | null => {
+      if (selector === 'throw') {
+        throw new DOMException('Invalid selector');
+      }
+
+      return (matches[0] ?? null) as T | null;
+    },
+    querySelectorAll: <T extends Element = Element>(selector: string): NodeListOf<T> => {
+      if (selector === 'throw') {
+        throw new DOMException('Invalid selector');
+      }
+
+      return matches as unknown as NodeListOf<T>;
+    },
+  };
+
+  return root as unknown as ParentNode;
+}
+
+function makeElementLabel(
+  attributes: Partial<Record<'aria-label' | 'title', string>>,
+  textContent = '',
+): Element {
+  return {
+    getAttribute: (name: string) => attributes[name as 'aria-label' | 'title'] ?? null,
+    textContent,
+  } as unknown as Element;
+}
+
+test('query helpers return matches and swallow invalid selectors', () => {
+  const first = makeElementLabel({ 'aria-label': 'First' });
+  const second = makeElementLabel({ 'aria-label': 'Second' });
+  const root = makeRoot([first, second]);
+
+  expect(query('valid', root)).toBe(first);
+  expect(queryAll('valid', root)).toEqual([first, second]);
+  expect(query('throw', root)).toBeNull();
+  expect(queryAll('throw', root)).toEqual([]);
+});
+
+test('normalizeLabel removes chevrons, folds whitespace, and lowercases text', () => {
+  expect(normalizeLabel('  YouTube  Music ›  Selected >  ')).toBe('youtube music selected');
+  expect(normalizeLabel('\nSubscriptions\tLink')).toBe('subscriptions link');
+});
+
+test('labelMatchesEntry accepts YouTube sidebar label variants without overmatching', () => {
+  expect(labelMatchesEntry('subscriptions', 'Subscriptions')).toBe(true);
+  expect(labelMatchesEntry('subscriptions subscriptions', 'Subscriptions')).toBe(true);
+  expect(labelMatchesEntry('subscriptions selected', 'Subscriptions')).toBe(true);
+  expect(labelMatchesEntry('subscriptions link', 'Subscriptions')).toBe(true);
+  expect(labelMatchesEntry('my subscriptions', 'Subscriptions')).toBe(false);
+  expect(labelMatchesEntry('subscriptions and more', 'Subscriptions')).toBe(false);
+});
+
+test('elementMatchesAnyLabel combines aria label, title, and text before matching', () => {
+  const matchingElement = makeElementLabel({ 'aria-label': 'Explore ›' }, 'Selected');
+  const blankElement = makeElementLabel({});
+  const unrelatedElement = makeElementLabel({ title: 'Library' }, 'History');
+
+  expect(elementMatchesAnyLabel(matchingElement, ['Explore'])).toBe(true);
+  expect(elementMatchesAnyLabel(blankElement, ['Explore'])).toBe(false);
+  expect(elementMatchesAnyLabel(unrelatedElement, ['Explore'])).toBe(false);
+});

--- a/tests/unit/settings.unit.spec.ts
+++ b/tests/unit/settings.unit.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  DEFAULT_SETTINGS as CONTENT_DEFAULT_SETTINGS,
+  SETTING_KEYS,
+  isFeatureEnabled,
+  normalizeSettings,
+  type Settings,
+} from '../../src/content/settings';
+import { DEFAULT_SETTINGS as SHARED_DEFAULT_SETTINGS } from '../../src/shared/settings';
+
+test('content defaults stay aligned with shared settings defaults', () => {
+  expect(CONTENT_DEFAULT_SETTINGS).toEqual(SHARED_DEFAULT_SETTINGS);
+  expect(SETTING_KEYS).toEqual(Object.keys(CONTENT_DEFAULT_SETTINGS));
+});
+
+test('normalizeSettings accepts valid stored values and falls back for invalid values', () => {
+  const settings = normalizeSettings({
+    generalFeedColumns: 4,
+    generalHideSponsoredPosts: false,
+    generalHideShorts: 'false',
+    theaterHideComments: true,
+    defaultHideComments: 1,
+    pipButton: false,
+    floatingMiniPlayer: true,
+  });
+
+  expect(settings.generalFeedColumns).toBe(4);
+  expect(settings.generalHideSponsoredPosts).toBe(false);
+  expect(settings.generalHideShorts).toBe(CONTENT_DEFAULT_SETTINGS.generalHideShorts);
+  expect(settings.theaterHideComments).toBe(true);
+  expect(settings.defaultHideComments).toBe(CONTENT_DEFAULT_SETTINGS.defaultHideComments);
+  expect(settings.pipButton).toBe(false);
+  expect(settings.floatingMiniPlayer).toBe(false);
+});
+
+test('normalizeSettings rejects unsupported feed column counts', () => {
+  for (const generalFeedColumns of [0, 1, 5, '3', null, undefined]) {
+    expect(normalizeSettings({ generalFeedColumns }).generalFeedColumns).toBe(
+      CONTENT_DEFAULT_SETTINGS.generalFeedColumns,
+    );
+  }
+
+  for (const generalFeedColumns of [2, 3, 4]) {
+    expect(normalizeSettings({ generalFeedColumns }).generalFeedColumns).toBe(generalFeedColumns);
+  }
+});
+
+test('isFeatureEnabled preserves the PiP-controlled floating mini player compatibility alias', () => {
+  const disabledPipSettings: Settings = {
+    ...CONTENT_DEFAULT_SETTINGS,
+    pipButton: false,
+    floatingMiniPlayer: true,
+  };
+  const enabledPipSettings: Settings = {
+    ...CONTENT_DEFAULT_SETTINGS,
+    pipButton: true,
+    floatingMiniPlayer: false,
+  };
+
+  expect(isFeatureEnabled(disabledPipSettings, 'floatingMiniPlayer')).toBe(false);
+  expect(isFeatureEnabled(enabledPipSettings, 'floatingMiniPlayer')).toBe(true);
+  expect(isFeatureEnabled(disabledPipSettings, 'generalHideSponsoredPosts')).toBe(
+    disabledPipSettings.generalHideSponsoredPosts,
+  );
+});


### PR DESCRIPTION
## Summary
- add a Playwright unit project for fast helper-level tests
- cover settings normalization/default parity and PiP alias behavior
- cover selector-safe DOM helper behavior without adding new dependencies

## How to test / what to tell the controller
- human review requested: no
- commands:
  - `npm run test:unit`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run validate:all`
- expected result: all commands pass; `validate:all` runs package validation plus the unit and fixture Playwright projects
- feedback format: `SYT-010D review: <Ready to Integrate | Needs Fixes | Blocked> - <notes>`
