### PR TITLE
Codex: Fix native hover SPA regression

### DIFF
--- a/SWARM.md
+++ b/SWARM.md
@@ -17,16 +17,17 @@ Before acting, read:
 1. `../AGENTS.md` if available
 2. `SWARM.md`
 3. `docs/swarm/controller-directives.md`
-4. `docs/swarm/project-brief.md`
+4. `docs/swarm/context-map.md`
 5. `docs/swarm/current-state.md`
-6. `docs/swarm/bootstrap-log.md`
-7. `docs/swarm/agent-registry.md`
-8. `docs/swarm/github.md`
-9. `docs/swarm/task-board.md`
-10. `docs/swarm/user-feedback.md`
-11. Relevant files in `docs/swarm/handoffs/`
-12. `docs/swarm/integration-log.md`
-13. Existing repo docs such as `README.md`, `DEVELOPMENT.md`, `CHANGELOG.md`, and `KNOWN_ISSUES.md`
+6. `docs/swarm/agent-registry.md`
+7. `docs/swarm/github.md`
+8. `docs/swarm/task-board.md`
+9. `docs/swarm/user-feedback.md`
+10. Relevant current handoff files in `docs/swarm/handoffs/`
+11. `docs/swarm/project-brief.md`, `docs/swarm/bootstrap-log.md`, and `docs/swarm/integration-log.md` only when planning, bootstrapping, or integrating
+12. Existing repo docs such as `README.md`, `DEVELOPMENT.md`, `CHANGELOG.md`, and `KNOWN_ISSUES.md`
+
+Do not load archived completed-lane history unless the current task specifically needs it. Use `docs/swarm/archive/README.md` as the reference map.
 
 ## Repo Goal
 
@@ -57,6 +58,7 @@ The current goal is post-v0.3.0 hardening: make automated verification strong en
 ## Repo Swarm Files
 
 - `docs/swarm/controller-directives.md`: dynamic controller mode, pacing, next actions, spawn strategy, and stop conditions
+- `docs/swarm/context-map.md`: compact hot context, current lane, and archive references
 - `docs/swarm/current-state.md`: current mission, constraints, priorities, risks, and verification status
 - `docs/swarm/project-brief.md`: durable discovery brief and milestone lane map
 - `docs/swarm/task-board.md`: active queue and task state
@@ -73,5 +75,5 @@ This repo should use a paced controller-led model:
 
 - The main repo chat acts as controller.
 - Controller passes should do only a few safe orchestration actions, then leave a clean recovery point.
-- A 90-minute active-pulse heartbeat is proposed after the swarm packet branch is merged and the worktree is clean.
+- A 30-minute active-pulse heartbeat is active while `SYT-021` is in review/fix/integration.
 - The heartbeat prompt should stay generic and read `SWARM.md` plus `docs/swarm/controller-directives.md`; do not encode current PR lists or one-off task state in the automation prompt.

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019eb0bd-d604-78a3-a94f-949659401efb` / Godel | `SYT-021` | Reviewer | In Progress | `swarm/syt-008b-native-hover-spa-regression` | main worktree | #22 | 2026-06-10 04:47 EDT | 2026-06-10 04:47 EDT | Review PR #22 and report `Ready to Integrate`, `Needs Fixes`, or `Blocked`. | none |
 
 ## Paused / Stale Agents
 
@@ -58,7 +58,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-021` | Reviewer | `swarm/syt-008b-native-hover-spa-regression` / PR #22 | Branch is clean and pushed; launch one reviewer for source/test/docs/PR audit | `docs/swarm/handoffs/SYT-021.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019eb0c7-e8dc-7352-9531-8f7be5692bdb` / Gibbs | `SYT-021` | Reviewer | In Progress | `swarm/syt-008b-native-hover-spa-regression` | main worktree | #22 | 2026-06-10 04:56 EDT | 2026-06-10 04:56 EDT | Re-review PR #22 after whitespace fix and report `Ready to Integrate`, `Needs Fixes`, or `Blocked`. | none |
 
 ## Paused / Stale Agents
 
@@ -59,7 +59,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-021` | Reviewer | `swarm/syt-008b-native-hover-spa-regression` / PR #22 | Whitespace fix pushed; launch one reviewer for source/test/docs/PR audit | `docs/swarm/handoffs/SYT-021.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -58,7 +58,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-021` | Reviewer | `swarm/syt-008b-native-hover-spa-regression` / PR #22 | Branch is clean and pushed; launch one reviewer for source/test/docs/PR audit | `docs/swarm/handoffs/SYT-021.md` |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019eb0bd-d604-78a3-a94f-949659401efb` / Godel | `SYT-021` | Reviewer | In Progress | `swarm/syt-008b-native-hover-spa-regression` | main worktree | #22 | 2026-06-10 04:47 EDT | 2026-06-10 04:47 EDT | Review PR #22 and report `Ready to Integrate`, `Needs Fixes`, or `Blocked`. | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -53,12 +53,13 @@ Use this file to track who is working, where they are working, and whether the c
 | `019ddb72-af51-7372-8146-43d5ead7148a` / Dirac | `SYT-010D` | Planner/Runner | Opened draft PR #18 | 2026-04-29 20:28 EDT | Added Playwright unit project and helper tests; `npm run test:unit`, `typecheck`, `lint`, and `validate:all` passed. |
 | `019ddbcb-2d65-76c1-982c-54abedb730cc` / Ptolemy | `SYT-010D` | Reviewer | Ready to Integrate, no findings | 2026-04-29 22:03 EDT | PR #18 review passed; `npm run test:unit`, `git diff --check origin/main...HEAD`, `npm run validate:all`, and `git diff --check` passed. |
 | `019ddc21-c7bb-75a2-94f6-e8d84b8f4489` / Planck | `SYT-010D` | Integrator | Merged PR #18 | 2026-04-29 22:07 EDT | PR #18 squash-merged into `main` at `88f0a91`; local branch cleanup completed and stale remote-tracking ref pruned. |
+| `019eb0bd-d604-78a3-a94f-949659401efb` / Godel | `SYT-021` | Reviewer | Needs Fixes | 2026-06-10 04:52 EDT | Review found `git diff --check origin/main...HEAD` failed on EOF blank lines in compact docs; `npm run test:e2e` passed. Controller fixed whitespace on the PR branch; re-review next. |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-021` | Reviewer | `swarm/syt-008b-native-hover-spa-regression` / PR #22 | Whitespace fix pushed; launch one reviewer for source/test/docs/PR audit | `docs/swarm/handoffs/SYT-021.md` |
 
 ## Side Chats
 

--- a/docs/swarm/archive/README.md
+++ b/docs/swarm/archive/README.md
@@ -1,0 +1,34 @@
+# Swarm Archive Reference Map
+
+This archive keeps completed-lane history out of hot controller context while preserving recovery paths.
+
+## How To Recover Full History
+
+Use Git history for the file before the 2026-06-10 compaction commit:
+
+```bash
+git log -- docs/swarm/handoffs/<TASK-ID>.md
+git show <commit-before-compaction>:docs/swarm/handoffs/<TASK-ID>.md
+```
+
+GitHub PR bodies and reviews remain the preferred public history for completed work.
+
+## Completed Lane Map
+
+| Task | Public Reference | Merge / Result | Hot Stub |
+| --- | --- | --- | --- |
+| `SYT-CTL-001` | PR #11 | `676efc8`, repo-local swarm packet integrated | `docs/swarm/handoffs/SYT-CTL-001.md` |
+| `SYT-010A` | PR #12 | `59ec975`, fixture coverage hardening integrated | `docs/swarm/handoffs/SYT-010A.md` |
+| `SYT-010B` | PR #14 | `5675059`, settings parity validation hardening integrated | `docs/swarm/handoffs/SYT-010B.md` |
+| `SYT-010C` | PR #16 | `0fca6c3`, release-candidate process docs integrated | `docs/swarm/handoffs/SYT-010C.md` |
+| `SYT-010D` | PR #18 | `88f0a91`, helper unit tests integrated | `docs/swarm/handoffs/SYT-010D.md` |
+
+## Active / Deferred Work
+
+| Task | Status | Reference |
+| --- | --- | --- |
+| `SYT-021` | Active, PR #22 Needs Review | `docs/swarm/handoffs/SYT-021.md` |
+| `SYT-008A` | Paused future research | `docs/swarm/handoffs/SYT-008A.md` |
+| `SYT-010E` | Backlog code hardening | `docs/swarm/task-board.md` |
+| `SYT-RC-001` | Backlog release candidate checklist | `docs/swarm/task-board.md` |
+

--- a/docs/swarm/archive/README.md
+++ b/docs/swarm/archive/README.md
@@ -31,4 +31,3 @@ GitHub PR bodies and reviews remain the preferred public history for completed w
 | `SYT-008A` | Paused future research | `docs/swarm/handoffs/SYT-008A.md` |
 | `SYT-010E` | Backlog code hardening | `docs/swarm/task-board.md` |
 | `SYT-RC-001` | Backlog release candidate checklist | `docs/swarm/task-board.md` |
-

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -1,0 +1,47 @@
+# Context Map
+
+Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller-directives.md`.
+
+## Current Hot State
+
+- Active implementation lane: `SYT-021`
+- GitHub issue: #21
+- Draft PR: #22
+- Branch: `swarm/syt-008b-native-hover-spa-regression`
+- Current status: Needs Review
+- Required gate before merge: reviewer result plus any human QA gate the reviewer/controller keeps
+- Do not do during this lane: version bump, tag, release, Web Store asset changes, or #8 enhanced Home/Search hover grow revival
+
+## Hot Files
+
+- Controller routing: `docs/swarm/controller-directives.md`
+- Current state: `docs/swarm/current-state.md`
+- Task queue: `docs/swarm/task-board.md`
+- Agent capacity: `docs/swarm/agent-registry.md`
+- GitHub policy/state: `docs/swarm/github.md`
+- Active handoff: `docs/swarm/handoffs/SYT-021.md`
+- User steering: `docs/swarm/user-feedback.md`
+
+## Cold / Archived History
+
+Completed lanes are intentionally compacted to stubs:
+
+- `SYT-CTL-001` -> PR #11, merge `676efc8`
+- `SYT-010A` -> PR #12, merge `59ec975`
+- `SYT-010B` -> PR #14, merge `5675059`
+- `SYT-010C` -> PR #16, merge `0fca6c3`
+- `SYT-010D` -> PR #18, merge `88f0a91`
+
+Full prior handoff text is recoverable through Git history before the 2026-06-10 compaction commit. Use `docs/swarm/archive/README.md` for the reference map.
+
+## Next Safe Controller Action
+
+Route a reviewer for PR #22. The reviewer should focus on:
+
+- Home/Search native hover behavior stays native, with no extension grow/highlight revival.
+- SPA cleanup deferral does not leave sponsored/Shorts holes permanently.
+- Native preview fallback only plays an already-mounted preview under the pointer.
+- Watch helpers prefer `#movie_player video.html5-main-video`.
+- Player click fallback timing does not double-toggle normal native clicks.
+- Modern `#secondary yt-lockup-view-model` recommendations are covered.
+

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -31,6 +31,7 @@ Completed lanes are intentionally compacted to stubs:
 - `SYT-010B` -> PR #14, merge `5675059`
 - `SYT-010C` -> PR #16, merge `0fca6c3`
 - `SYT-010D` -> PR #18, merge `88f0a91`
+- `SYT-010E` -> next #10 hardening lane, `docs/swarm/handoffs/SYT-010E.md`
 
 Full prior handoff text is recoverable through Git history before the 2026-06-10 compaction commit. Use `docs/swarm/archive/README.md` for the reference map.
 
@@ -45,3 +46,4 @@ Route a reviewer for PR #22. The reviewer should focus on:
 - Player click fallback timing does not double-toggle normal native clicks.
 - Modern `#secondary yt-lockup-view-model` recommendations are covered.
 
+After PR #22 review/integration state is clear, route `SYT-010E` as the next #10 code-hardening lane.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -30,8 +30,15 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Controller pass budget: max 6 safe orchestration actions or 60 minutes, hard stop at 75 minutes while `SYT-021` is active
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
 - Active capacity: max 1 active subagent total
-- Heartbeat cadence target: 45 minutes while `SYT-021` is in review/fix/integration, then slow back toward 90 minutes
+- Heartbeat cadence target: 30 minutes while `SYT-021` is in review/fix/integration, then slow back toward 90 minutes
 - Next human QA gate: optional `SYT-021` live YouTube spot-check, release-candidate lane, or #8 visual/product-direction gate
+
+## Context Hygiene
+
+- Read `docs/swarm/context-map.md` before loading historical handoffs.
+- Keep completed-lane details out of hot docs. Stubs plus PR/merge references are enough for normal controller passes.
+- Do not load `docs/swarm/archive/**` unless a current task needs old implementation details.
+- When a lane completes, compact its handoff to status, scope, verification, PR, merge, and archive references.
 
 Heartbeat overlap rule:
 
@@ -97,7 +104,8 @@ Heartbeat overlap rule:
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
 | 1 | `SYT-021` | Route review for draft PR #22 native hover SPA regression and live recommendation drift | Reviewer | `swarm/syt-008b-native-hover-spa-regression` | Reviewer result recorded |
-| 2 | `SYT-008A` | Keep research gate paused until #21 is resolved and user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+| 2 | `SYT-010E` | Plan next #10 code-hardening lane after PR #22 review/integration state is clear | Planner / Senior Runner | TBD | Scoped hardening lane created with verification |
+| 3 | `SYT-008A` | Keep research gate paused until #21 is resolved and user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
 
