### PR TITLE
SYT-008A hover research gate

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-30 01:21 EDT | Reconcile `SYT-008A` research and route review | Stop after one Reviewer is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
+| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-008A` review and stopped with capacity full. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd` / Arendt | `SYT-008A` | Reviewer | In Progress | `swarm/syt-008a-hover-research` | forked workspace | #20 | 2026-04-30 01:22 EDT | 2026-04-30 01:22 EDT | Review PR #20 and report Ready for Human QA/Product Direction, Needs Fixes, or Blocked | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `docs/swarm/handoffs/SYT-008A.md`, #8 research notes, fixture/prototype plan only | `SYT-008A` | Pending Reviewer launch | `swarm/syt-008a-hover-research` | Research gate review; no runtime implementation | Release when research PR is reviewed/integrated, deferred, or blocked. |
+| `docs/swarm/handoffs/SYT-008A.md`, #8 research notes, fixture/prototype plan only | `SYT-008A` | Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) | `swarm/syt-008a-hover-research` | Research gate review; no runtime implementation | Release when research PR is reviewed/integrated, deferred, or blocked. |
 
 ## Recently Completed
 
@@ -59,7 +59,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-008A` | Reviewer | `swarm/syt-008a-hover-research` | Planner completed with PR #20 clean/draft | `docs/swarm/handoffs/SYT-008A.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-008A` research and stopped with capacity full. |
+| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-30 01:21 EDT | Reconcile `SYT-008A` research and route review | Stop after one Reviewer is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019ddc7d-3114-7603-9c3e-a3daaf9f055a` / Lovelace | `SYT-008A` | Planner | In Progress | `swarm/syt-008a-hover-research` | forked workspace | none | 2026-04-29 23:44 EDT | 2026-04-29 23:44 EDT | Produce #8 research plan, push branch, open draft PR if reviewable | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `docs/swarm/handoffs/SYT-008A.md`, #8 research notes, fixture/prototype plan only | `SYT-008A` | Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) | `swarm/syt-008a-hover-research` | Research gate; no runtime implementation | Release when research PR is reviewed/integrated, deferred, or blocked. |
+| `docs/swarm/handoffs/SYT-008A.md`, #8 research notes, fixture/prototype plan only | `SYT-008A` | Pending Reviewer launch | `swarm/syt-008a-hover-research` | Research gate review; no runtime implementation | Release when research PR is reviewed/integrated, deferred, or blocked. |
 
 ## Recently Completed
 
@@ -53,12 +53,13 @@ Use this file to track who is working, where they are working, and whether the c
 | `019ddb72-af51-7372-8146-43d5ead7148a` / Dirac | `SYT-010D` | Planner/Runner | Opened draft PR #18 | 2026-04-29 20:28 EDT | Added Playwright unit project and helper tests; `npm run test:unit`, `typecheck`, `lint`, and `validate:all` passed. |
 | `019ddbcb-2d65-76c1-982c-54abedb730cc` / Ptolemy | `SYT-010D` | Reviewer | Ready to Integrate, no findings | 2026-04-29 22:03 EDT | PR #18 review passed; `npm run test:unit`, `git diff --check origin/main...HEAD`, `npm run validate:all`, and `git diff --check` passed. |
 | `019ddc21-c7bb-75a2-94f6-e8d84b8f4489` / Planck | `SYT-010D` | Integrator | Merged PR #18 | 2026-04-29 22:07 EDT | PR #18 squash-merged into `main` at `88f0a91`; local branch cleanup completed and stale remote-tracking ref pruned. |