@@ -111,3 +119,4 @@ Heartbeat overlap rule:
 - PR #16 squash-merged into `main` at `0fca6c3`; remote and local task branch cleanup completed.
 - PR #18 squash-merged into `main` at `88f0a91`; local branch cleanup completed and stale remote-tracking ref pruned.
 - 2026-06-10: User reported live watch-to-Home native hover autoplay regression and requested overnight automation. Controller opened #21 and draft PR #22, implemented `SYT-021`, ran `npm run validate:all`, and performed signed-in Chrome live smoke. Review is next.
+- 2026-06-10: User requested compact docs/context and faster automation. Heartbeat cadence updated to 30 minutes; completed handoffs compacted with archive references.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,14 +8,14 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-04-29 22:07 EDT
+- Last reviewed by controller: 2026-06-10 04:05 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `main`
-- Expected Git state: clean `main...origin/main` after `SYT-010D` integration record lands
-- Open PR expectation: none
+- Current branch: `swarm/syt-008b-native-hover-spa-regression`
+- Expected Git state: `SYT-021` branch dirty until docs/source/test changes are committed and pushed
+- Open PR expectation: draft PR for `SYT-021` after branch push
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: none started by the Integrator; controller may choose the next lane in a later pass
@@ -27,11 +27,11 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Lease expected action: none
 - Lease stop condition: none
 - Lease stale after: 90 minutes
-- Controller pass budget: max 3 safe orchestration actions or 35 minutes, hard stop at 45 minutes
+- Controller pass budget: max 6 safe orchestration actions or 60 minutes, hard stop at 75 minutes while `SYT-021` is active
 - Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
 - Active capacity: max 1 active subagent total
-- Heartbeat cadence target: 90 minutes while active
-- Next human QA gate: release-candidate lane or #8 visual/product-direction gate
+- Heartbeat cadence target: 45 minutes while `SYT-021` is in review/fix/integration, then slow back toward 90 minutes
+- Next human QA gate: optional `SYT-021` live YouTube spot-check, release-candidate lane, or #8 visual/product-direction gate
 
 Heartbeat overlap rule:
 
@@ -96,8 +96,8 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010D` | Integrated PR #18 helper unit tests | Integrator complete | `main` | Integration record landed |
-| 2 | `SYT-008A` | Research gate for future enhanced home/search hover | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+| 1 | `SYT-021` | Push branch, open draft PR, route review for native hover SPA regression and live recommendation drift | Controller / Reviewer | `swarm/syt-008b-native-hover-spa-regression` | Draft PR opened and reviewer result recorded |
+| 2 | `SYT-008A` | Keep research gate paused until #21 is resolved and user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
 
@@ -110,3 +110,4 @@ Heartbeat overlap rule:
 - PR #14 squash-merged into `main` at `5675059`; remote and local task branch cleanup completed.
 - PR #16 squash-merged into `main` at `0fca6c3`; remote and local task branch cleanup completed.
 - PR #18 squash-merged into `main` at `88f0a91`; local branch cleanup completed and stale remote-tracking ref pruned.
+- 2026-06-10: User reported live watch-to-Home native hover autoplay regression and requested overnight automation. Controller opened #21, implemented `SYT-021`, ran `npm run validate:all`, and performed signed-in Chrome live smoke. Branch needs commit/push/draft PR/review next.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -14,8 +14,8 @@ This file is the repo-local dynamic control plane for the controller chat and an
 
 - Default branch: `main`
 - Current branch: `swarm/syt-008b-native-hover-spa-regression`
-- Expected Git state: `SYT-021` branch dirty until docs/source/test changes are committed and pushed
-- Open PR expectation: draft PR for `SYT-021` after branch push
+- Expected Git state: clean `swarm/syt-008b-native-hover-spa-regression...origin/swarm/syt-008b-native-hover-spa-regression` after PR-state docs follow-up is pushed
+- Open PR expectation: draft PR #22 for `SYT-021`
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: none started by the Integrator; controller may choose the next lane in a later pass
@@ -96,7 +96,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-021` | Push branch, open draft PR, route review for native hover SPA regression and live recommendation drift | Controller / Reviewer | `swarm/syt-008b-native-hover-spa-regression` | Draft PR opened and reviewer result recorded |
+| 1 | `SYT-021` | Route review for draft PR #22 native hover SPA regression and live recommendation drift | Reviewer | `swarm/syt-008b-native-hover-spa-regression` | Reviewer result recorded |
 | 2 | `SYT-008A` | Keep research gate paused until #21 is resolved and user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
@@ -110,4 +110,4 @@ Heartbeat overlap rule:
 - PR #14 squash-merged into `main` at `5675059`; remote and local task branch cleanup completed.
 - PR #16 squash-merged into `main` at `0fca6c3`; remote and local task branch cleanup completed.
 - PR #18 squash-merged into `main` at `88f0a91`; local branch cleanup completed and stale remote-tracking ref pruned.
-- 2026-06-10: User reported live watch-to-Home native hover autoplay regression and requested overnight automation. Controller opened #21, implemented `SYT-021`, ran `npm run validate:all`, and performed signed-in Chrome live smoke. Branch needs commit/push/draft PR/review next.
+- 2026-06-10: User reported live watch-to-Home native hover autoplay regression and requested overnight automation. Controller opened #21 and draft PR #22, implemented `SYT-021`, ran `npm run validate:all`, and performed signed-in Chrome live smoke. Review is next.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,7 +4,7 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening setup
+- Status: existing repo, post-v0.3.0 hardening with active live-regression fix lane
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
 
 ## Project Brief
@@ -19,9 +19,10 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Current Focus
 
-1. Route #10 hardening into small PRs with `validate:all` as the final gate.
-2. Keep #8 as a future high-risk research lane until tests and product direction justify it.
-3. Keep release-candidate work separate from routine fixture/source hardening.
+1. Review and integrate `SYT-021` / GitHub #21 after the native hover SPA regression branch is pushed.
+2. Keep #10 hardening in small PRs with `validate:all` as the final gate.
+3. Keep #8 as a future high-risk research lane until tests and product direction justify it.
+4. Keep release-candidate work separate from routine fixture/source hardening.
 
 ## Success Criteria
 
@@ -48,10 +49,11 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Settings are duplicated between `src/shared/settings.ts` and `src/content/settings.ts`; validation checks parity, but refactoring could affect bundling.
 - Fixture tests do not fully simulate live YouTube hover preview overlay behavior, so #8 needs a research gate and likely human/visual QA.
 - Live YouTube smoke can be flaky due to consent, experiments, bot checks, ads, or network issues.
+- Current live YouTube recommendations may render as modern `#secondary yt-lockup-view-model` cards instead of legacy compact renderers.
 
 ## Recommended First Milestone
 
-`SYT-010D` is integrated: pure helper tests and Playwright unit-project wiring were squash-merged through PR #18.
+`SYT-021` is ready for review on branch `swarm/syt-008b-native-hover-spa-regression`: it fixes GitHub #21, expands fixture coverage, and passed full validation plus signed-in Chrome live smoke.
 
 ## Verification Defaults
 
@@ -76,16 +78,16 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 - Controller heartbeat: active.
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`.
-- Heartbeat cadence: about 90 minutes while active.
+- Heartbeat cadence: about 45 minutes while this live-regression lane is active.
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none after `SYT-010D` integration.
+- Active subagents: none; `SYT-021` is controller-authored and ready for reviewer routing after PR creation.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
 
 ## Last Updated
 
-- Date: 2026-04-29
-- By: Planck, `SYT-010D` Integrator
+- Date: 2026-06-10
+- By: Codex controller, `SYT-021` Runner

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -53,7 +53,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-021` is ready for review on branch `swarm/syt-008b-native-hover-spa-regression`: it fixes GitHub #21, expands fixture coverage, and passed full validation plus signed-in Chrome live smoke.
+`SYT-021` is ready for review in draft PR #22 on branch `swarm/syt-008b-native-hover-spa-regression`: it fixes GitHub #21, expands fixture coverage, and passed full validation plus signed-in Chrome live smoke.
 
 ## Verification Defaults
 
@@ -82,7 +82,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none; `SYT-021` is controller-authored and ready for reviewer routing after PR creation.
+- Active subagents: none; `SYT-021` is controller-authored and ready for reviewer routing on draft PR #22.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -23,6 +23,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 2. Keep #10 hardening in small PRs with `validate:all` as the final gate.
 3. Keep #8 as a future high-risk research lane until tests and product direction justify it.
 4. Keep release-candidate work separate from routine fixture/source hardening.
+5. Keep hot swarm context compact; use `docs/swarm/context-map.md` and archive references instead of loading old completed handoffs.
 
 ## Success Criteria
 
@@ -78,7 +79,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 - Controller heartbeat: active.
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`.
-- Heartbeat cadence: about 45 minutes while this live-regression lane is active.
+- Heartbeat cadence: about 30 minutes while this live-regression lane is active.
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `SYT-021` | `swarm/syt-008b-native-hover-spa-regression` | TBD | Needs push / draft PR | Controller | Fixes #21; full validation and live Chrome smoke passed locally. |
 
 ## Setup Log
 
@@ -58,3 +58,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-04-29: Opened draft PR #16 for `SYT-010C`.
 - 2026-04-29: PR #16 squash-merged for `SYT-010C`; branch cleanup completed.
 - 2026-04-29: PR #18 squash-merged for `SYT-010D`; branch cleanup completed.
+- 2026-06-10: Opened issue #21 for native Home/Search hover preview stall after watch-to-Home SPA navigation and modern `#secondary yt-lockup-view-model` recommendation selector drift. Branch `swarm/syt-008b-native-hover-spa-regression` is expected to open a draft PR.

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `SYT-021` | `swarm/syt-008b-native-hover-spa-regression` | TBD | Needs push / draft PR | Controller | Fixes #21; full validation and live Chrome smoke passed locally. |
+| `SYT-021` | `swarm/syt-008b-native-hover-spa-regression` | #22 draft | Needs Review | Controller | Fixes #21; full validation and live Chrome smoke passed locally. |
 
 ## Setup Log
 
@@ -58,4 +58,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-04-29: Opened draft PR #16 for `SYT-010C`.
 - 2026-04-29: PR #16 squash-merged for `SYT-010C`; branch cleanup completed.
 - 2026-04-29: PR #18 squash-merged for `SYT-010D`; branch cleanup completed.
-- 2026-06-10: Opened issue #21 for native Home/Search hover preview stall after watch-to-Home SPA navigation and modern `#secondary yt-lockup-view-model` recommendation selector drift. Branch `swarm/syt-008b-native-hover-spa-regression` is expected to open a draft PR.
+- 2026-06-10: Opened issue #21 for native Home/Search hover preview stall after watch-to-Home SPA navigation and modern `#secondary yt-lockup-view-model` recommendation selector drift. Opened draft PR #22 from `swarm/syt-008b-native-hover-spa-regression`.

--- a/docs/swarm/handoffs/SYT-010A.md
+++ b/docs/swarm/handoffs/SYT-010A.md
@@ -1,162 +1,27 @@
-# SYT-010A: Audit And Harden Fixture Coverage
+# SYT-010A: Fixture Coverage Audit And Hardening
 
-## State
+## Status
 
-- Status: Integrated
-- Role: Complete
-- Repo: Simple YT Tweaks
+- State: Integrated
+- PR: #12
 - Branch: `swarm/syt-010a-test-harness-audit`
-- Owner: Codex Controller
-- Created: 2026-04-29
-- Updated: 2026-04-29
+- Merge commit: `59ec975`
+- Date: 2026-04-29
 
-## Goal
+## Summary
 