+| `019ddc7d-3114-7603-9c3e-a3daaf9f055a` / Lovelace | `SYT-008A` | Planner | Opened draft PR #20 | 2026-04-30 01:21 EDT | Research decision requires human/product direction before prototype; `git diff --check` passed; no runtime/source/tests touched. |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-008A` | Reviewer | `swarm/syt-008a-hover-research` | Planner completed with PR #20 clean/draft | `docs/swarm/handoffs/SYT-008A.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-008A` review and stopped with capacity full. |
+| none | none | none | none | 90 minutes | `SYT-008A` review is complete; controller is stopped at product-direction gate. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd` / Arendt | `SYT-008A` | Reviewer | In Progress | `swarm/syt-008a-hover-research` | forked workspace | #20 | 2026-04-30 01:22 EDT | 2026-04-30 01:22 EDT | Review PR #20 and report Ready for Human QA/Product Direction, Needs Fixes, or Blocked | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `docs/swarm/handoffs/SYT-008A.md`, #8 research notes, fixture/prototype plan only | `SYT-008A` | Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) | `swarm/syt-008a-hover-research` | Research gate review; no runtime implementation | Release when research PR is reviewed/integrated, deferred, or blocked. |
+| none | none | none | none | none | none |
 
 ## Recently Completed
 
@@ -53,6 +53,8 @@ Use this file to track who is working, where they are working, and whether the c
 | `019ddb72-af51-7372-8146-43d5ead7148a` / Dirac | `SYT-010D` | Planner/Runner | Opened draft PR #18 | 2026-04-29 20:28 EDT | Added Playwright unit project and helper tests; `npm run test:unit`, `typecheck`, `lint`, and `validate:all` passed. |
 | `019ddbcb-2d65-76c1-982c-54abedb730cc` / Ptolemy | `SYT-010D` | Reviewer | Ready to Integrate, no findings | 2026-04-29 22:03 EDT | PR #18 review passed; `npm run test:unit`, `git diff --check origin/main...HEAD`, `npm run validate:all`, and `git diff --check` passed. |
 | `019ddc21-c7bb-75a2-94f6-e8d84b8f4489` / Planck | `SYT-010D` | Integrator | Merged PR #18 | 2026-04-29 22:07 EDT | PR #18 squash-merged into `main` at `88f0a91`; local branch cleanup completed and stale remote-tracking ref pruned. |
+| `019ddc7d-3114-7603-9c3e-a3daaf9f055a` / Lovelace | `SYT-008A` | Planner | Opened draft PR #20 | 2026-04-30 01:21 EDT | Research decision requires human/product direction before prototype; `git diff --check` passed; no runtime/source/tests touched. |
+| `019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd` / Arendt | `SYT-008A` | Reviewer | Ready for Human QA/Product Direction | 2026-04-30 02:56 EDT | PR #20 review passed; docs-only, no runtime changes; product direction required before prototype. |
 | `019ddc7d-3114-7603-9c3e-a3daaf9f055a` / Lovelace | `SYT-008A` | Planner | Opened draft PR #20 | 2026-04-30 01:21 EDT | Research decision requires human/product direction before prototype; `git diff --check` passed; no runtime/source/tests touched. |
 
 ## Pending Launch

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,13 +15,13 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-29 23:43 EDT | Prepare and launch `SYT-008A` research gate | Stop after one Planner is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
+| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-008A` research and stopped with capacity full. |
 
 ## Active Agents
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019ddc7d-3114-7603-9c3e-a3daaf9f055a` / Lovelace | `SYT-008A` | Planner | In Progress | `swarm/syt-008a-hover-research` | forked workspace | none | 2026-04-29 23:44 EDT | 2026-04-29 23:44 EDT | Produce #8 research plan, push branch, open draft PR if reviewable | none |
 
 ## Paused / Stale Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `docs/swarm/handoffs/SYT-008A.md`, #8 research notes, fixture/prototype plan only | `SYT-008A` | Pending Planner launch | `swarm/syt-008a-hover-research` | Research gate prep; no runtime implementation | Release when research PR is reviewed/integrated, deferred, or blocked. |
+| `docs/swarm/handoffs/SYT-008A.md`, #8 research notes, fixture/prototype plan only | `SYT-008A` | Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) | `swarm/syt-008a-hover-research` | Research gate; no runtime implementation | Release when research PR is reviewed/integrated, deferred, or blocked. |
 
 ## Recently Completed
 
@@ -58,7 +58,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-008A` | Planner | `swarm/syt-008a-hover-research` | `SYT-010D` integrated and capacity available | `docs/swarm/handoffs/SYT-008A.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,7 +15,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | 90 minutes | Controller heartbeat launched `SYT-010D` integration and stopped with capacity full. |
+| heartbeat `simple-yt-tweaks-controller-heartbeat` | 2026-04-29 23:43 EDT | Prepare and launch `SYT-008A` research gate | Stop after one Planner is launched or a blocker is recorded | 90 minutes | Bounded active-pulse pass. |
 
 ## Active Agents
 
@@ -33,7 +33,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `docs/swarm/handoffs/SYT-008A.md`, #8 research notes, fixture/prototype plan only | `SYT-008A` | Pending Planner launch | `swarm/syt-008a-hover-research` | Research gate prep; no runtime implementation | Release when research PR is reviewed/integrated, deferred, or blocked. |
 
 ## Recently Completed
 
@@ -58,7 +58,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-008A` | Planner | `swarm/syt-008a-hover-research` | `SYT-010D` integrated and capacity available | `docs/swarm/handoffs/SYT-008A.md` |
 
 ## Side Chats
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,17 +8,17 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-30 01:22 EDT
+- Last reviewed by controller: 2026-04-30 02:56 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-008a-hover-research`
-- Expected Git state: clean `swarm/syt-008a-hover-research` with `SYT-008A` review active in a forked workspace
+- Expected Git state: clean `swarm/syt-008a-hover-research` with PR #20 waiting for product direction
 - Open PR expectation: #20 for `SYT-008A`
-- Active agents expectation: Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) is reviewing `SYT-008A`
+- Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: await `SYT-008A` review result
+- Current priority lane: wait for user product direction on `SYT-008A`
 
 ## Controller Lease And Pacing
 
@@ -96,8 +96,8 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-008A` | Await research gate review for future enhanced home/search hover | Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) | `swarm/syt-008a-hover-research` | Review reports Ready for Human QA/Product Direction, Needs Fixes, or Blocked |
-| 2 | `SYT-010E` | Large module split review | Planner | `swarm/syt-010e-module-split-review` | Decide if any split reduces real risk |
+| 1 | `SYT-008A` | Wait for product direction: defer, prototype off-by-default, or non-transform polish | User/Controller | `swarm/syt-008a-hover-research` | User gives `Product direction for SYT-008A: ...` |
+| 2 | `SYT-010E` | Large module split review | Planner | `swarm/syt-010e-module-split-review` | Only route after `SYT-008A` direction or explicit controller decision to continue unrelated work |
 
 ## Dynamic Notes
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 23:44 EDT
+- Last reviewed by controller: 2026-04-30 01:21 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-008a-hover-research`
-- Expected Git state: clean `swarm/syt-008a-hover-research` with `SYT-008A` research active in a forked workspace
-- Open PR expectation: none
-- Active agents expectation: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) is researching `SYT-008A`
-- Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: await `SYT-008A` research result
+- Expected Git state: clean `swarm/syt-008a-hover-research` with `SYT-008A` PR #20 ready for review
+- Open PR expectation: #20 for `SYT-008A`
+- Active agents expectation: none until `SYT-008A` Reviewer is launched
+- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
+- Current priority lane: route `SYT-008A` review
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: none
-- Lease started: none
-- Lease expected action: none
-- Lease stop condition: none
+- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
+- Lease started: 2026-04-30 01:21 EDT
+- Lease expected action: route `SYT-008A` review
+- Lease stop condition: `SYT-008A` Reviewer launched or blocker recorded
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-008A` | Await research gate for future enhanced home/search hover | Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) | `swarm/syt-008a-hover-research` | Research reports Needs Review, Deferred, or Blocked |
+| 1 | `SYT-008A` | Review research gate for future enhanced home/search hover | Reviewer | `swarm/syt-008a-hover-research` | Review reports Ready for Human QA/Product Direction, Needs Fixes, or Blocked |
 | 2 | `SYT-010E` | Large module split review | Planner | `swarm/syt-010e-module-split-review` | Decide if any split reduces real risk |
 
 ## Dynamic Notes

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 22:07 EDT
+- Last reviewed by controller: 2026-04-29 23:43 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `main`
-- Expected Git state: clean `main...origin/main` after `SYT-010D` integration record lands
+- Current branch: `swarm/syt-008a-hover-research`
+- Expected Git state: clean task branch after `SYT-008A` research-gate launch prep is committed/pushed
 - Open PR expectation: none
-- Active agents expectation: none
-- Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: none started by the Integrator; controller may choose the next lane in a later pass
+- Active agents expectation: none until `SYT-008A` Planner is launched
+- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
+- Current priority lane: route `SYT-008A` research gate
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: none
-- Lease started: none
-- Lease expected action: none
-- Lease stop condition: none
+- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
+- Lease started: 2026-04-29 23:43 EDT
+- Lease expected action: prepare and launch `SYT-008A`
+- Lease stop condition: `SYT-008A` Planner launched or blocker recorded
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,8 +96,8 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010D` | Integrated PR #18 helper unit tests | Integrator complete | `main` | Integration record landed |
-| 2 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+| 1 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+| 2 | `SYT-010E` | Large module split review | Planner | `swarm/syt-010e-module-split-review` | Decide if any split reduces real risk |
 
 ## Dynamic Notes
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-30 01:21 EDT
+- Last reviewed by controller: 2026-04-30 01:22 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-008a-hover-research`
-- Expected Git state: clean `swarm/syt-008a-hover-research` with `SYT-008A` PR #20 ready for review
+- Expected Git state: clean `swarm/syt-008a-hover-research` with `SYT-008A` review active in a forked workspace
 - Open PR expectation: #20 for `SYT-008A`
-- Active agents expectation: none until `SYT-008A` Reviewer is launched
-- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
-- Current priority lane: route `SYT-008A` review
+- Active agents expectation: Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) is reviewing `SYT-008A`
+- Controller lease expectation: none between bounded heartbeat passes
+- Current priority lane: await `SYT-008A` review result
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
-- Lease started: 2026-04-30 01:21 EDT
-- Lease expected action: route `SYT-008A` review
-- Lease stop condition: `SYT-008A` Reviewer launched or blocker recorded
+- Controller lease owner: none
+- Lease started: none
+- Lease expected action: none
+- Lease stop condition: none
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-008A` | Review research gate for future enhanced home/search hover | Reviewer | `swarm/syt-008a-hover-research` | Review reports Ready for Human QA/Product Direction, Needs Fixes, or Blocked |
+| 1 | `SYT-008A` | Await research gate review for future enhanced home/search hover | Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) | `swarm/syt-008a-hover-research` | Review reports Ready for Human QA/Product Direction, Needs Fixes, or Blocked |
 | 2 | `SYT-010E` | Large module split review | Planner | `swarm/syt-010e-module-split-review` | Decide if any split reduces real risk |
 
 ## Dynamic Notes

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,24 +8,24 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 23:43 EDT
+- Last reviewed by controller: 2026-04-29 23:44 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `swarm/syt-008a-hover-research`
-- Expected Git state: clean task branch after `SYT-008A` research-gate launch prep is committed/pushed
+- Expected Git state: clean `swarm/syt-008a-hover-research` with `SYT-008A` research active in a forked workspace
 - Open PR expectation: none
-- Active agents expectation: none until `SYT-008A` Planner is launched
-- Controller lease expectation: active only for this bounded heartbeat pass, then clear after launch or blocker
-- Current priority lane: route `SYT-008A` research gate
+- Active agents expectation: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) is researching `SYT-008A`
+- Controller lease expectation: none between bounded heartbeat passes
+- Current priority lane: await `SYT-008A` research result
 
 ## Controller Lease And Pacing
 
-- Controller lease owner: heartbeat `simple-yt-tweaks-controller-heartbeat`
-- Lease started: 2026-04-29 23:43 EDT
-- Lease expected action: prepare and launch `SYT-008A`
-- Lease stop condition: `SYT-008A` Planner launched or blocker recorded
+- Controller lease owner: none
+- Lease started: none
+- Lease expected action: none
+- Lease stop condition: none
 - Lease stale after: 90 minutes
 - Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+| 1 | `SYT-008A` | Await research gate for future enhanced home/search hover | Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) | `swarm/syt-008a-hover-research` | Research reports Needs Review, Deferred, or Blocked |
 | 2 | `SYT-010E` | Large module split review | Planner | `swarm/syt-010e-module-split-review` | Decide if any split reduces real risk |
 
 ## Dynamic Notes

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ The next safe milestone is `SYT-008A`: a research-only gate for #8 enhanced home
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none yet; `SYT-008A` Planner pending launch.
+- Active subagents: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) researching `SYT-008A`.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -11,7 +11,7 @@
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; `SYT-010D` helper-test lane is integrated
+- Dispatch readiness: swarm packet integrated; `SYT-008A` research gate is being launched
 
 ## Goal
 
@@ -51,7 +51,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-010D` is integrated: pure helper tests and Playwright unit-project wiring were squash-merged through PR #18.
+The next safe milestone is `SYT-008A`: a research-only gate for #8 enhanced home/search hover. Runtime implementation remains out of scope until the research plan, validation gates, and any required human/product decision are explicit.
 
 ## Verification Defaults
 
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none after `SYT-010D` integration.
+- Active subagents: none yet; `SYT-008A` Planner pending launch.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
@@ -88,4 +88,4 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 ## Last Updated
 
 - Date: 2026-04-29