-Audit the existing Playwright extension harness and add missing deterministic fixture coverage needed before #10 hardening and any future #8 research.
-
-## Scope
-
-- Inspect `tests/e2e/extension.fixture.spec.ts`, `tests/e2e/youtube-fixtures.ts`, `tests/e2e/extension-fixture.ts`, and `playwright.config.ts`.
-- Map existing tests to the current GitHub #8/#10 risks.
-- Add fixture tests only where they catch likely regressions from hardening work.
-- Update `DEVELOPMENT.md` or swarm docs if commands/coverage expectations change.
-
-## Non-Scope
-
-- Do not implement enhanced home/search hover.
-- Do not change production behavior unless a fixture bug exposes an obvious test-only issue.
-- Do not rely on live YouTube tests as the primary gate.
-
-## Dependencies
-
-- `SYT-CTL-001` merged.
-
-## Lane Metadata
-
-- Parallel-safe: yes with docs-only lanes if capacity is raised; default capacity still keeps this single-owner.
-- Serial-required: no.
-- Depends-on: `SYT-CTL-001`.
-- Conflict-risk: medium; fixture contracts and test expectations.
-- Shared coordination docs allowed: only this handoff unless controller assigns more.
-
-## Plan
-
-1. Create a task branch from current `main`.
-2. Audit fixture coverage against #10 targets: settings parity, comments visibility, popup defaults, search cleanup, home sponsored gap cleanup, sidebar hover grow, sticky player/PiP click fallback.
-3. Audit #8 prerequisites: prove current home/search native hover code is not reintroduced and identify what fixtures cannot prove.
-4. Add focused fixture coverage for missing deterministic cases.
-5. Run focused tests, then full `npm run validate:all` before PR.
-
-## Files / Areas
-
-- `tests/e2e/**`
-- `playwright.config.ts`
-- `DEVELOPMENT.md`
-- `docs/swarm/handoffs/SYT-010A.md`
-
-## Decisions
-
-- Fixture tests are the gate; live smoke is optional and non-blocking.
-- Any #8 implementation remains paused until this lane identifies a safe proof strategy.
-
-## Work Log
-
-- 2026-04-29: Lane seeded during bootstrap.
-- 2026-04-29: Runner audited fixture harness, added deterministic hardening coverage, and opened draft PR #12 from `swarm/syt-010a-test-harness-audit`.
-- 2026-04-29: Controller heartbeat routed Reviewer Mendel (`019dd89b-89b0-79f3-bf62-b64b3cb0ae6f`) for PR #12.
-- 2026-04-29: Reviewer Mendel reported no findings and marked PR #12 Ready to Integrate.
-- 2026-04-29: Controller heartbeat routed Integrator McClintock (`019dd8f8-d696-7f82-a403-c1f7b70e2716`) for PR #12.
-- 2026-04-29: Integrator ran `npm run validate:all`, marked PR #12 ready for review, squash-merged it into `main` at `59ec975`, synced local `main`, and cleaned the task branch.
-
-## Coverage Matrix
-
-| Area / Risk | Current Coverage Before This Lane | Added / Confirmed In This Lane | Missing Deterministic Cases | Fixtures Cannot Prove | Live / Human Gate |
-| --- | --- | --- | --- | --- | --- |
-| Home feed cleanup and #8 guardrail | Home fixture verified 3-column layout, sponsored removal, Shorts hidden, and CSS did not include old home preview selectors. | Added a native preview-like home card and verifies hover does not add `simple-yt-tweaks-grid-hover-ready`; keeps CSS negative assertions for `ytd-video-preview` and old home hover class. | Does not assert every possible YouTube home renderer variant. | Whether live YouTube experiments change native preview markup or preview startup timing. | No gate for #10. Required before any #8 implementation decision. |
-| Search compact grid cleanup | Search fixture verified grid display, channel card centering, Shorts grid hidden, playlist hidden, badge movement, and continuation hiding. | Added deterministic exclusions for Shorts-like video results, radio/mix results, `ytd-radio-renderer`, generic shelves, and no old home/search hover CSS. | Additional renderer names may appear on live YouTube and should be added when observed. | Live search experiment renderer churn and ad/consent/bot surfaces. | No gate for #10; optional live smoke only if reviewer asks. |
-| Search setting gate | Popup default checked `generalApplyFeedColumnsToSearch`, but content behavior only covered enabled state. | Added storage-backed disabled-state fixture: no grid CSS behavior, playlist remains visible, badges are not moved. | Does not cover every feed-column count in search. | Live YouTube layout with disabled setting. | No human gate. |
-| Popup defaults, normalization, and storage | Popup test covered version, default tabs, two defaults, persistence for `pipButton`, and nested mode controls. | Added visible-pane reset for `pipButton`; added invalid stored values test for `generalFeedColumns`, boolean fallback, and `pipButton` retaining valid false. | Storage runtime error fallback remains source-level only; not simulated because Chrome extension APIs do not expose a stable way to force `runtime.lastError` in this harness. | Browser-specific sync storage quota/error behavior. | No human gate. |
-| Watch comments visibility | Default/theater comments were asserted visible under defaults. | Added storage-backed hidden comments coverage for default and theater modes. | Fullscreen comments/action overlays remain covered only by existing source behavior and optional manual checks. | YouTube live-chat/comment experiment variants. | No human gate for comments. |
-| Sidebar recommendation hover grow | Existing watch fixture covered hover-ready class after hover. | Added delay guard before ready class appears; added disabled default/theater hover-grow setting gate. | Does not test every recommendation renderer variant or edge positioning class. | Real hover preview lifecycle and renderer timing on live YouTube. | #8 future hover research needs human/visual gate. |
-| Player click fallback | Existing watch fixture proved video surface clicks toggle play/pause. | Extracted playback probe helper and added guardrails that player controls and modified video clicks do not trigger fallback. | Bottom-control-region coordinate test was avoided to keep fixture stable across overlay hit-testing. | Native YouTube player controls and browser media policy nuances. | No human gate unless reviewer flags live player behavior risk. |
-| Sticky player | Existing fixture indirectly keeps video pointer events `auto`; no sticky dock fixture. | No new deterministic sticky-player dock test added in this lane; audit documents gap. | Deterministic scroll/visibility dock/undock behavior for sticky player. | Real viewport, player sizing, PiP interactions, and YouTube layout shifts. | Candidate future fixture task before sticky-player refactors; live/manual for release candidates. |
-| Live YouTube smoke | Optional `test:e2e:live` exists and skips unless `SIMPLE_YT_TWEAKS_LIVE=1`. | Confirmed it remains optional and non-blocking. | None for this lane. | Consent screens, bot checks, ads, experiments, network failures. | Not requested for SYT-010A. |
-
-## Files Changed
-
-- `tests/e2e/extension.fixture.spec.ts`
-  - Added extension storage writer helper.
-  - Added reusable playback probe helper.
-  - Added search disabled-setting test, hover disabled/hidden comments test, player click fallback guardrail test, and invalid popup storage normalization test.
-  - Strengthened existing home, search, watch, and popup tests.
-- `tests/e2e/youtube-fixtures.ts`
-  - Added native preview-like home fixture card.
-  - Added search cleanup edge-case renderers.
-  - Added a player control button to the watch fixture.
-
-## Decisions
-
-- Kept live YouTube smoke optional and non-blocking.
-- Did not edit runtime/product behavior; fixture coverage did not expose a product bug requiring source changes.
-- Did not add sticky-player dock assertions in this pass because stable scroll/visibility docking deserves a separate focused fixture task instead of fragile incidental coverage.
-- Did not update shared controller-owned docs beyond this handoff.
+Audited and strengthened deterministic Playwright fixture coverage for the post-v0.3.0 hardening lanes. Confirmed fixture-first verification as the normal release gate and kept live YouTube checks supplemental.
 
 ## Verification
 
-- Verification tier: focused runner checks plus full gate before PR.
+- `npm run test:e2e`: passed
+- `npm run validate:all`: passed
+- `git diff --check`: passed
 
-| Check | Result | Notes |
-| --- | --- | --- |
-| `npm run test:e2e` | Passed | 8 fixture tests passed after adding coverage. |
-| `npm run validate:all` | Passed | Includes typecheck, lint, `git diff --check`, package validation, and fixture Playwright tests. |
-| `npm run validate:all` | Passed | Integrator full gate before merge; 8 fixture tests passed. |
-| `git diff --check origin/main...HEAD` | Passed | Reviewer targeted whitespace check. |
-| `npm run test:e2e:live` | Optional | Use only if the lane explicitly needs live smoke context. |
+## Archive Reference
 
-## Human Acceptance Checklist
+The detailed coverage matrix and work log were compacted on 2026-06-10.
 
-- Required before merge: No
-- URL(s): https://github.com/cryptoteatime/simple-yt-tweaks/pull/12
-- Who should test: Reviewer/Integrator
-- Steps:
-  1. Review coverage matrix.
-  2. Run `npm run validate:all`.
-  3. Confirm no human YouTube QA is requested for routine test-hardening changes.
-- Expected result: fixture suite covers the next safe #10 hardening slice and documents #8 limitations.
-- If it passes, tell the controller: `Review passed for SYT-010A: fixture coverage ready`
-- If it fails, tell the controller: `Review failed for SYT-010A: <issue>`
-
-## Blockers / Risks
-
-- Future #8 hover behavior may require live-site observation that fixtures cannot safely prove.
-- Sticky-player dock/undock behavior remains a documented deterministic coverage gap for a future focused test lane.
-
-## Review Result
-
-- Reviewer: Mendel (`019dd89b-89b0-79f3-bf62-b64b3cb0ae6f`)
-- Verdict: Ready to Integrate
-- Findings: none
-- Targeted checks:
-  - `git status --short --branch`: clean on `swarm/syt-010a-test-harness-audit...origin/swarm/syt-010a-test-harness-audit`
-  - `git diff --check origin/main...HEAD`: passed
-  - `npm run test:e2e`: passed, 8 fixture tests
-- Human QA requested: no
-
-## Next Handoff
-
-- Next role: Controller
-- Next action: Route `SYT-010B` only when ready; do not launch product/runtime work from this integration pass.
-- Branch/worktree cleanup needed after merge: complete.
-- Merge: https://github.com/cryptoteatime/simple-yt-tweaks/pull/12, squash merge commit `59ec975d5671efe425e39f317948a6c426714ccf`
-- Copy-ready prompt:
-
-```text
-Run Simple YT Tweaks SYT-010A.
-
-Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
-Create branch: swarm/syt-010a-test-harness-audit
-
-Read ../AGENTS.md, SWARM.md, docs/swarm/controller-directives.md, docs/swarm/project-brief.md, docs/swarm/current-state.md, docs/swarm/task-board.md, docs/swarm/github.md, and docs/swarm/handoffs/SYT-010A.md.
-
-Audit Playwright fixture coverage against #8 and #10. Add deterministic fixture tests only where they will catch likely hardening regressions. Keep live YouTube smoke optional and non-blocking. Run npm run test:e2e and npm run validate:all. Update this handoff and open a draft PR with a How to test / what to tell the controller section.
-```
+- Reference map: `docs/swarm/archive/README.md`
+- Full prior text: Git history before `SYT-021` docs compaction
+- PR body and review: GitHub PR #12

--- a/docs/swarm/handoffs/SYT-010B.md
+++ b/docs/swarm/handoffs/SYT-010B.md
@@ -1,129 +1,28 @@
 # SYT-010B: Settings Parity And Source-Of-Truth Hardening
 
-## State
+## Status
 
-- Status: Integrated
-- Role: Integrator
-- Repo: Simple YT Tweaks
+- State: Integrated
+- PR: #14
 - Branch: `swarm/syt-010b-settings-hardening`
-- Owner: Codex Controller
-- Created: 2026-04-29
-- Updated: 2026-04-29
+- Merge commit: `5675059`
+- Date: 2026-04-29
 
-## Goal
+## Summary
 