-- By: Planck, `SYT-010D` Integrator
+- By: Controller heartbeat

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -11,7 +11,7 @@
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; `SYT-008A` research gate is ready for review
+- Dispatch readiness: swarm packet integrated; `SYT-008A` research gate is waiting for product direction
 
 ## Goal
 
@@ -51,7 +51,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-008A` research is ready for review. Runtime implementation remains out of scope until the research plan, validation gates, and required human/product decision are explicit.
+`SYT-008A` research passed review and is waiting for product direction. Runtime implementation remains out of scope until the user chooses defer, off-by-default prototype, or non-transform polish.
 
 ## Verification Defaults
 
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) reviewing `SYT-008A`.
+- Active subagents: none; stopped at `SYT-008A` product-direction gate.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -11,7 +11,7 @@
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; `SYT-008A` research gate is being launched
+- Dispatch readiness: swarm packet integrated; `SYT-008A` research gate is ready for review
 
 ## Goal
 
@@ -51,7 +51,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-The next safe milestone is `SYT-008A`: a research-only gate for #8 enhanced home/search hover. Runtime implementation remains out of scope until the research plan, validation gates, and any required human/product decision are explicit.
+`SYT-008A` research is ready for review. Runtime implementation remains out of scope until the research plan, validation gates, and required human/product decision are explicit.
 
 ## Verification Defaults
 
@@ -80,7 +80,7 @@ The next safe milestone is `SYT-008A`: a research-only gate for #8 enhanced home
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) researching `SYT-008A`.
+- Active subagents: none; `SYT-008A` Reviewer pending launch.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -80,7 +80,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none; `SYT-008A` Reviewer pending launch.
+- Active subagents: Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) reviewing `SYT-008A`.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/handoffs/SYT-008A.md
+++ b/docs/swarm/handoffs/SYT-008A.md
@@ -61,6 +61,7 @@ Research whether #8 can be safely revived in a future release without breaking n
 | `gh api repos/cryptoteatime/simple-yt-tweaks/issues/8/comments --jq '.[] | {user:.user.login, created_at, body}'` | Passed | Read issue comments. |
 | `rg -n "hover|preview|autoplay|flicker|edge|clip|#8|SYT-008|grid-hover|home/search|home search" . -g '!node_modules/**' -g '!dist/**' -g '!release/**'` | Passed | Found current guardrails and prior notes; output included generated asset noise, so source/docs were read directly afterward. |
 | `git diff --check` | Passed | Required docs-only verification. |
+| `gh pr create --draft --base main --head swarm/syt-008a-hover-research` | Passed | Opened draft PR #20 for review/product-direction routing. |
 
 ## Blockers / Risks
 
@@ -151,7 +152,7 @@ Live/manual gate:
 - Next role: Reviewer for docs/research review, then controller/product direction.
 - Next action: Review this handoff, then ask the user whether #8 should stay deferred, move to an off-by-default prototype, or be narrowed to non-transform polish.
 - Branch/worktree cleanup needed after merge: yes.
-- PR: TBD.
+- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/20
 - Copy-ready prompt:
 
 ```text

--- a/docs/swarm/handoffs/SYT-008A.md
+++ b/docs/swarm/handoffs/SYT-008A.md
@@ -2,11 +2,11 @@
 
 ## State
 
-- Status: Needs Review - research decision drafted; product direction required before prototype
-- Role: Planner
+- Status: Ready for Human QA/Product Direction
+- Role: Planner/Reviewer
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-008a-hover-research`
-- Owner: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`)
+- Owner: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) / Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`)
 - Created: 2026-04-29
 - Updated: 2026-04-30
 
@@ -36,7 +36,7 @@ Research whether #8 can be safely revived in a future release without breaking n
 
 - Parallel-safe: no with #10 source work.
 - Serial-required: yes; live YouTube preview lifecycle is fragile.
-- Depends-on: `SYT-010A`, user/product gate.
+- Depends-on: `SYT-010A`, `SYT-010D`, user/product gate.
 - Conflict-risk: high; home/search feed CSS, YouTube preview overlay lifecycle, `src/content/grid-hover.ts`.
 - Shared coordination docs allowed: this handoff only unless controller assigns more.
 
@@ -45,13 +45,19 @@ Research whether #8 can be safely revived in a future release without breaking n
 | Check | Result | Notes |
 | --- | --- | --- |
 | `git diff --check` | Passed | Docs-only whitespace check. |
+| `git diff --check origin/main...HEAD` | Passed | Reviewer check. |
 | `npm run test:e2e` | Not run for this docs-only lane | Required for any fixture/prototype lane. |
 | `npm run test:e2e:live` | Not run for this lane yet | Optional research smoke, not stable gate. |
 | Human QA | Not run for this lane yet | Required before merging any visual behavior change. |
 
 ## Files Touched
 
+- `docs/swarm/agent-registry.md`
+- `docs/swarm/controller-directives.md`
+- `docs/swarm/current-state.md`
 - `docs/swarm/handoffs/SYT-008A.md`
+- `docs/swarm/project-brief.md`
+- `docs/swarm/task-board.md`
 
 ## Commands Run
 
@@ -62,6 +68,16 @@ Research whether #8 can be safely revived in a future release without breaking n
 | `rg -n "hover|preview|autoplay|flicker|edge|clip|#8|SYT-008|grid-hover|home/search|home search" . -g '!node_modules/**' -g '!dist/**' -g '!release/**'` | Passed | Found current guardrails and prior notes; output included generated asset noise, so source/docs were read directly afterward. |
 | `git diff --check` | Passed | Required docs-only verification. |
 | `gh pr create --draft --base main --head swarm/syt-008a-hover-research` | Passed | Opened draft PR #20 for review/product-direction routing. |
+| `gh pr view 20 --json ...` | Passed | Reviewer confirmed PR is draft/open/clean. |
+| `git diff --stat origin/main...HEAD` | Passed | Reviewer confirmed docs-only diff. |
+| `git diff origin/main...HEAD -- . ':(exclude)docs/swarm/**'` | Passed | Empty; reviewer confirmed no runtime changes. |
+
+## Review Result
+
+- Status: Ready for Human QA/Product Direction.
+- Reviewer: Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`).
+- Findings: none blocking.
+- Notes: The research decision coherently blocks runtime hover implementation behind product direction, keeps #8 separate from #10, uses fixture-first gates, and scopes next lanes serially around the fragile hover lifecycle.
 
 ## Blockers / Risks
 
@@ -135,7 +151,7 @@ Live/manual gate:
 | Task ID | Role | Status | Scope | Parallel-safe | Serial-required | Depends-on | Conflict-risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-008B` | Product/Planner | Blocked pending human direction | Decide whether #8 remains deferred, gets an off-by-default prototype, or narrows to non-transform polish. | yes, docs only | no | `SYT-008A` review | low |
-| `SYT-008C` | Runner | Proposed only if `SYT-008B` approves prototype | Add fixture coverage for off/default-on prototype gates before runtime hover behavior. | no with hover source work | yes | `SYT-008B` | medium, fixture contracts |
+| `SYT-008C` | Runner | Proposed only if `SYT-008B` approves prototype | Add fixture coverage for default-off and explicitly enabled prototype gates before runtime hover behavior. | no with hover source work | yes | `SYT-008B` | medium, fixture contracts |
 | `SYT-008D` | Senior Runner | Proposed only after fixture gate | Branch-only off-by-default prototype; no release/version/store assets. | no | yes | `SYT-008C` | high, live YouTube preview lifecycle |
 
 ## Human Acceptance Checklist
@@ -149,8 +165,8 @@ Live/manual gate:
 
 ## Next Handoff
 
-- Next role: Reviewer for docs/research review, then controller/product direction.
-- Next action: Review this handoff, then ask the user whether #8 should stay deferred, move to an off-by-default prototype, or be narrowed to non-transform polish.
+- Next role: Controller/User product direction.
+- Next action: Ask the user whether #8 should stay deferred, move to an off-by-default prototype, or be narrowed to non-transform polish.
 - Branch/worktree cleanup needed after merge: yes.
 - PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/20
 - Copy-ready prompt:

--- a/docs/swarm/handoffs/SYT-008A.md
+++ b/docs/swarm/handoffs/SYT-008A.md
@@ -6,7 +6,7 @@
 - Role: Planner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-008a-hover-research`