-Reduce settings-maintenance risk after fixture coverage is ready.
-
-## Scope
-
-- Review duplication between `src/shared/settings.ts` and `src/content/settings.ts`.
-- Either consolidate safely or keep duplication and strengthen parity validation/tests.
-- Preserve existing defaults and popup behavior.
-
-## Non-Scope
-
-- Do not change setting defaults.
-- Do not rename user-facing settings unless a separate product decision approves it.
-- Do not edit unrelated modules.
-
-## Dependencies
-
-- `SYT-010A` should complete first so behavior coverage is stronger.
-
-## Lane Metadata
-
-- Parallel-safe: no by default.
-- Serial-required: yes; settings contracts touch popup, content, validation, and storage.
-- Depends-on: `SYT-010A`.
-- Conflict-risk: high; `src/shared/settings.ts`, `src/content/settings.ts`, popup rendering, validation script.
-- Shared coordination docs allowed: only this handoff unless controller assigns more.
-
-## Plan
-
-1. Inspect bundling constraints around shared settings in popup and content script.
-2. Decide whether true consolidation is worth the risk.
-3. If consolidation is not clean, add stronger validation or tests for parity.
-4. Run focused checks and full `npm run validate:all`.
-
-## Files / Areas
-
-- `src/shared/settings.ts`
-- `src/content/settings.ts`
-- `src/popup/popup.ts`
-- `scripts/validate-extension.mjs`
-- `tests/e2e/**` if needed
-
-## Decisions
-
-- Chose conservative validation hardening with type-level consolidation only.
-- Tried full runtime consolidation of content settings onto `src/shared/settings.ts`; fixture E2E exposed the expected bundling risk because Vite emitted a shared `dist/assets/settings.js` chunk and the content script stopped behaving as a self-contained extension script. Reverted that approach before finalizing.
-- Kept content runtime defaults, `SETTING_KEYS`, `loadSettings`, and `normalizeSettings` local to preserve self-contained content-script output.
-- Removed duplicated content type unions by re-exporting/importing shared setting types only; TypeScript erases these imports from the content bundle.
-- Strengthened `scripts/validate-extension.mjs` so validation now checks shared setting definitions against defaults, verifies parent keys/options, enforces the `floatingMiniPlayer` alias behavior, requires content type re-exports from shared, and keeps content runtime defaults/keys in parity with shared settings.
-
-## Work Log
-
-- 2026-04-29: Lane seeded during bootstrap.
-- 2026-04-29: Controller opened task branch `swarm/syt-010b-settings-hardening` for runner launch after `SYT-010A` integration.
-- 2026-04-29: Controller routed Senior Runner Linnaeus (`019dd952-fc1f-7692-878b-cc0cbaa13d42`) for implementation.
-- 2026-04-29: Implemented type-level settings source-of-truth hardening and stronger validation checks; no settings defaults, storage keys, labels, or user-facing behavior changed.
-- 2026-04-29: Controller routed Reviewer Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`) for PR #14 review.
-- 2026-04-29: Reviewer Hypatia reported no findings and marked PR #14 Ready to Integrate.
-- 2026-04-29: Controller routed Integrator Helmholtz (`019dda09-c04a-7040-ab08-a641d093f545`) for PR #14 integration.
-- 2026-04-29: Integrator Helmholtz merged PR #14 into `main` at `5675059e50669626063799ed14df3888dc5df9e2` and completed branch cleanup.
+Kept content-script runtime settings self-contained after bundling risk was proven, while strengthening parity validation and type-level reuse around shared settings contracts.
 
 ## Verification
 
-- Verification tier: focused runner checks and full gate.
+- `npm run validate:all`: passed
+- `npm run test:e2e`: passed
+- `npm run lint`: passed
+- `npm run typecheck`: passed
 
-| Check | Result | Notes |
-| --- | --- | --- |
-| `npm run typecheck` | Passed | Focused check after settings/validation edits. |
-| `npm run lint` | Passed | Focused check after settings/validation edits. |
-| `npm run test:e2e` | Passed | 8 fixture tests passed after conservative type-only sharing adjustment. A prior full runtime consolidation attempt failed fixture E2E and was abandoned. |
-| `npm run validate:all` | Passed | Includes typecheck, lint, `git diff --check`, package validation, packaged validation, and 8 fixture tests. |
-| `npm run validate` | Passed | Reviewer targeted check. |
-| `npm run build` | Passed | Reviewer verified content build emitted only `dist/content/content.js` for the content script. |
-| `rg "^\\s*(import\|export)\\s\|shared/settings" dist/content/content.js` | Passed | Reviewer found no runtime module import/export or shared settings reference. |
-| `npm run validate:all` | Passed | Integrator full gate before merge; 8 fixture tests passed. |
+## Archive Reference
 
-## Human Acceptance Checklist
+The detailed implementation notes and attempted-consolidation rationale were compacted on 2026-06-10.
 
-- Required before merge: No, unless user-facing settings behavior changes.
-- URL(s): https://github.com/cryptoteatime/simple-yt-tweaks/pull/14
-- Who should test: Reviewer/Integrator
-- Expected result: no behavior drift, settings defaults/storage parity preserved.
-
-## Blockers / Risks
-
-- Full runtime consolidation is not safe with the current Vite chunking setup unless build config changes also guarantee a self-contained content script.
-- Remaining duplication is intentional runtime duplication for content-script bundling safety; validation now guards parity.
-
-## Review Result
-
-- Reviewer: Hypatia (`019dd9b0-7e98-7983-88de-9463e804000e`)
-- Verdict: Ready to Integrate
-- Findings: none
-- Targeted checks:
-  - `git diff --check origin/main...HEAD`: passed
-  - `npm run validate`: passed
-  - `npm run build`: passed
-  - `rg "^\\s*(import\|export)\\s\|shared/settings" dist/content/content.js`: no runtime module import/export or shared settings reference found
-  - `npm run test:e2e`: passed, 8 fixture tests
-- Human QA requested: no
-
-## Next Handoff
-
-- Next role: Controller.
-- Next action: route `SYT-010C` planning/runner work when capacity is available.
-- Branch/worktree cleanup needed after merge: no; remote and local task branches were cleaned.
-- Copy-ready prompt:
-
-```text
-Run Simple YT Tweaks SYT-010B after SYT-010A is integrated.
-
-Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
-Create branch: swarm/syt-010b-settings-hardening
-
-Read the swarm docs and docs/swarm/handoffs/SYT-010B.md. Focus on settings parity/source-of-truth hardening. Preserve existing defaults and user-facing behavior. Prefer strengthening validation if consolidation creates bundling risk. Run npm run validate:all before PR.
-```
+- Reference map: `docs/swarm/archive/README.md`
+- Full prior text: Git history before `SYT-021` docs compaction
+- PR body and review: GitHub PR #14

--- a/docs/swarm/handoffs/SYT-010C.md
+++ b/docs/swarm/handoffs/SYT-010C.md
@@ -1,147 +1,25 @@
 # SYT-010C: Release-Candidate Process Smoothing
 
-## State
+## Status
 
-- Status: Integrated
-- Role: Integrator
-- Repo: Simple YT Tweaks
+- State: Integrated
+- PR: #16
 - Branch: `swarm/syt-010c-rc-process`
-- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/16
-- Owner: Codex Controller
-- Created: 2026-04-29
-- Updated: 2026-04-29
+- Merge commit: `0fca6c3`
+- Date: 2026-04-29
 
-## Goal
+## Summary
 
-Make the next release-candidate process smoother and less dependent on ad hoc chat memory.
-
-## Scope
-
-- Document release-candidate gates in `DEVELOPMENT.md` and swarm docs.
-- Define when to run fixture tests, live smoke, package validation, and human QA.
-- Add scripts only if a clear repeatable command is missing.
-
-## Non-Scope
-
-- Do not bump version or create a release.
-- Do not change product behavior.
-- Do not edit Web Store assets unless a future release issue explicitly asks.
-
-## Dependencies
-
-- Prefer waiting for `SYT-010A` so the RC process references accurate test coverage.
-
-## Lane Metadata
-
-- Parallel-safe: yes with source-free docs lanes if capacity is raised.
-- Serial-required: no.
-- Depends-on: `SYT-010A` preferred.
-- Conflict-risk: low/medium; release docs and package scripts.
-- Shared coordination docs allowed: this handoff only unless controller assigns more.
-
-## Controller-Friendly RC Gate
-
-The release-candidate gate is now documented in `DEVELOPMENT.md` as a fixture-first sequence:
-
-1. Confirm candidate scope and release-blocking issues.
-2. Update public release notes after scope is known; keep private Web Store notes out of the repo.
-3. Run `npm run version:set -- <next-version>` only for an actual RC or Web Store candidate.
-4. Run `npm run validate:all` as the stable automated gate. This covers typecheck, lint, `git diff --check`, package creation, packaged validation, and deterministic fixture E2E.
-5. Run `npm run test:e2e:live` only for YouTube-facing behavior changes, explicit reviewer/controller live-site confidence, or final manual acceptance. Inconclusive live smoke should be recorded without replacing fixture/package validation.
-6. Require human QA before publishing an RC or Web Store upload. Expected controller messages:
-
-```text
-Human QA passed for SYT-RC-001: <browser/version, package version, notes>
-Human QA failed for SYT-RC-001: <steps and observed problem>
-```
-
-7. Require explicit release approval before tagging, creating a GitHub release, or preparing Web Store upload artifacts. Approval should name the version, package path, and publish/draft/stop direction.
-
-## Files Changed
-
-- `DEVELOPMENT.md`: Added the release-candidate gate, live-smoke rule, human QA message format, and controller PR checklist.
-- `docs/swarm/handoffs/SYT-010C.md`: Recorded the gate, decisions, verification, and next role.
-
-## Decisions Made
-
-- No script changes were needed. Existing commands already cover the repeatable gate:
-  - `npm run validate:all`
-  - `npm run package`
-  - `npm run validate:packaged`
-  - `npm run test:e2e:live`
-  - `npm run version:set -- <next-version>`
-- `npm run validate:all` remains the stable fixture-first RC baseline.
-- Live smoke remains optional and supplemental because live YouTube can be inconclusive for reasons outside the extension.
-- Human QA is required for an actual RC/release but not for this docs-only process PR.
-- Version bump, tag, GitHub release, and Web Store upload remain blocked until explicit release approval.
+Documented the release-candidate gate in `DEVELOPMENT.md`: `validate:all` as the stable automated baseline, optional live smoke for YouTube-facing changes, and explicit human approval before version/tag/release/Web Store actions.
 
 ## Verification
 
-| Check | Result | Notes |
-| --- | --- | --- |
-| `git diff --check` | Passed | Docs-only whitespace check passed. |
-| `git diff --check origin/main...HEAD` | Passed | Reviewer targeted whitespace check passed. |
-| `git diff --check origin/main...HEAD` | Passed | Integrator final docs-only whitespace check passed before merge. |
-| `npm run validate:all` | Not run | Not required because no scripts/package/source files changed. |
-| PR #16 | Merged | https://github.com/cryptoteatime/simple-yt-tweaks/pull/16 |
+- `git diff --check`: passed
 
-## Work Log
+## Archive Reference
 
-- 2026-04-29: Controller opened task branch `swarm/syt-010c-rc-process` for release-candidate process smoothing after `SYT-010B` integration.
-- 2026-04-29: Controller routed Planner/Runner Ampere (`019dda63-8fdc-7531-b649-2a91669070c4`) for implementation.
-- 2026-04-29: Added docs-only RC gate to `DEVELOPMENT.md`; kept scripts unchanged because the repo already has repeatable validation/package/live-smoke commands.
-- 2026-04-29: Opened draft PR #16 for review.
-- 2026-04-29: Controller reconciled Ampere completion and queued Reviewer for PR #16.
-- 2026-04-29: Controller routed Reviewer Boole (`019ddabc-9d77-7692-81b6-80ff60498621`) for PR #16 review.
-- 2026-04-29: Reviewer Boole reported no findings and marked PR #16 Ready to Integrate.
-- 2026-04-29: Controller routed Integrator Carson (`019ddb16-4dcd-7c83-9fce-e664dfdf53a1`) for PR #16 integration.
-- 2026-04-29: Integrator Carson confirmed PR #16 was mergeable and docs-only, marked it ready for review, squash-merged it into `main` at `0fca6c3`, synced local `main`, and confirmed branch cleanup.
+The longer RC process handoff was compacted on 2026-06-10.
 
-## Human Acceptance Checklist
-
-- Required before merge: No for this docs-only process PR.
-- Required before release: Yes before an actual release candidate is shipped or uploaded.
-- Expected release QA pass/fail format is documented in `DEVELOPMENT.md`.
-
-## Integration Result
-
-- Integrator: Carson (`019ddb16-4dcd-7c83-9fce-e664dfdf53a1`)
-- Decision: Integrated.
-- Merge: squash merge commit `0fca6c312675400f38c8f0cd09da2c82081d0f52`.
-- Branch cleanup: GitHub deleted the remote task branch during merge; local task branch was deleted by the GitHub CLI merge workflow.
-- Human QA: not required for this docs-only process PR.
-
-## Blockers / Risks
-
-- No blockers after integration.
-- Live YouTube smoke can be inconclusive; the documented gate requires recording the reason and falling back to fixture/package validation plus human QA.
-- This lane intentionally did not validate or change Web Store submission assets.
-
-## Review Result
-
-- Reviewer: Boole (`019ddabc-9d77-7692-81b6-80ff60498621`)
-- Verdict: Ready to Integrate
-- Findings: none
-- Targeted checks:
-  - `gh pr view 16 --json ...`: PR open draft, base `main`, head `swarm/syt-010c-rc-process`, merge state `CLEAN`
-  - `git fetch origin main swarm/syt-010c-rc-process --prune`: passed
-  - `git diff --name-status origin/main...HEAD`: only `DEVELOPMENT.md` and swarm docs changed
-  - `git diff --check origin/main...HEAD`: passed
-  - Package scripts inspected: `validate:all` already runs typecheck, lint, `git diff --check`, package, packaged validation, and fixture Playwright
-- Human QA requested: no for this docs-only process PR
-
-## Next Handoff
-
-- Next role: Controller.
-- Next action: route or defer `SYT-010D` pure helper tests; do not start release/tag/version/Web Store work without an explicit release-candidate lane.
-- Branch/worktree cleanup needed after merge: no; cleanup completed.
-- Copy-ready prompt:
-
-```text
-Run Simple YT Tweaks SYT-010C after SYT-010A is integrated or when the controller asks for RC process docs.
-
-Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
-Create branch: swarm/syt-010c-rc-process
-
-Read the swarm docs and docs/swarm/handoffs/SYT-010C.md. Document a release-candidate gate that uses fixture tests first, optional live smoke only when useful, package validation, and human QA only for RC behavior. Do not bump version or release.
-```
+- Reference map: `docs/swarm/archive/README.md`
+- Full prior text: Git history before `SYT-021` docs compaction
+- PR body and review: GitHub PR #16

--- a/docs/swarm/handoffs/SYT-010D.md
+++ b/docs/swarm/handoffs/SYT-010D.md
@@ -1,156 +1,28 @@
-# SYT-010D Handoff: Pure Helper Tests
+# SYT-010D: Pure Helper Tests
 
-## Task
+## Status
 
-- Task id: `SYT-010D`
-- Title: Pure helper tests
-- Assigned role: Planner/Runner - Dirac (`019ddb72-af51-7372-8146-43d5ead7148a`); Reviewer - Ptolemy (`019ddbcb-2d65-76c1-982c-54abedb730cc`); Integrator - Planck (`019ddc21-c7bb-75a2-94f6-e8d84b8f4489`)
-- Current state: Integrated
-- Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+- State: Integrated
+- PR: #18
 - Branch: `swarm/syt-010d-helper-tests`
+- Merge commit: `88f0a91`
+- Date: 2026-04-29
 
-## Goal
+## Summary
 
-Add fast helper-level coverage where it provides real regression value for post-v0.3.0 hardening, especially settings normalization and selector-safe DOM helpers. If a helper-level test lane would add more maintenance cost than value, document a narrow deferral instead of forcing a brittle test layer.
+Added a Playwright unit project and helper-level tests for settings normalization and selector-safe DOM helpers. This improved confidence before future module splitting or hover research.
 
-## Scope
+## Verification
 
-- Audit browser-independent or low-browser-coupling helpers such as:
-  - `src/content/settings.ts`: `normalizeSettings`, `isFeatureEnabled`, settings fallback behavior.
-  - `src/content/dom.ts`: `normalizeLabel`, `labelMatchesEntry`, `elementMatchesAnyLabel`, `query`, and `queryAll`.
-  - `src/shared/settings.ts` only if needed to assert default/parity behavior.
-- Prefer existing tooling. Playwright is already available and can run TypeScript tests; avoid new dependencies unless clearly justified.
-- If adding a unit/helper project, keep it small and obvious, such as `tests/unit/**`, `playwright.config.ts`, and `package.json` scripts.
-- Keep product/runtime behavior unchanged unless a tiny export or testability adjustment is necessary and low risk.
+- `npm run test:unit`: passed
+- `npm run typecheck`: passed
+- `npm run lint`: passed
+- `npm run validate:all`: passed
 
-## Non-Scope
+## Archive Reference
 
-- No version bump, tag, release, or Web Store asset change.
-- No enhanced home/search hover implementation; #8 remains a future research lane.
-- No broad module splitting or architecture refactor.
-- No live YouTube dependency for this lane.
-- No popup/user-facing behavior changes.
+The detailed runner/reviewer/integrator work log was compacted on 2026-06-10.
 
-## Dependencies
-
-- Depends on: `SYT-010A`, `SYT-010B`, `SYT-010C`
-- Blocks: none directly; improves confidence before future `SYT-010E` module review or `SYT-008A` research.
-
-## Parallelization
-
-- parallel-safe: yes, if limited to tests/config/helper exports and no other active source tasks exist.
-- serial-required: no, under current max capacity 1.
-- depends-on: integrated `SYT-010A`, `SYT-010B`, and `SYT-010C`.
-- conflict-risk: low/medium. Low for tests-only; medium if helper exports or shared settings contracts are touched.
-
-## Suggested Implementation Plan
-
-1. Inspect existing Playwright config, scripts, and helper exports.
-2. Decide whether a `tests/unit` Playwright project is worthwhile.
-3. Add narrow tests for settings normalization and DOM helper behavior, or document why the lane should be deferred.
-4. Keep `npm run validate:all` as the final gate if config/source/package files change.
-5. Push the branch and open a draft PR with a `How to test / what to tell the controller` section.
-
-## Verification Tier
-
-- Verification tier: focused runner checks, full if config/source/package changes.
-- Minimum checks if tests/config/source/package change:
-  - `npm run typecheck`
-  - `npm run lint`
-  - focused new helper test command or targeted Playwright project
-  - `npm run validate:all`
-- Minimum checks if docs-only deferral:
-  - `git diff --check`
-
-## GitHub Actions Allowed
-
-- Push branch: yes.
-- Open draft PR: yes, if implementation or documented deferral is useful to review.
-- Merge: no.
-- Human QA: no, unless runtime behavior changes unexpectedly.
-
-## Files Or Areas Touched
-
-- Controller prep:
-  - `docs/swarm/handoffs/SYT-010D.md`
-  - `docs/swarm/task-board.md`
-  - `docs/swarm/agent-registry.md`
-  - `docs/swarm/current-state.md`
-  - `docs/swarm/controller-directives.md`
-- Runner implementation:
-  - `package.json`
-  - `playwright.config.ts`
-  - `tests/unit/dom.unit.spec.ts`
-  - `tests/unit/settings.unit.spec.ts`
-
-## Commands Run
-
-- Controller prep:
-  - `git diff --check`: PASS
-  - `git push -u origin swarm/syt-010d-helper-tests`: PASS
-- Runner implementation:
-  - `npm run test:unit`: PASS, 8 unit tests passed.
-  - `npm run typecheck`: PASS.
-  - `npm run lint`: PASS.
-  - `npm run validate:all`: PASS, including package validation, 8 unit tests, and 8 fixture tests.
-- Reviewer:
-  - `npm run test:unit`: PASS, 8 unit tests passed.
-  - `git diff --check origin/main...HEAD`: PASS.
-  - `npm run validate:all`: PASS, including package validation, 8 unit tests, and 8 fixture tests.
-- Integrator:
-  - `gh pr view 18 --json number,title,state,isDraft,mergeable,mergeStateStatus,headRefName,baseRefName,headRepositoryOwner,reviewDecision,statusCheckRollup,url,body,reviews`: PASS, PR #18 was open, draft, mergeable, and clean; PR body had required test instructions; handoff review evidence marked Ready to Integrate.
-  - `git fetch origin main swarm/syt-010d-helper-tests --prune`: PASS.
-  - `git diff --name-status origin/main...HEAD`: PASS, scope limited to swarm docs, package/config wiring, and helper unit tests.
-  - `git diff --check origin/main...HEAD`: PASS.
-  - `npm run test:unit`: PASS, 8 unit tests passed.
-  - `npm run validate:all`: PASS, including typecheck, lint, `git diff --check`, package validation, 8 unit tests, and 8 fixture tests.
-  - `gh pr ready 18`: PASS.
-  - `gh pr merge 18 --squash --delete-branch --subject "Add helper unit tests" --body "Adds Playwright unit-project coverage for settings and DOM helpers."`: PASS, squash merge commit `88f0a913dd4550239391bde236d6ef905ca7099b`.
-  - `git fetch origin --prune`: PASS, stale remote-tracking ref for `origin/swarm/syt-010d-helper-tests` pruned.
-
-## Decisions Made
-
-- Keep this lane separate from #8 enhanced hover research and `SYT-010E` module splitting.
-- Do not add dependencies unless the existing Playwright/TypeScript stack cannot cover the helper behavior cleanly.
-- Added a small Playwright `unit` project instead of introducing a new unit-test dependency.
-- Added `npm run test:unit` and included the unit project in `npm run validate:all` so helper coverage runs in the full repo gate.
-- Kept runtime/source behavior unchanged; no helper exports or source refactors were needed.
-
-## Blockers Or Risks
-
-- No blockers.
-- Residual risk: unit tests use fake roots/elements for selector-safe DOM helpers rather than a real DOM. This is intentional to keep the lane fast and dependency-free; browser fixture coverage remains responsible for integrated DOM behavior.
-
-## Review Result
-
-- Status: Ready to Integrate.
-- Findings: none.
-- Review notes: PR #18 is scoped to docs, Playwright unit-project wiring, package scripts, and new helper tests. No product/runtime source files changed, no #8 hover/release/version work was introduced, and the PR body includes the required controller test section with human review requested: no.
-
-## Pull Request
-
-- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/18
-- Merge: squash merge commit `88f0a913dd4550239391bde236d6ef905ca7099b`
-
-## Next Recommended Role
-
-- None for this lane. `SYT-010D` is integrated; controller should choose any future lane in a separate pass.
-
-## Copy-Ready Runner Prompt
-
-```text
-You are the Planner/Runner for Simple YT Tweaks task SYT-010D.
-
-Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
-Branch: swarm/syt-010d-helper-tests
-
-Read ../AGENTS.md, SWARM.md, docs/swarm/controller-directives.md, docs/swarm/task-board.md, docs/swarm/agent-registry.md, docs/swarm/github.md, and docs/swarm/handoffs/SYT-010D.md before editing.
-
-Scope: add fast helper-level coverage for settings normalization and selector-safe DOM helpers, or document a narrow deferral if the test layer would be more costly than useful. Prefer existing Playwright/TypeScript tooling. Avoid new dependencies unless clearly justified. Do not change product/runtime behavior except for tiny low-risk testability exports if needed. Do not work on #8 enhanced hover, releases, version bumps, tags, live YouTube behavior, or broad module splitting.
-
-Allowed GitHub actions: push the task branch and open a draft PR with a visible "How to test / what to tell the controller" section. Do not merge.
-
-Verification: if tests/config/source/package files change, run npm run typecheck, npm run lint, a focused helper test command or targeted Playwright project, and npm run validate:all. If the lane is docs-only deferral, run git diff --check.
-
-Update docs/swarm/handoffs/SYT-010D.md with files touched, commands/results, decisions, blockers, and next role. Report Needs Review when complete.
-```
+- Reference map: `docs/swarm/archive/README.md`
+- Full prior text: Git history before `SYT-021` docs compaction
+- PR body and review: GitHub PR #18

--- a/docs/swarm/handoffs/SYT-010E.md
+++ b/docs/swarm/handoffs/SYT-010E.md
@@ -52,4 +52,3 @@ Continue post-v0.3.0 hardening without broad rewrites. Use fixture and unit cove
 - Focused checks for the chosen scope.
 - Always run `npm run validate:all` before integration.
 - Use signed-in Chrome live smoke only when the target touches live-only YouTube behavior.
-

--- a/docs/swarm/handoffs/SYT-010E.md
+++ b/docs/swarm/handoffs/SYT-010E.md
@@ -1,0 +1,55 @@
+# SYT-010E: Post-#21 Code Hardening Lane
+
+## Status
+
+- State: Ready after PR #22 review/integration state is clear
+- GitHub issue: #10
+- Branch: TBD, use `swarm/syt-010e-<short-slug>`
+- Role: Planner or Senior Runner
+- Updated: 2026-06-10
+
+## Goal
+
+Continue post-v0.3.0 hardening without broad rewrites. Use fixture and unit coverage as the gate, and only refactor where it reduces real regression risk.
+
+## Scope
+
+- Audit the largest/highest-risk content modules after #21 settles:
+  - `src/content/grid-hover.ts`
+  - `src/content/sidebar.ts`
+  - `src/content/sticky-player.ts`
+  - `src/content/fullscreen.ts`
+  - `src/content/theater.ts`
+- Pick one narrow implementation target per PR.
+- Prefer behavior-preserving extraction, selector normalization, or helper tests over aesthetic file splitting.
+- Add or extend tests before changing fragile YouTube DOM behavior.
+
+## Non-Scope
+
+- Do not revive #8 enhanced Home/Search hover grow.
+- Do not change settings defaults.
+- Do not version bump, tag, release, or edit Web Store assets.
+- Do not combine broad code hardening with release-candidate work.
+
+## Lane Metadata
+
+- Parallel-safe: no while #21 is under review or integration.
+- Serial-required: yes for runtime source hardening.
+- Depends-on: PR #22 review/integration state clear.
+- Conflict-risk: medium/high because these files touch live YouTube DOM behavior.
+
+## Suggested First Pass
+
+1. Review PR #22 outcome and any reviewer/user QA notes.
+2. Run `npm run validate:all` on the current baseline.
+3. Choose one hardening target with a bounded write scope.
+4. Add/adjust fixture or unit coverage for that target.
+5. Implement the smallest behavior-preserving cleanup.
+6. Open a draft PR with `How to test / what to tell the controller`.
+
+## Verification
+
+- Focused checks for the chosen scope.
+- Always run `npm run validate:all` before integration.
+- Use signed-in Chrome live smoke only when the target touches live-only YouTube behavior.
+

--- a/docs/swarm/handoffs/SYT-021.md
+++ b/docs/swarm/handoffs/SYT-021.md
@@ -7,7 +7,7 @@
 - Repo: Simple YT Tweaks
 - Branch: `swarm/syt-008b-native-hover-spa-regression`
 - GitHub issue: #21
-- PR: TBD after branch push
+- PR: #22
 - Created: 2026-06-10
 - Updated: 2026-06-10
 
@@ -83,6 +83,5 @@ Fix the live YouTube regression where native Home hover previews can stall after
 ## Next Handoff
 
 - Next role: Reviewer.
-- Next action: Review branch diff and PR body once opened. Focus on preserving native Home/Search behavior, not over-expanding selector scope, and ensuring click fallback timing cannot double-toggle normal native clicks.
+- Next action: Review PR #22. Focus on preserving native Home/Search behavior, not over-expanding selector scope, and ensuring click fallback timing cannot double-toggle normal native clicks.
 - Expected result: `Ready to Integrate` if review and checks pass. Human QA is useful because this fixes live YouTube behavior, but the branch already has automated and live Chrome smoke coverage.
-

--- a/docs/swarm/handoffs/SYT-021.md
+++ b/docs/swarm/handoffs/SYT-021.md
@@ -1,0 +1,88 @@
+# SYT-021: Native Hover SPA Regression And Live Recommendation Drift
+
+## State
+
+- Status: Needs Review
+- Role: Controller/Runner
+- Repo: Simple YT Tweaks
+- Branch: `swarm/syt-008b-native-hover-spa-regression`
+- GitHub issue: #21
+- PR: TBD after branch push
+- Created: 2026-06-10
+- Updated: 2026-06-10
+
+## Goal
+
+Fix the live YouTube regression where native Home hover previews can stall after navigating from a watch page back to Home without a full refresh, while preserving the v0.3.0 decision not to reintroduce enhanced Home/Search hover grow.
+
+## Scope
+
+- Preserve native Home/Search hover preview behavior with no extension grow/highlight classes.
+- Defer destructive Home sponsored cleanup briefly after SPA navigation so YouTube can finish mounting native preview/feed nodes.
+- Add a narrow fallback that only calls `play()` on an existing native feed preview video under the pointer when YouTube has already mounted it and left it paused.
+- Ensure watch-page video helpers prefer the real `#movie_player` video instead of stale preview videos.
+- Harden player-surface click fallback against transient native no-op timing.
+- Support current live recommendation cards rendered as `#secondary yt-lockup-view-model`.
+- Add fixture coverage for these regression paths.
+
+## Non-Scope
+
+- Do not revive #8 enhanced Home/Search hover grow.
+- Do not bump version, tag, release, or update Web Store assets.
+- Do not merge directly to `main`.
+
+## Dependencies
+
+- Branch started from post-v0.3.0 hardening baseline.
+- Existing #8 enhanced hover research remains deferred.
+- Existing #10 hardening remains open.
+
+## Lane Metadata
+
+- Parallel-safe: no with #8 hover research or sidebar/player runtime work.
+- Serial-required: yes; live YouTube preview lifecycle and recommendation markup are fragile.
+- Depends-on: v0.3.0 baseline and fixture harness.
+- Conflict-risk: high; touches `src/content/grid-hover.ts`, `src/content/sidebar.ts`, watch click fallback, and YouTube DOM selectors.
+- Shared coordination docs allowed: this handoff plus controller-owned task board/current state/GitHub notes.
+
+## Files Touched
+
+- `src/content/content.ts`
+- `src/content/dom.ts`
+- `src/content/grid-hover.ts`
+- `src/content/lifecycle.ts`
+- `src/content/sidebar.ts`
+- `src/content/state.ts`
+- `tests/e2e/extension.fixture.spec.ts`
+- `tests/e2e/youtube-fixtures.ts`
+- `docs/swarm/**` state docs
+
+## Verification
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `npm run test:e2e` | Passed | 10 fixture tests, including new SPA cleanup, modern recommendation card, and transient click fallback coverage. |
+| `npm run typecheck` | Passed | TypeScript clean. |
+| `npm run lint` | Passed | ESLint clean. |
+| `git diff --check` | Passed | Included in `validate:all`. |
+| `npm run validate:all` | Passed | Typecheck, lint, whitespace, package, packaged validation, unit, and fixture tests passed. |
+| Live signed-in Chrome smoke | Passed | Home watch-to-back hover previews played/advanced on three cards; Search grid/Shorts cleanup passed; Search preview played; comments visible; real CoreGraphics player click toggled pause/play; modern `#secondary yt-lockup-view-model` recommendation hover delay passed. |
+
+## Decisions
+
+- Keep Home/Search previews visually native. The fallback only resumes an already-mounted native preview video under the pointer; it does not create preview UI or apply grow/highlight behavior.
+- Stop removing arbitrary empty Home grid items. Only explicit hidden/sponsored home containers/items are removed, preventing accidental interference with YouTube SPA/preview placeholders.
+- Keep #8 separate as future research for enhanced hover preview; #21 only repairs native behavior and live selector drift.
+- Treat accessibility/connector clicks as unreliable for YouTube player click testing. The real user-facing click path was verified with a lower-level CoreGraphics click.
+
+## Risks
+
+- YouTube live DOM experiments may continue to drift. Fixture now covers the observed modern `#secondary yt-lockup-view-model` recommendation shape.
+- Live YouTube ad/consent/experiment behavior can make smoke checks noisy. The stable gate remains `npm run validate:all`.
+
+## Next Handoff
+
+- Next role: Reviewer.
+- Next action: Review branch diff and PR body once opened. Focus on preserving native Home/Search behavior, not over-expanding selector scope, and ensuring click fallback timing cannot double-toggle normal native clicks.
+- Expected result: `Ready to Integrate` if review and checks pass. Human QA is useful because this fixes live YouTube behavior, but the branch already has automated and live Chrome smoke coverage.
+

--- a/docs/swarm/handoffs/SYT-CTL-001.md
+++ b/docs/swarm/handoffs/SYT-CTL-001.md
@@ -1,108 +1,26 @@
 # SYT-CTL-001: Bootstrap Repo-Local Swarm Packet
 
-## State
+## Status
 
-- Status: Ready to Integrate
-- Role: Integrator
-- Repo: Simple YT Tweaks
+- State: Integrated
+- PR: #11
 - Branch: `swarm/syt-bootstrap-controller-packet`
-- Owner: Controller
-- Created: 2026-04-29
-- Updated: 2026-04-29
+- Merge commit: `676efc8`
+- Date: 2026-04-29
 
-## Goal
+## Summary
 
-Create the repo-owned swarm packet and seed paced controller lanes for post-v0.3.0 hardening.
-
-## Scope
-
-- `SWARM.md`
-- `docs/swarm/**`
-- Initial handoffs for #8/#10 lanes
-
-## Non-Scope
-
-- Product runtime code
-- Version bumps, tags, releases, Web Store assets
-- Live YouTube behavior changes
-
-## Dependencies
-
-- Workspace `AGENTS.md` and `.codex-swarm/prompts/REPO_BOOTSTRAP.md` read.
-- Existing repo discovery complete.
-
-## Lane Metadata
-
-- Parallel-safe: no; controller-owned docs bootstrap.
-- Serial-required: yes during bootstrap.
-- Depends-on: none.
-- Conflict-risk: low; docs only.
-- Shared coordination docs allowed: all `docs/swarm/**` for controller.
-
-## Plan
-
-1. Create repo-local swarm files.
-2. Seed #8/#10 task lanes and handoffs.
-3. Run docs checks.
-4. Commit, push, and open a draft PR with controller test instructions.
-
-## Files / Areas
-
-- `SWARM.md`
-- `docs/swarm/**`
-
-## Decisions
-
-- Record heartbeat as proposed, not active, until the docs branch is merged and the repo is clean.
-- Treat live YouTube smoke as supplemental only.
-- Route first implementation work to `SYT-010A`.
-
-## Work Log
-
-- 2026-04-29: Repo discovery and tooling preflight completed. `npm run validate:all` passed before docs edits.
+Created the repo-local swarm packet, seeded controller docs, and established GitHub/heartbeat policy for Simple YT Tweaks.
 
 ## Verification
 
-- Verification tier: docs-only plus full baseline preflight.
+- `npm run validate:all`: passed
+- `git diff --check`: passed
 
-| Check | Result | Notes |
-| --- | --- | --- |
-| `npm run validate:all` | PASS | Ran after docs edits. |
-| `git diff --check` | PASS | Included in `validate:all`; also ran directly before full gate. |
+## Archive Reference
 
-## Human Acceptance Checklist
+The full historical handoff was intentionally compacted on 2026-06-10 to reduce hot-context load.
 
-- Required before merge: No
-- URL(s): https://github.com/cryptoteatime/simple-yt-tweaks/pull/11
-- Who should test: Reviewer/Integrator
-- Steps:
-  1. Review docs for accurate repo policy and lanes.
-  2. Run `git diff --check`.
-  3. Confirm no product code changed.
-- Expected result: docs-only bootstrap packet is accurate and mergeable.
-- If it passes, tell the controller: `Review passed for SYT-CTL-001: docs-only bootstrap ready`
-- If it fails, tell the controller: `Review failed for SYT-CTL-001: <issue>`
-
-## Blockers / Risks
-
-- None.
-
-## Next Handoff
-
-- Next role: Integrator
-- Next action: Mark draft PR #11 ready if needed, merge it through GitHub, sync `main`, and clean the task branch if safe.
-- Branch/worktree cleanup needed after merge: yes, delete branch after merge.
-- Copy-ready prompt:
-
-```text
-Review Simple YT Tweaks SYT-CTL-001.
-
-Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
-Branch: swarm/syt-bootstrap-controller-packet
-
-Read ../AGENTS.md, SWARM.md, docs/swarm/controller-directives.md, docs/swarm/project-brief.md, docs/swarm/current-state.md, docs/swarm/task-board.md, docs/swarm/github.md, and docs/swarm/handoffs/SYT-CTL-001.md.
-
-Review only the repo-local swarm packet. Confirm the docs accurately reflect the existing repo, GitHub policy, #8/#10 lanes, verification strategy, and controller pacing. Run git diff --check. Do not change product code.
-
-Report findings first. If clean, mark Ready to Integrate.
-```
+- Reference map: `docs/swarm/archive/README.md`
+- Full prior text: Git history before `SYT-021` docs compaction
+- PR body and review: GitHub PR #11

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -28,7 +28,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Title | Reason | Notes |
 | --- | --- | --- | --- |
-| `SYT-010E` | Large module split review | Reduce risk in large content modules only where it lowers real maintenance cost. | Do not split for aesthetics; require test coverage first. |
+| `SYT-010E` | Code-hardening lane after #21 | Reduce runtime risk in large content modules only where it lowers real maintenance cost. | Start after PR #22 review/integration state is clear. First target should be a small scoped audit/refactor with `validate:all`, not broad aesthetic splitting. |
 | `SYT-RC-001` | Next release-candidate checklist | Make future version bump/package/release flow smoother. | Human QA required before release. |
 
 ## Blocked
@@ -69,3 +69,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - GitHub workflow: `docs/swarm/github.md`.
 - Current controller phase: Phase 4 active; `SYT-010D` integrated and no new lane started by the Integrator.
 - 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and draft PR #22 for `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`; review is next.
+- 2026-06-10: User requested compact context/docs and more frequent automation. Completed historical handoffs were compacted to stubs with `docs/swarm/archive/README.md` reference mapping; `docs/swarm/context-map.md` is now the hot context entrypoint.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -22,6 +22,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
 | `SYT-010D` | Pure helper tests | Integrator | Integrated | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 merged |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
+| `SYT-021` | Native hover SPA regression and live recommendation drift | Controller/Runner | Needs Review | `swarm/syt-008b-native-hover-spa-regression` | #21 native Home/Search preview repair, watch click fallback hardening, modern recommendation selector drift | serial-required | v0.3.0 baseline | high, live YouTube SPA/player behavior | `docs/swarm/handoffs/SYT-021.md` | TBD |
 
 ## Backlog
 
@@ -40,7 +41,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-021` | `swarm/syt-008b-native-hover-spa-regression` | Preserve native Home/Search behavior, click fallback timing, modern recommendation selectors, fixture coverage | full plus live Chrome smoke | `docs/swarm/handoffs/SYT-021.md` |
 
 ## Ready To Integrate
 
@@ -67,3 +68,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
 - Current controller phase: Phase 4 active; `SYT-010D` integrated and no new lane started by the Integrator.
+- 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and prepared `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`; review is next after branch push/PR.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -22,7 +22,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
 | `SYT-010D` | Pure helper tests | Integrator | Integrated | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 merged |
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
-| `SYT-021` | Native hover SPA regression and live recommendation drift | Controller/Runner | Needs Review | `swarm/syt-008b-native-hover-spa-regression` | #21 native Home/Search preview repair, watch click fallback hardening, modern recommendation selector drift | serial-required | v0.3.0 baseline | high, live YouTube SPA/player behavior | `docs/swarm/handoffs/SYT-021.md` | TBD |
+| `SYT-021` | Native hover SPA regression and live recommendation drift | Controller/Runner | Needs Review | `swarm/syt-008b-native-hover-spa-regression` | #21 native Home/Search preview repair, watch click fallback hardening, modern recommendation selector drift | serial-required | v0.3.0 baseline | high, live YouTube SPA/player behavior | `docs/swarm/handoffs/SYT-021.md` | #22 draft |
 
 ## Backlog
 
@@ -41,7 +41,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| `SYT-021` | `swarm/syt-008b-native-hover-spa-regression` | Preserve native Home/Search behavior, click fallback timing, modern recommendation selectors, fixture coverage | full plus live Chrome smoke | `docs/swarm/handoffs/SYT-021.md` |
+| `SYT-021` | `swarm/syt-008b-native-hover-spa-regression` / PR #22 | Preserve native Home/Search behavior, click fallback timing, modern recommendation selectors, fixture coverage | full plus live Chrome smoke | `docs/swarm/handoffs/SYT-021.md` |
 
 ## Ready To Integrate
 
@@ -68,4 +68,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
 - Current controller phase: Phase 4 active; `SYT-010D` integrated and no new lane started by the Integrator.
-- 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and prepared `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`; review is next after branch push/PR.
+- 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and draft PR #22 for `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`; review is next.

--- a/docs/swarm/user-feedback.md
+++ b/docs/swarm/user-feedback.md
@@ -11,6 +11,8 @@ Use this file for durable human steering that should survive across controller t
 - 2026-04-29: Use task branches and draft PRs when useful. Include `How to test / what to tell the controller` in PR bodies.
 - 2026-04-29: Do not request human QA for every small PR. Save human QA for release candidates, risky browser behavior, or visual/product-direction questions.
 - 2026-04-29: Default to 1 active subagent at a time and a slow controller heartbeat around 90 minutes after repo state is clean.
+- 2026-06-10: Use the signed-in Chrome profile for supplemental live YouTube usability audits when behavior depends on real YouTube SPA/player state. Keep repo-owned tests and `validate:all` as the required gate.
+- 2026-06-10: For #21, fix the watch-to-Home native hover autoplay regression, audit other live features/settings, patch regressions found during audit, and keep automation running while the user sleeps.
 
 ## Product Ideas
 
@@ -19,12 +21,14 @@ Use this file for durable human steering that should survive across controller t
 | Revisit enhanced home/search grid hover preview | GitHub #8 / prior manual testing | Deferred | `SYT-008A` |
 | Strengthen fixture tests before hardening code | User | Planned | `SYT-010A` |
 | Smooth release-candidate validation/package flow | User | Planned | `SYT-010C` |
+| Keep native Home/Search hover only, with no enhanced grow/highlight | User / #8 decision | Active constraint | `SYT-021`, `SYT-008A` deferred |
 
 ## Human QA Notes
 
 | Date | Milestone / PR | Result | Notes |
 | --- | --- | --- | --- |
 | 2026-04-29 | v0.3.0 baseline | Passed previously | v0.3.0 released; hardening starts from passing baseline. |
+| 2026-06-10 | SYT-021 live Chrome smoke | Passed by controller | Signed-in Chrome: watch-to-Home Home hover previews played/advanced; Search previews/cleanup passed; comments visible; real player click toggled; modern recommendation hover delay passed. |
 
 ## Rules
 

--- a/docs/swarm/user-feedback.md
+++ b/docs/swarm/user-feedback.md
@@ -13,6 +13,7 @@ Use this file for durable human steering that should survive across controller t
 - 2026-04-29: Default to 1 active subagent at a time and a slow controller heartbeat around 90 minutes after repo state is clean.
 - 2026-06-10: Use the signed-in Chrome profile for supplemental live YouTube usability audits when behavior depends on real YouTube SPA/player state. Keep repo-owned tests and `validate:all` as the required gate.
 - 2026-06-10: For #21, fix the watch-to-Home native hover autoplay regression, audit other live features/settings, patch regressions found during audit, and keep automation running while the user sleeps.
+- 2026-06-10: Keep repo docs compact so controller passes do not repeatedly compact; archive completed-lane detail with clear reference maps. Run the heartbeat more frequently, around every 30 minutes, while active work is moving.
 
 ## Product Ideas
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -120,6 +120,7 @@ function resetNavigationState(): void {
   document.body.classList.remove('simple-yt-tweaks-top-hover');
   resetStickyPlayerState();
   resetFullscreenNavigationState();
+  state.homeFeedCleanupDeferredUntil = Date.now() + 1_500;
 }
 
 function refreshPlayerLayout(): void {

--- a/src/content/dom.ts
+++ b/src/content/dom.ts
@@ -36,7 +36,7 @@ export function queryAll<T extends Element = Element>(
 }
 
 export function getVideo(): HTMLVideoElement | null {
-  return query<HTMLVideoElement>(SELECTORS.html5Video);
+  return query<HTMLVideoElement>('#movie_player video.html5-main-video') ?? query<HTMLVideoElement>(SELECTORS.html5Video);
 }
 
 export function getPlayer(): HTMLElement | null {

--- a/src/content/grid-hover.ts
+++ b/src/content/grid-hover.ts
@@ -23,8 +23,10 @@ const PREVIEW_CONTAINER_SELECTOR = [
 const SIDEBAR_CARD_SELECTOR = [
   '#related ytd-compact-video-renderer',
   'ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer',
+  '#secondary ytd-compact-video-renderer',
   '#related yt-lockup-view-model',
   'ytd-watch-next-secondary-results-renderer yt-lockup-view-model',
+  '#secondary yt-lockup-view-model',
 ].join(',');
 const SEARCH_GRID_CONTENTS_SELECTOR =
   'ytd-search ytd-two-column-search-results-renderer #primary ytd-section-list-renderer > #contents.ytd-section-list-renderer';
@@ -32,14 +34,17 @@ const HOVER_CARD_SELECTOR = SIDEBAR_CARD_SELECTOR;
 const HOVER_MEDIA_SELECTOR = [
   '#related ytd-compact-video-renderer ytd-thumbnail',
   'ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer ytd-thumbnail',
+  '#secondary ytd-compact-video-renderer ytd-thumbnail',
   '#related yt-lockup-view-model yt-thumbnail-view-model',
   'ytd-watch-next-secondary-results-renderer yt-lockup-view-model yt-thumbnail-view-model',
+  '#secondary yt-lockup-view-model yt-thumbnail-view-model',
 ].join(',');
 
 let handlersBound = false;
 let activeHoverCard: HTMLElement | null = null;
 let hoverReadyTimer: number | null = null;
 let hoverClearTimer: number | null = null;
+let nativePreviewPlayTimer: number | null = null;
 let lastPointerX = Number.POSITIVE_INFINITY;
 let lastPointerY = Number.POSITIVE_INFINITY;
 
@@ -294,7 +299,9 @@ function buildSidebarFoundationCss(): string {
     body.simple-yt-tweaks-active #related yt-lockup-view-model,
     body.simple-yt-tweaks-active #related .ytLockupViewModelHost,
     body.simple-yt-tweaks-active ytd-watch-next-secondary-results-renderer yt-lockup-view-model,
-    body.simple-yt-tweaks-active ytd-watch-next-secondary-results-renderer .ytLockupViewModelHost {
+    body.simple-yt-tweaks-active ytd-watch-next-secondary-results-renderer .ytLockupViewModelHost,
+    body.simple-yt-tweaks-active #secondary yt-lockup-view-model,
+    body.simple-yt-tweaks-active #secondary .ytLockupViewModelHost {
       overflow: visible !important;
     }
   `;
@@ -318,35 +325,42 @@ function buildSidebarHoverCss(settings: Settings): string {
     'ytd-compact-video-renderer',
     '#related yt-lockup-view-model:has(a[href*="/watch"])',
     'ytd-watch-next-secondary-results-renderer yt-lockup-view-model:has(a[href*="/watch"])',
+    '#secondary yt-lockup-view-model:has(a[href*="/watch"])',
   ]);
   const media = scopedSelectors(scopes, [
     'ytd-compact-video-renderer ytd-thumbnail',
     '#related yt-lockup-view-model:has(a[href*="/watch"]) yt-thumbnail-view-model',
     'ytd-watch-next-secondary-results-renderer yt-lockup-view-model:has(a[href*="/watch"]) yt-thumbnail-view-model',
+    '#secondary yt-lockup-view-model:has(a[href*="/watch"]) yt-thumbnail-view-model',
   ]);
   const readyMedia = scopedSelectors(scopes, [
     `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS} ytd-thumbnail`,
     `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) yt-thumbnail-view-model`,
     `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) yt-thumbnail-view-model`,
+    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) yt-thumbnail-view-model`,
   ]);
   const readyCards = scopedSelectors(scopes, [
     `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS}`,
     `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"])`,
     `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"])`,
+    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"])`,
   ]);
   const overlayButtons = scopedSelectors(scopes, [
     `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model`,
     `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model`,
+    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model`,
     `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS} ytd-thumbnail-overlay-toggle-button-renderer`,
   ]);
   const overlayButtonElements = scopedSelectors(scopes, [
     `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button`,
     `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button`,
+    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button`,
     `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS} ytd-thumbnail-overlay-toggle-button-renderer button`,
   ]);
   const overlayButtonIcons = scopedSelectors(scopes, [
     `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button .ytIconWrapperHost`,
     `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button .ytIconWrapperHost`,
+    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button .ytIconWrapperHost`,
     `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS} ytd-thumbnail-overlay-toggle-button-renderer button .ytIconWrapperHost`,
   ]);
 
@@ -460,6 +474,12 @@ function clearHoverClearTimer(): void {
   hoverClearTimer = null;
 }
 
+function clearNativePreviewPlayTimer(): void {
+  if (nativePreviewPlayTimer === null) return;
+  window.clearTimeout(nativePreviewPlayTimer);
+  nativePreviewPlayTimer = null;
+}
+
 function clearActiveHoverCard(): void {
   clearHoverReadyTimer();
   clearHoverClearTimer();
@@ -489,6 +509,51 @@ function scheduleHoverReady(card: HTMLElement): void {
 function getElementUnderPointer(): Element | null {
   if (!Number.isFinite(lastPointerX) || !Number.isFinite(lastPointerY)) return null;
   return document.elementFromPoint(lastPointerX, lastPointerY);
+}
+
+function isNativeFeedPreviewPage(): boolean {
+  return location.pathname === '/' || location.pathname === '/results';
+}
+
+function getNativePreviewVideoUnderPointer(): HTMLVideoElement | null {
+  if (!isNativeFeedPreviewPage()) return null;
+  if (!Number.isFinite(lastPointerX) || !Number.isFinite(lastPointerY)) return null;
+
+  for (const video of document.querySelectorAll<HTMLVideoElement>('ytd-video-preview video, #inline-preview-player video')) {
+    const rect = video.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) continue;
+    if (
+      lastPointerX >= rect.left &&
+      lastPointerX <= rect.right &&
+      lastPointerY >= rect.top &&
+      lastPointerY <= rect.bottom
+    ) {
+      return video;
+    }
+  }
+
+  return null;
+}
+
+function scheduleNativePreviewPlaybackFallback(): void {
+  if (!isNativeFeedPreviewPage()) {
+    clearNativePreviewPlayTimer();
+    return;
+  }
+
+  const video = getNativePreviewVideoUnderPointer();
+  if (!video || !video.paused || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
+  if (nativePreviewPlayTimer !== null) return;
+
+  nativePreviewPlayTimer = window.setTimeout(() => {
+    nativePreviewPlayTimer = null;
+    const currentVideo = getNativePreviewVideoUnderPointer();
+    if (!currentVideo || !currentVideo.paused || currentVideo.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
+
+    void currentVideo.play().catch(() => {
+      // Native preview autoplay can still be blocked by YouTube/account state; leave the UI untouched.
+    });
+  }, 220);
 }
 
 function isPointerInsideCard(card: HTMLElement): boolean {
@@ -610,6 +675,7 @@ function isRecommendedHoverGrowEnabled(settings: Settings): boolean {
 
 export function syncGridHoverState(settings: Settings): void {
   // Home/search feed previews stay native; avoid writing YouTube's own column metadata during preview startup.
+  scheduleNativePreviewPlaybackFallback();
 
   if (settings.generalApplyFeedColumnsToSearch) {
     moveSearchBadgesToChannelRow();
@@ -646,6 +712,7 @@ export function bindGridHoverHandlers(getSettings: () => Settings): void {
     (event) => {
       lastPointerX = event.clientX;
       lastPointerY = event.clientY;
+      scheduleNativePreviewPlaybackFallback();
       if (!isRecommendedHoverGrowEnabled(getSettings())) return;
 
       const card = getHoverCard(event.target);
@@ -665,6 +732,7 @@ export function bindGridHoverHandlers(getSettings: () => Settings): void {
     (event) => {
       lastPointerX = event.clientX;
       lastPointerY = event.clientY;
+      scheduleNativePreviewPlaybackFallback();
       if (!isRecommendedHoverGrowEnabled(getSettings())) return;
 
       const card = activeHoverCard ?? getHoverCard(event.target);
@@ -685,6 +753,7 @@ export function bindGridHoverHandlers(getSettings: () => Settings): void {
     (event) => {
       lastPointerX = event.clientX;
       lastPointerY = event.clientY;
+      clearNativePreviewPlayTimer();
       const card = activeHoverCard;
       if (!card) return;
       if (event.relatedTarget instanceof Node && card.contains(event.relatedTarget)) {

--- a/src/content/lifecycle.ts
+++ b/src/content/lifecycle.ts
@@ -256,18 +256,28 @@ export function bindPlayerSurfaceClickFallback(): void {
       if (!video) return;
 
       const wasPaused = video.paused;
-      window.setTimeout(() => {
+      const applyFallbackIfUnchanged = (): boolean => {
         const currentVideo = getVideo();
-        if (!currentVideo || !document.body.contains(currentVideo) || currentVideo.paused !== wasPaused) return;
+        if (!currentVideo || !document.body.contains(currentVideo)) return true;
+        if (currentVideo.paused !== wasPaused) return false;
 
         if (wasPaused) {
           void currentVideo.play().catch((error) => {
             console.warn('Simple YT Tweaks player click fallback failed:', error);
           });
-          return;
+          return true;
         }
 
         currentVideo.pause();
+        return true;
+      };
+
+      window.setTimeout(() => {
+        if (applyFallbackIfUnchanged()) return;
+
+        window.setTimeout(() => {
+          applyFallbackIfUnchanged();
+        }, 340);
       }, 180);
     },
     { capture: true, passive: true },

--- a/src/content/sidebar.ts
+++ b/src/content/sidebar.ts
@@ -1,4 +1,4 @@
-import { query, queryAll, getElementLabel, elementMatchesAnyLabel, labelMatchesEntry, isDedicatedShortsPage, isVisibleNode } from './dom';
+import { query, queryAll, getElementLabel, elementMatchesAnyLabel, labelMatchesEntry, isDedicatedShortsPage } from './dom';
 import {
   GENERAL_HIDDEN_CLASS,
   SIDEBAR_HOME_NEUTRAL_CLASS,
@@ -33,6 +33,28 @@ const HOME_SPONSORED_CONTAINER_CSS_SELECTOR = [
   `body.simple-yt-tweaks-active ytd-browse[page-subtype="home"] ytd-rich-grid-renderer ${selector}:has(${HOME_SPONSORED_ITEM_SELECTORS})`,
 ).join(',\n    ');
 
+function scheduleDeferredHomeFeedCleanup(): void {
+  if (state.homeFeedCleanupTimer !== null) return;
+
+  const delay = Math.max(80, state.homeFeedCleanupDeferredUntil - Date.now() + 40);
+  state.homeFeedCleanupTimer = window.setTimeout(() => {
+    state.homeFeedCleanupTimer = null;
+    state.domRerun?.();
+  }, delay);
+}
+
+function isHomeFeedCleanupDeferred(): boolean {
+  if (location.pathname !== '/') return false;
+  return Date.now() < state.homeFeedCleanupDeferredUntil;
+}
+
+function shouldDeferHomeFeedCleanup(): boolean {
+  if (!isHomeFeedCleanupDeferred()) return false;
+
+  scheduleDeferredHomeFeedCleanup();
+  return true;
+}
+
 export function buildGeneralCss(settings: Settings): string {
   const generalHideEndScreenCards = settings.generalHideEndScreenCards;
   const generalFeedColumns = settings.generalFeedColumns;
@@ -57,7 +79,7 @@ export function buildGeneralCss(settings: Settings): string {
       display: none !important;
     }
 
-    ${generalHideSponsoredPosts ? `
+    ${generalHideSponsoredPosts && !isHomeFeedCleanupDeferred() ? `
     ${HOME_SPONSORED_CONTAINER_CSS_SELECTOR} {
       display: none !important;
     }
@@ -263,6 +285,7 @@ function isSponsoredHomeFeedItem(item: HTMLElement): boolean {
 
 function removeSponsoredHomeFeedItems(): void {
   if (!state.settings.generalHideSponsoredPosts) return;
+  if (shouldDeferHomeFeedCleanup()) return;
 
   for (const item of queryAll<HTMLElement>(
     'ytd-browse[page-subtype="home"] ytd-rich-grid-renderer #contents ytd-rich-item-renderer',
@@ -431,11 +454,14 @@ export function updateSidebarSectionPolish(): void {
 
 export function updateSponsoredVisibility(): void {
   if (!state.settings.generalHideSponsoredPosts) return;
+  const deferHomeFeedCleanup = shouldDeferHomeFeedCleanup();
 
   for (const target of queryAll<HTMLElement>(SPONSORED_CARD_SELECTORS.join(','))) {
     const onHomeFeed = Boolean(target.closest('ytd-browse[page-subtype="home"]'));
 
     if (onHomeFeed) {
+      if (deferHomeFeedCleanup) continue;
+
       removeClosestTag(target, [
         'ytd-rich-item-renderer',
         'ytd-rich-section-renderer',
@@ -581,6 +607,7 @@ export function updateShortsVisibility(): void {
 export function normalizeHomeFeedLayout(): void {
   const homeFeed = query<HTMLElement>('ytd-browse[page-subtype="home"] ytd-rich-grid-renderer #contents');
   if (!homeFeed) return;
+  if (shouldDeferHomeFeedCleanup()) return;
 
   for (const container of queryAll<HTMLElement>('ytd-rich-section-renderer, ytd-feed-nudge-renderer', homeFeed)) {
     if (
@@ -597,22 +624,6 @@ export function normalizeHomeFeedLayout(): void {
       (state.settings.generalHideSponsoredPosts && isSponsoredHomeFeedItem(item))
     ) {
       item.remove();
-      continue;
-    }
-
-    const hasVisibleChild = Array.from(item.children).some(
-      (child) => child instanceof HTMLElement && isVisibleNode(child),
-    );
-
-    if (!hasVisibleChild) {
-      item.remove();
-    }
-  }
-
-  for (const row of queryAll<HTMLElement>('ytd-rich-grid-row', homeFeed)) {
-    const visibleItems = queryAll<HTMLElement>('ytd-rich-item-renderer', row).filter(isVisibleNode);
-    if (visibleItems.length === 0) {
-      row.remove();
     }
   }
 }

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -23,6 +23,8 @@ export type ContentState = {
   lastPointerY: number;
   lastEnhancedTheaterActive: boolean;
   modeTransitionTimers: number[];
+  homeFeedCleanupDeferredUntil: number;
+  homeFeedCleanupTimer: number | null;
 };
 
 export const state: ContentState = {
@@ -41,4 +43,6 @@ export const state: ContentState = {
   lastPointerY: Number.POSITIVE_INFINITY,
   lastEnhancedTheaterActive: false,
   modeTransitionTimers: [],
+  homeFeedCleanupDeferredUntil: 0,
+  homeFeedCleanupTimer: null,
 };

--- a/tests/e2e/extension.fixture.spec.ts
+++ b/tests/e2e/extension.fixture.spec.ts
@@ -5,6 +5,7 @@ import { routeYouTubeFixture } from './youtube-fixtures';
 declare global {
   interface Window {
     __simpleYtTweaksPlaybackEvents?: string[];
+    __simpleYtTweaksSimulateTransientClick?: boolean;
   }
 }
 
@@ -42,7 +43,7 @@ async function writeExtensionSettings(
 }
 
 async function setupPlaybackProbe(page: Page): Promise<void> {
-  await page.locator('video.html5-main-video').evaluate(async (video) => {
+  await page.locator('#movie_player video.html5-main-video').evaluate(async (video) => {
     window.__simpleYtTweaksPlaybackEvents = [];
 
     const canvas = document.createElement('canvas');
@@ -82,9 +83,11 @@ test('home fixture uses native feed layout while cleanup stays active', async ({
   const grid = page.locator('ytd-browse[page-subtype="home"] ytd-rich-grid-renderer');
   await expect(grid).toHaveCSS('--ytd-rich-grid-items-per-row', '3');
   await expect(page.locator('[data-testid="sponsored"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="home-spa-placeholder"]')).toHaveCount(1);
+  await expect(page.locator('[data-testid="home-spa-placeholder"]')).toBeHidden();
   await expect(page.locator('[data-testid="shorts-card"]')).toBeHidden();
   await expect(page.locator('[data-testid="shorts-shelf"]')).toBeHidden();
-  await expect(page.locator('ytd-rich-item-renderer')).toHaveCount(4);
+  await expect(page.locator('ytd-rich-item-renderer')).toHaveCount(5);
 
   const injectedCss = await page.locator('#simple-yt-tweaks-style').textContent();
   expect(injectedCss).not.toContain('ytd-video-preview');
@@ -93,6 +96,29 @@ test('home fixture uses native feed layout while cleanup stays active', async ({
   await expect(page.locator('[data-testid="video-with-preview"]')).not.toHaveClass(
     /simple-yt-tweaks-grid-hover-ready/,
   );
+  expect(extensionErrors(errors)).toEqual([]);
+});
+
+test('home fixture defers destructive cleanup briefly after watch-to-home navigation', async ({ context }) => {
+  const page = await context.newPage();
+  const errors = await openFixture(page, 'home', 'https://www.youtube.com/');
+
+  await page.evaluate(() => {
+    history.pushState({}, '', '/watch?v=fixture');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  });
+  await page.waitForTimeout(220);
+  await page.evaluate(() => {
+    const sponsored = document.createElement('ytd-rich-item-renderer');
+    sponsored.setAttribute('data-testid', 'deferred-sponsored');
+    sponsored.innerHTML = '<ad-badge-view-model>Sponsored</ad-badge-view-model><a href="https://googleadservices.com/pagead/aclk">Deferred sponsored card</a>';
+    document.querySelector('ytd-browse[page-subtype="home"] ytd-rich-grid-renderer #contents')?.prepend(sponsored);
+    history.pushState({}, '', '/');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  });
+
+  await expect(page.locator('[data-testid="deferred-sponsored"]')).toHaveCount(1);
+  await expect(page.locator('[data-testid="deferred-sponsored"]')).toHaveCount(0, { timeout: 3_000 });
   expect(extensionErrors(errors)).toEqual([]);
 });
 
@@ -140,7 +166,7 @@ test('watch fixture validates mode classes, visible comments, hover grow, and vi
   const page = await context.newPage();
   const errors = await openFixture(page, 'watch', 'https://www.youtube.com/watch?v=fixture');
 
-  const videoSurface = page.locator('video.html5-main-video');
+  const videoSurface = page.locator('#movie_player video.html5-main-video');
   await setupPlaybackProbe(page);
   await expect(page.locator('body')).toHaveClass(/simple-yt-tweaks-default-view/);
   await expect(page.locator('#comments')).toBeVisible();
@@ -155,6 +181,11 @@ test('watch fixture validates mode classes, visible comments, hover grow, and vi
     timeout: 1_500,
   });
 
+  const modernRecommendedCard = page.locator('[data-testid="modern-recommended-card"]');
+  await modernRecommendedCard.locator('yt-thumbnail-view-model').hover();
+  await expect(modernRecommendedCard).not.toHaveClass(/simple-yt-tweaks-grid-hover-ready/, { timeout: 250 });
+  await expect(modernRecommendedCard).toHaveClass(/simple-yt-tweaks-grid-hover-ready/, { timeout: 1_500 });
+
   await videoSurface.click({ position: { x: 120, y: 120 } });
   await expect.poll(() => page.evaluate(() => window.__simpleYtTweaksPlaybackEvents ?? [])).toContainEqual('play');
   await videoSurface.click({ position: { x: 120, y: 120 } });
@@ -166,7 +197,7 @@ test('watch fixture validates mode classes, visible comments, hover grow, and vi
   await expect(page.locator('body')).toHaveClass(/simple-yt-tweaks-theater/);
   await expect(page.locator('#comments')).toBeVisible();
 
-  const playerPointerEvents = await page.locator('video.html5-main-video').evaluate((video) => getComputedStyle(video).pointerEvents);
+  const playerPointerEvents = await page.locator('#movie_player video.html5-main-video').evaluate((video) => getComputedStyle(video).pointerEvents);
   expect(playerPointerEvents).toBe('auto');
   expect(extensionErrors(errors)).toEqual([]);
 });
@@ -207,9 +238,41 @@ test('player click fallback ignores controls and modified video clicks', async (
   await page.waitForTimeout(260);
   expect(await playbackEvents(page)).toEqual([]);
 
-  await page.locator('video.html5-main-video').click({ modifiers: ['Shift'], position: { x: 120, y: 120 } });
+  await page.locator('#movie_player video.html5-main-video').click({ modifiers: ['Shift'], position: { x: 120, y: 120 } });
   await page.waitForTimeout(260);
   expect(await playbackEvents(page)).toEqual([]);
+  expect(extensionErrors(errors)).toEqual([]);
+});
+
+test('player click fallback corrects transient native no-op clicks', async ({ context }) => {
+  const page = await context.newPage();
+  const errors = await openFixture(page, 'watch', 'https://www.youtube.com/watch?v=fixture');
+
+  const videoSurface = page.locator('#movie_player video.html5-main-video');
+  await setupPlaybackProbe(page);
+  await videoSurface.click({ position: { x: 120, y: 120 } });
+  await expect.poll(() => playbackEvents(page)).toContainEqual('play');
+
+  await videoSurface.evaluate((video) => {
+    window.__simpleYtTweaksPlaybackEvents = [];
+    window.__simpleYtTweaksSimulateTransientClick = true;
+    document.querySelector('#movie_player')?.addEventListener(
+      'click',
+      () => {
+        if (!window.__simpleYtTweaksSimulateTransientClick) return;
+        window.__simpleYtTweaksSimulateTransientClick = false;
+        video.pause();
+        window.setTimeout(() => {
+          void video.play();
+        }, 260);
+      },
+      { capture: true },
+    );
+  });
+
+  await videoSurface.click({ position: { x: 120, y: 120 } });
+  await expect.poll(() => playbackEvents(page), { timeout: 1_500 }).toEqual(['pause', 'play', 'pause']);
+  await expect.poll(() => videoSurface.evaluate((video) => video.paused)).toBe(true);
   expect(extensionErrors(errors)).toEqual([]);
 });
 

--- a/tests/e2e/youtube-fixtures.ts
+++ b/tests/e2e/youtube-fixtures.ts
@@ -81,6 +81,7 @@ function homeFixture(): string {
                 <ad-badge-view-model>Sponsored</ad-badge-view-model>
                 <a href="https://googleadservices.com/pagead/aclk">Sponsored card</a>
               </ytd-rich-item-renderer>
+              <ytd-rich-item-renderer data-testid="home-spa-placeholder" items-per-row="3" hidden></ytd-rich-item-renderer>
               <ytd-rich-item-renderer data-testid="video-2" items-per-row="3">
                 <a class="ytLockupViewModelContentImage" href="/watch?v=home-2">
                   <yt-thumbnail-view-model></yt-thumbnail-view-model>
@@ -207,6 +208,13 @@ function watchFixture(): string {
     'YouTube Fixture Watch',
     `
       <ytd-app>
+        <div id="video-preview">
+          <ytd-video-preview>
+            <div id="inline-preview-player">
+              <video class="html5-main-video" data-testid="stale-preview-video"></video>
+            </div>
+          </ytd-video-preview>
+        </div>
         <ytd-watch-flexy>
           <div id="columns">
             <div id="primary">
@@ -254,6 +262,19 @@ function watchFixture(): string {
                   </div>
                 </ytd-compact-video-renderer>
               </div>
+              <yt-lockup-view-model class="lockup ytLockupViewModelWrapper" data-testid="modern-recommended-card">
+                <a class="ytLockupViewModelContentImage" href="/watch?v=modern-recommended-1">
+                  <yt-thumbnail-view-model>
+                    <div class="ytThumbnailViewModelHost">Modern recommended thumbnail</div>
+                  </yt-thumbnail-view-model>
+                  <thumbnail-overlay-button-view-model>
+                    <button type="button">
+                      <span class="ytIconWrapperHost">Queue</span>
+                    </button>
+                  </thumbnail-overlay-button-view-model>
+                </a>
+                <a class="ytLockupMetadataViewModelTitle" href="/watch?v=modern-recommended-1">Modern recommended title</a>
+              </yt-lockup-view-model>
             </div>
           </div>
         </ytd-watch-flexy>


### PR DESCRIPTION
## Summary
- fixes #21 by preserving YouTube native Home/Search hover previews after watch-to-Home SPA navigation
- defers destructive Home feed cleanup briefly after SPA navigation and stops removing arbitrary empty Home grid placeholders
- resumes only an already-mounted native feed preview video under the pointer when YouTube leaves it paused
- prefers the real `#movie_player` video over stale native preview videos for watch-page helpers
- hardens player click fallback timing for transient native no-op clicks
- expands recommendation hover-grow support to current live `#secondary yt-lockup-view-model` cards
- adds fixture coverage for the SPA cleanup window, modern recommendation cards, and transient click fallback
- compacts completed swarm handoffs into short stubs with `docs/swarm/context-map.md` and `docs/swarm/archive/README.md` reference mapping

Fixes #21.

## How to test / what to tell the controller
Human review requested: yes. This is live YouTube SPA/player behavior.

Commands run locally:
- `npm run test:e2e`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm run validate:all`

Expected automated result:
- all commands pass
- `validate:all` packages and validates `release/simple-yt-tweaks-v0.3.0.zip` without changing the version
- fixture tests include 10 passing extension tests

Signed-in Chrome smoke already performed:
- watch page -> browser Back to Home -> hover first visible Home cards: native preview videos played and advanced, with no old enhanced Home/Search hover classes
- Search page: grid active, visible Shorts count 0, native preview played/advanced
- Watch page: comments visible in Default mode
- Watch player: real CoreGraphics click toggled pause and a second click resumed playback
- Sidebar recommendations: current live `#secondary yt-lockup-view-model` cards do not grow at 250ms and do grow after the intentional delay

Human QA checklist before merge:
1. Load the PR branch/unpacked `dist/` in Chrome or Brave.
2. Open YouTube Home, open a video, navigate back to Home, hover multiple Home cards including the first visible card.
3. Confirm native previews autoplay with no extension grow/highlight/flicker.
4. Search YouTube and confirm results still hide Shorts shelves and use native preview only.
5. On a watch page, confirm comments are visible when Hide Comments is unchecked.
6. Click the video surface in Default and Theater modes and confirm play/pause toggles.
7. Hover sidebar/recommended cards and confirm hover grow waits briefly and then applies.

Tell the controller exactly one of:
- `Human QA passed for SYT-021 / PR <url>: <browser/version, notes>`
- `Human QA failed for SYT-021 / PR <url>: <steps and observed problem>`

No version bump, tag, release, or Web Store asset update is included.