-- Owner: Pending Planner launch
+- Owner: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`)
 - Created: 2026-04-29
 - Updated: 2026-04-29
 

--- a/docs/swarm/handoffs/SYT-008A.md
+++ b/docs/swarm/handoffs/SYT-008A.md
@@ -2,13 +2,13 @@
 
 ## State
 
-- Status: In Progress - pending Planner launch
+- Status: Needs Review - research decision drafted; product direction required before prototype
 - Role: Planner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-008a-hover-research`
 - Owner: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`)
 - Created: 2026-04-29
-- Updated: 2026-04-29
+- Updated: 2026-04-30
 
 ## Goal
 
@@ -44,9 +44,98 @@ Research whether #8 can be safely revived in a future release without breaking n
 
 | Check | Result | Notes |
 | --- | --- | --- |
-| `npm run test:e2e` | Not run for this lane yet | Required for any prototype. |
+| `git diff --check` | Passed | Docs-only whitespace check. |
+| `npm run test:e2e` | Not run for this docs-only lane | Required for any fixture/prototype lane. |
 | `npm run test:e2e:live` | Not run for this lane yet | Optional research smoke, not stable gate. |
 | Human QA | Not run for this lane yet | Required before merging any visual behavior change. |
+
+## Files Touched
+
+- `docs/swarm/handoffs/SYT-008A.md`
+
+## Commands Run
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `gh api repos/cryptoteatime/simple-yt-tweaks/issues/8 --jq '{title, state, body, created_at, updated_at, html_url}'` | Passed | Read issue #8 after `gh issue view` hit GitHub's deprecated Projects classic GraphQL field. |
+| `gh api repos/cryptoteatime/simple-yt-tweaks/issues/8/comments --jq '.[] | {user:.user.login, created_at, body}'` | Passed | Read issue comments. |
+| `rg -n "hover|preview|autoplay|flicker|edge|clip|#8|SYT-008|grid-hover|home/search|home search" . -g '!node_modules/**' -g '!dist/**' -g '!release/**'` | Passed | Found current guardrails and prior notes; output included generated asset noise, so source/docs were read directly afterward. |
+| `git diff --check` | Passed | Required docs-only verification. |
+
+## Blockers / Risks
+
+- Future implementation is blocked on human/product direction: keep deferred, approve an off-by-default prototype, or narrow the idea to non-transform polish.
+- Fixtures can prove selector/class guardrails and setting behavior, but cannot prove live YouTube preview startup timing, renderer experiments, consent/ad surfaces, or all edge-card clipping cases.
+- Any runtime prototype remains high conflict risk in `src/content/grid-hover.ts` and should be serial-only.
+
+## Research Sources
+
+- GitHub issue #8: `Revisit enhanced home/search grid hover preview`.
+- `src/content/grid-hover.ts`: current hover growth is intentionally scoped to watch-page sidebar recommendations; `syncGridHoverState` notes that home/search feed previews stay native to avoid YouTube preview startup bookkeeping.
+- `tests/e2e/extension.fixture.spec.ts`: home/search fixtures assert injected CSS does not include `ytd-video-preview` or old home/search hover-ready selectors; the home fixture hovers a native-preview-like card and asserts the extension does not add `simple-yt-tweaks-grid-hover-ready`.
+- `tests/e2e/youtube-fixtures.ts`: includes a native-preview-like home card with `is-mouse-over-for-preview` and `ytd-video-preview`.
+- `docs/swarm/handoffs/SYT-010A.md`: coverage audit says fixtures can guard against reintroducing old selectors, but cannot prove live YouTube preview startup timing, renderer experiments, or edge-card behavior.
+- `CHANGELOG.md`: v0.3.0 explicitly kept home/search hover playback native because enhanced grid hover proved too fragile.
+
+## Research Decision
+
+Decision: require human/product direction before any prototype.
+
+Rationale:
+
+- The issue is an enhancement, not a correctness blocker.
+- The known failures are visual and lifecycle-sensitive: native hover autoplay startup, flicker when entering through thumbnail/title/card edges, first-row/first-column clipping, and top-level `ytd-video-preview` overlays.
+- The current repo already has a stable guardrail that prevents accidental home/search hover enhancement from returning. That guardrail should stay in place until a human confirms the desired product tradeoff.
+- A prototype without product direction risks spending implementation time on a visual treatment the owner may not want once the tradeoffs are explicit.
+
+Prototype is not ready to dispatch from this lane. The next safe action is a product-direction review that chooses one of these paths:
+
+1. Keep #8 deferred indefinitely and preserve native home/search hover only.
+2. Approve a branch-only prototype with an independent off-by-default setting.
+3. Narrow the idea to non-transform visual polish that never touches YouTube preview/card hover state.
+
+## Future Prototype Constraints
+
+If product direction approves a prototype, the implementation lane should be branch-only and off by default.
+
+- Add an independent setting such as `generalEnhancedFeedHoverPreview`, default `false`; do not couple it to feed columns or sidebar `Recommended Hover Grow`.
+- Do not change YouTube-owned preview state attributes such as `is-mouse-over-for-preview`, player/preview elements, inline player surfaces, or card bookkeeping.
+- Do not apply transforms to `ytd-video-preview`, `yt-inline-player-view-model`, `video`, or `.html5-video-player`.
+- Prefer a wrapper/outline/shadow treatment that leaves the thumbnail/preview element geometry and hit testing stable.
+- Keep the existing native-home/search guardrails enabled when the setting is off.
+- Keep watch sidebar hover behavior separate from home/search behavior.
+- Avoid shipping until fixture, optional live smoke, and manual visual gates all pass.
+
+## Validation Plan
+
+Stable fixture gate:
+
+- Keep existing negative assertions that home/search CSS does not include `ytd-video-preview` or old home/search hover-ready selectors when the new setting is off.
+- Add a future fixture-only lane before runtime implementation if product direction approves a prototype:
+  - Home cards with native preview markup in first column, middle column, and last column.
+  - Search video cards with thumbnail, title, and card-edge pointer entry paths.
+  - Disabled setting assertion proving no runtime class, CSS selector, or layout effect is added.
+  - Enabled setting assertion limited to the proposed wrapper/outline class, with no mutation of `is-mouse-over-for-preview` and no selector targeting preview player surfaces.
+- Prototype lane focused checks should run `npm run test:e2e`, `npm run lint`, `npm run typecheck`, and `git diff --check`.
+
+Live/manual gate:
+
+- Do not use live YouTube as the stable gate.
+- Use `npm run test:e2e:live` only as supplemental evidence after fixture tests pass and only if the prototype is ready for visual inspection.
+- Required human QA before merging any implementation:
+  - Home and search, at least 3-column layout.
+  - First column, middle column, last column, and first row.
+  - Pointer entry from thumbnail, title, card edge, and quick card-to-card movement.
+  - Confirm native hover autoplay still starts and stops normally.
+  - Confirm no flicker, no edge clipping, no swallowed clicks, and setting can disable the behavior independently.
+
+## Proposed Next Lanes
+
+| Task ID | Role | Status | Scope | Parallel-safe | Serial-required | Depends-on | Conflict-risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `SYT-008B` | Product/Planner | Blocked pending human direction | Decide whether #8 remains deferred, gets an off-by-default prototype, or narrows to non-transform polish. | yes, docs only | no | `SYT-008A` review | low |
+| `SYT-008C` | Runner | Proposed only if `SYT-008B` approves prototype | Add fixture coverage for off/default-on prototype gates before runtime hover behavior. | no with hover source work | yes | `SYT-008B` | medium, fixture contracts |
+| `SYT-008D` | Senior Runner | Proposed only after fixture gate | Branch-only off-by-default prototype; no release/version/store assets. | no | yes | `SYT-008C` | high, live YouTube preview lifecycle |
 
 ## Human Acceptance Checklist
 
@@ -59,16 +148,17 @@ Research whether #8 can be safely revived in a future release without breaking n
 
 ## Next Handoff
 
-- Next role: Planner now that fixture/helper hardening is in place.
-- Next action: Research only; do not implement until controller explicitly unpauses #8.
+- Next role: Reviewer for docs/research review, then controller/product direction.
+- Next action: Review this handoff, then ask the user whether #8 should stay deferred, move to an off-by-default prototype, or be narrowed to non-transform polish.
 - Branch/worktree cleanup needed after merge: yes.
+- PR: TBD.
 - Copy-ready prompt:
 
 ```text
-Plan Simple YT Tweaks SYT-008A after SYT-010D is integrated.
+Review Simple YT Tweaks SYT-008A research output.
 
 Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
 Branch: swarm/syt-008a-hover-research
 
-Read GitHub #8, the swarm docs, and docs/swarm/handoffs/SYT-008A.md. Produce a research plan for enhanced home/search hover that preserves native YouTube autoplay and defines fixture/live/manual gates. Do not implement runtime hover behavior unless the controller explicitly unpauses implementation.
+Read GitHub #8, the swarm docs, and docs/swarm/handoffs/SYT-008A.md. Review the research decision, validation plan, and proposed next lanes. Confirm whether the lane is ready for controller/product direction. Do not implement runtime hover behavior.
 ```

--- a/docs/swarm/handoffs/SYT-008A.md
+++ b/docs/swarm/handoffs/SYT-008A.md
@@ -2,11 +2,11 @@
 
 ## State
 
-- Status: Paused
+- Status: In Progress - pending Planner launch
 - Role: Planner
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-008a-hover-research`
-- Owner: Unassigned
+- Owner: Pending Planner launch
 - Created: 2026-04-29
 - Updated: 2026-04-29
 
@@ -29,6 +29,7 @@ Research whether #8 can be safely revived in a future release without breaking n
 ## Dependencies
 
 - `SYT-010A` coverage audit complete.
+- `SYT-010D` helper tests integrated.
 - User/product-direction gate before implementation.
 
 ## Lane Metadata
@@ -58,13 +59,13 @@ Research whether #8 can be safely revived in a future release without breaking n
 
 ## Next Handoff
 
-- Next role: Planner after #10 test hardening.
+- Next role: Planner now that fixture/helper hardening is in place.
 - Next action: Research only; do not implement until controller explicitly unpauses #8.
 - Branch/worktree cleanup needed after merge: yes.
 - Copy-ready prompt:
 
 ```text
-Plan Simple YT Tweaks SYT-008A only after SYT-010A is integrated.
+Plan Simple YT Tweaks SYT-008A after SYT-010D is integrated.
 
 Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
 Branch: swarm/syt-008a-hover-research

--- a/docs/swarm/project-brief.md
+++ b/docs/swarm/project-brief.md
@@ -111,4 +111,4 @@ No blocking material questions for the current setup. Defaults are safe:
 
 ## Next Controller Decision
 
-`SYT-010C` is integrated. The next safe controller action is to route or defer `SYT-010D` pure helper tests when capacity is available.
+`SYT-010D` is integrated. The next safe controller action is to route `SYT-008A` as a research-only gate for #8, with no runtime hover implementation until the plan and human/product gate are explicit.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: Active; `SYT-008A` research gate is being launched.
+- Implementation dispatch: Active; `SYT-008A` research gate is ready for review.
 
 ## Active Tasks
 
@@ -21,7 +21,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
 | `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
 | `SYT-010D` | Pure helper tests | Integrator | Integrated | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 merged |
-| `SYT-008A` | Enhanced home/search hover research gate | Planner | In Progress | `swarm/syt-008a-hover-research` | #8 research and validation plan only; no runtime implementation | serial-required | `SYT-010A`, `SYT-010D`; user/product gate before implementation | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
+| `SYT-008A` | Enhanced home/search hover research gate | Reviewer | Needs Review | `swarm/syt-008a-hover-research` | #8 research and validation plan only; no runtime implementation | serial-required | `SYT-010A`, `SYT-010D`; user/product gate before implementation | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | #20 |
 
 ## Backlog
 
@@ -40,7 +40,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-008A` | `swarm/syt-008a-hover-research` | Research decision, validation gates, proposed next lanes, PR body/handoff accuracy; confirm no runtime implementation | targeted docs/research review plus `git diff --check origin/main...HEAD` | `docs/swarm/handoffs/SYT-008A.md` |
 
 ## Ready To Integrate
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) researching `SYT-008A`.
+- Active controller-spawned subagents: none; `SYT-008A` Reviewer pending launch.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none yet; `SYT-008A` Planner pending launch.
+- Active controller-spawned subagents: Lovelace (`019ddc7d-3114-7603-9c3e-a3daaf9f055a`) researching `SYT-008A`.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: Active; `SYT-008A` research gate is ready for review.
+- Implementation dispatch: Stopped at `SYT-008A` product-direction gate.
 
 ## Active Tasks
 
@@ -21,7 +21,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
 | `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
 | `SYT-010D` | Pure helper tests | Integrator | Integrated | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 merged |
-| `SYT-008A` | Enhanced home/search hover research gate | Reviewer | Needs Review | `swarm/syt-008a-hover-research` | #8 research and validation plan only; no runtime implementation | serial-required | `SYT-010A`, `SYT-010D`; user/product gate before implementation | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | #20 |
+| `SYT-008A` | Enhanced home/search hover research gate | Controller/User | Ready for Human QA | `swarm/syt-008a-hover-research` | #8 research and validation plan only; no runtime implementation | serial-required | `SYT-010A`, `SYT-010D`; user/product gate before implementation | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | #20 |
 
 ## Backlog
 
@@ -40,7 +40,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| `SYT-008A` | `swarm/syt-008a-hover-research` | Research decision, validation gates, proposed next lanes, PR body/handoff accuracy; confirm no runtime implementation | targeted docs/research review plus `git diff --check origin/main...HEAD` | `docs/swarm/handoffs/SYT-008A.md` |
+| none | none | none | none | none |
 
 ## Ready To Integrate
 
@@ -52,12 +52,12 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | PR / URL | Status | Required Before Merge | Exact Pass/Fail Message |
 | --- | --- | --- | --- | --- |
-| `SYT-008A` | none | Not started | Yes before implementing visual hover behavior | `Human QA passed/failed for SYT-008A: <notes>` |
+| `SYT-008A` | #20 | Waiting for product direction | Yes before prototype or implementation | `Product direction for SYT-008A: <defer #8 | prototype off-by-default | narrow to non-transform polish: notes>` |
 | `SYT-RC-001` | none | Not started | Yes before release | `Human QA passed/failed for SYT-RC-001: <notes>` |
 
 ## Controller Notes
 
-- Active controller-spawned subagents: Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) reviewing `SYT-008A`.
+- Active controller-spawned subagents: none; `SYT-008A` is waiting on user product direction.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; `SYT-008A` research gate is active.
+- Current controller phase: Phase 4 paused at `SYT-008A` product-direction gate.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: Idle after `SYT-010D` integration; no new lane started by the Integrator.
+- Implementation dispatch: Active; `SYT-008A` research gate is being launched.
 
 ## Active Tasks
 
@@ -21,7 +21,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
 | `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
 | `SYT-010D` | Pure helper tests | Integrator | Integrated | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 merged |
-| `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
+| `SYT-008A` | Enhanced home/search hover research gate | Planner | In Progress | `swarm/syt-008a-hover-research` | #8 research and validation plan only; no runtime implementation | serial-required | `SYT-010A`, `SYT-010D`; user/product gate before implementation | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Backlog
 
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none; Planck integrated `SYT-010D`.
+- Active controller-spawned subagents: none yet; `SYT-008A` Planner pending launch.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -66,4 +66,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; `SYT-010D` integrated and no new lane started by the Integrator.
+- Current controller phase: Phase 4 active; `SYT-008A` research gate is active.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -57,7 +57,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none; `SYT-008A` Reviewer pending launch.
+- Active controller-spawned subagents: Arendt (`019ddcd6-f8f8-7bc1-ac2d-dc83b953b2dd`) reviewing `SYT-008A`.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.


### PR DESCRIPTION
## Summary
- documents the research decision for GitHub #8
- keeps enhanced home/search hover blocked on product direction before any prototype
- defines fixture, optional live, and human/manual gates for any future implementation

## How to test / what to tell the controller

Human review requested: yes, for product direction before any prototype.

Commands:
- `git diff --check`

Expected result:
- whitespace check passes
- review confirms the research output is docs-only and does not implement runtime hover behavior
- product direction chooses one of: keep #8 deferred, approve an off-by-default prototype, or narrow the idea to non-transform polish

Feedback format:
- `Product direction for SYT-008A: defer #8`
- `Product direction for SYT-008A: prototype off-by-default`
- `Product direction for SYT-008A: narrow to non-transform polish: <notes>`

Refs #8