### PR TITLE
Codex: Harden grid hover selector scoping

### DIFF
--- a/docs/swarm/handoffs/SYT-010E.md
+++ b/docs/swarm/handoffs/SYT-010E.md
@@ -2,15 +2,24 @@
 
 ## Status
 
-- State: Ready after PR #22 review/integration state is clear
+- State: Needs Review
 - GitHub issue: #10
-- Branch: TBD, use `swarm/syt-010e-<short-slug>`
-- Role: Planner or Senior Runner
-- Updated: 2026-06-10
+- Branch: `swarm/syt-010e-code-hardening`
+- PR: pending publish
+- Role: Senior Runner
+- Updated: 2026-06-10 by Senior Runner
 
 ## Goal
 
 Continue post-v0.3.0 hardening without broad rewrites. Use fixture and unit coverage as the gate, and only refactor where it reduces real regression risk.
+
+## Chosen Target
+
+Narrow behavior-preserving selector normalization in `src/content/grid-hover.ts`:
+
+- Centralized the watch recommendation hover-grow card/media/overlay selector variants used by `buildSidebarHoverCss`.
+- Kept the legacy `ytd-compact-video-renderer` and modern `yt-lockup-view-model` selectors emitted for default and theater watch modes.
+- Added unit coverage that asserts enabled-mode scoping and disabled-mode omission for the generated grid hover CSS.
 
 ## Scope
 
@@ -40,15 +49,34 @@ Continue post-v0.3.0 hardening without broad rewrites. Use fixture and unit cove
 
 ## Suggested First Pass
 
-1. Review PR #22 outcome and any reviewer/user QA notes.
-2. Run `npm run validate:all` on the current baseline.
-3. Choose one hardening target with a bounded write scope.
-4. Add/adjust fixture or unit coverage for that target.
-5. Implement the smallest behavior-preserving cleanup.
-6. Open a draft PR with `How to test / what to tell the controller`.
+Completed:
+
+1. Reviewed hot swarm state after PR #22 integration.
+2. Audited the requested high-risk modules by function outline and sampled relevant source/test sections.
+3. Chose one bounded target: grid hover watch recommendation selector normalization.
+4. Added unit coverage before/alongside the cleanup.
+5. Ran focused checks and the full validation gate.
+
+## Files Touched
+
+- `src/content/grid-hover.ts`
+- `tests/unit/grid-hover.unit.spec.ts`
+- `docs/swarm/handoffs/SYT-010E.md`
 
 ## Verification
 
-- Focused checks for the chosen scope.
-- Always run `npm run validate:all` before integration.
-- Use signed-in Chrome live smoke only when the target touches live-only YouTube behavior.
+- Focused: `npm run test:unit` - passed, 10 tests.
+- Focused: `npm run test:e2e` - passed, 10 fixture tests.
+- Full gate: `npm run validate:all` - passed, including typecheck, lint, `git diff --check`, package validation, unit tests, and fixture tests.
+- Live Chrome/YouTube smoke not used; this target is selector/CSS generation cleanup with fixture coverage.
+
+## Risks
+
+- Low/medium residual risk: the selector normalization still touches watch recommendation hover CSS assembly, but the emitted legacy and modern selector families are covered by unit assertions and fixture watch hover tests.
+- No settings defaults changed.
+- #8 enhanced Home/Search hover grow was not reintroduced.
+- No version, release, tag, or Web Store asset changes.
+
+## Next Recommended Role
+
+Reviewer: review `src/content/grid-hover.ts` selector normalization, `tests/unit/grid-hover.unit.spec.ts` coverage, PR body test instructions, and confirm `Needs Review` can move to `Ready to Integrate`.

--- a/docs/swarm/handoffs/SYT-010E.md
+++ b/docs/swarm/handoffs/SYT-010E.md
@@ -5,7 +5,7 @@
 - State: Needs Review
 - GitHub issue: #10
 - Branch: `swarm/syt-010e-code-hardening`
-- PR: pending publish
+- PR: #24, https://github.com/cryptoteatime/simple-yt-tweaks/pull/24
 - Role: Senior Runner
 - Updated: 2026-06-10 by Senior Runner
 

--- a/src/content/grid-hover.ts
+++ b/src/content/grid-hover.ts
@@ -31,6 +31,44 @@ const SIDEBAR_CARD_SELECTOR = [
 const SEARCH_GRID_CONTENTS_SELECTOR =
   'ytd-search ytd-two-column-search-results-renderer #primary ytd-section-list-renderer > #contents.ytd-section-list-renderer';
 const HOVER_CARD_SELECTOR = SIDEBAR_CARD_SELECTOR;
+const LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR = 'ytd-compact-video-renderer';
+const MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS = [
+  '#related yt-lockup-view-model:has(a[href*="/watch"])',
+  'ytd-watch-next-secondary-results-renderer yt-lockup-view-model:has(a[href*="/watch"])',
+  '#secondary yt-lockup-view-model:has(a[href*="/watch"])',
+];
+const WATCH_RECOMMENDATION_CARD_SELECTORS = [
+  LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR,
+  ...MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS,
+];
+function addGridHoverReadyClass(selector: string): string {
+  if (selector === LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR) {
+    return `${LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR}.${GRID_HOVER_READY_CLASS}`;
+  }
+
+  return selector.replace('yt-lockup-view-model', `yt-lockup-view-model.${GRID_HOVER_READY_CLASS}`);
+}
+const READY_WATCH_RECOMMENDATION_CARD_SELECTORS =
+  WATCH_RECOMMENDATION_CARD_SELECTORS.map(addGridHoverReadyClass);
+const WATCH_RECOMMENDATION_MEDIA_SELECTORS = [
+  `${LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR} ytd-thumbnail`,
+  ...MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS.map((selector) => `${selector} yt-thumbnail-view-model`),
+];
+const READY_WATCH_RECOMMENDATION_MEDIA_SELECTORS = [
+  `${addGridHoverReadyClass(LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR)} ytd-thumbnail`,
+  ...MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS.map(
+    (selector) => `${addGridHoverReadyClass(selector)} yt-thumbnail-view-model`,
+  ),
+];
+const WATCH_RECOMMENDATION_OVERLAY_BUTTON_SELECTORS = [
+  ...MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS.map(
+    (selector) => `${addGridHoverReadyClass(selector)} thumbnail-overlay-button-view-model`,
+  ),
+  `${addGridHoverReadyClass(LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR)} ytd-thumbnail-overlay-toggle-button-renderer`,
+];
+function appendDescendant(selectors: string[], descendant: string): string[] {
+  return selectors.map((selector) => `${selector} ${descendant}`);
+}
 const HOVER_MEDIA_SELECTOR = [
   '#related ytd-compact-video-renderer ytd-thumbnail',
   'ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer ytd-thumbnail',
@@ -321,48 +359,16 @@ function buildSidebarHoverCss(settings: Settings): string {
 
   if (!scopes.length) return '';
 
-  const cards = scopedSelectors(scopes, [
-    'ytd-compact-video-renderer',
-    '#related yt-lockup-view-model:has(a[href*="/watch"])',
-    'ytd-watch-next-secondary-results-renderer yt-lockup-view-model:has(a[href*="/watch"])',
-    '#secondary yt-lockup-view-model:has(a[href*="/watch"])',
-  ]);
-  const media = scopedSelectors(scopes, [
-    'ytd-compact-video-renderer ytd-thumbnail',
-    '#related yt-lockup-view-model:has(a[href*="/watch"]) yt-thumbnail-view-model',
-    'ytd-watch-next-secondary-results-renderer yt-lockup-view-model:has(a[href*="/watch"]) yt-thumbnail-view-model',
-    '#secondary yt-lockup-view-model:has(a[href*="/watch"]) yt-thumbnail-view-model',
-  ]);
-  const readyMedia = scopedSelectors(scopes, [
-    `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS} ytd-thumbnail`,
-    `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) yt-thumbnail-view-model`,
-    `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) yt-thumbnail-view-model`,
-    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) yt-thumbnail-view-model`,
-  ]);
-  const readyCards = scopedSelectors(scopes, [
-    `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS}`,
-    `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"])`,
-    `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"])`,
-    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"])`,
-  ]);
-  const overlayButtons = scopedSelectors(scopes, [
-    `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model`,
-    `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model`,
-    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model`,
-    `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS} ytd-thumbnail-overlay-toggle-button-renderer`,
-  ]);
-  const overlayButtonElements = scopedSelectors(scopes, [
-    `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button`,
-    `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button`,
-    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button`,
-    `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS} ytd-thumbnail-overlay-toggle-button-renderer button`,
-  ]);
-  const overlayButtonIcons = scopedSelectors(scopes, [
-    `#related yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button .ytIconWrapperHost`,
-    `ytd-watch-next-secondary-results-renderer yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button .ytIconWrapperHost`,
-    `#secondary yt-lockup-view-model.${GRID_HOVER_READY_CLASS}:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button .ytIconWrapperHost`,
-    `ytd-compact-video-renderer.${GRID_HOVER_READY_CLASS} ytd-thumbnail-overlay-toggle-button-renderer button .ytIconWrapperHost`,
-  ]);
+  const cards = scopedSelectors(scopes, WATCH_RECOMMENDATION_CARD_SELECTORS);
+  const media = scopedSelectors(scopes, WATCH_RECOMMENDATION_MEDIA_SELECTORS);
+  const readyMedia = scopedSelectors(scopes, READY_WATCH_RECOMMENDATION_MEDIA_SELECTORS);
+  const readyCards = scopedSelectors(scopes, READY_WATCH_RECOMMENDATION_CARD_SELECTORS);
+  const overlayButtons = scopedSelectors(scopes, WATCH_RECOMMENDATION_OVERLAY_BUTTON_SELECTORS);
+  const overlayButtonElements = scopedSelectors(scopes, appendDescendant(WATCH_RECOMMENDATION_OVERLAY_BUTTON_SELECTORS, 'button'));
+  const overlayButtonIcons = scopedSelectors(
+    scopes,
+    appendDescendant(WATCH_RECOMMENDATION_OVERLAY_BUTTON_SELECTORS, 'button .ytIconWrapperHost'),
+  );
 
   return `
     ${cards} {

--- a/tests/unit/grid-hover.unit.spec.ts
+++ b/tests/unit/grid-hover.unit.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+
+import { buildGridHoverCss } from '../../src/content/grid-hover';
+import { DEFAULT_SETTINGS } from '../../src/content/settings';
+import type { Settings } from '../../src/content/settings';
+
+function settings(overrides: Partial<Settings>): Settings {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...overrides,
+  };
+}
+
+test('grid hover CSS scopes watch recommendation selectors to enabled modes', () => {
+  const css = buildGridHoverCss(settings({
+    generalApplyFeedColumnsToSearch: false,
+    defaultRecommendedHoverGrow: true,
+    theaterRecommendedHoverGrow: true,
+  }));
+
+  expect(css).toContain('body.simple-yt-tweaks-active.simple-yt-tweaks-default-view ytd-compact-video-renderer');
+  expect(css).toContain('body.simple-yt-tweaks-active.simple-yt-tweaks-theater ytd-compact-video-renderer');
+  expect(css).toContain(
+    'body.simple-yt-tweaks-active.simple-yt-tweaks-default-view #secondary yt-lockup-view-model:has(a[href*="/watch"]) yt-thumbnail-view-model',
+  );
+  expect(css).toContain(
+    'body.simple-yt-tweaks-active.simple-yt-tweaks-theater #related yt-lockup-view-model.simple-yt-tweaks-grid-hover-ready:has(a[href*="/watch"]) thumbnail-overlay-button-view-model button .ytIconWrapperHost',
+  );
+});
+
+test('grid hover CSS omits disabled watch recommendation hover scopes', () => {
+  const theaterOnlyCss = buildGridHoverCss(settings({
+    generalApplyFeedColumnsToSearch: false,
+    defaultRecommendedHoverGrow: false,
+    theaterRecommendedHoverGrow: true,
+  }));
+
+  expect(theaterOnlyCss).not.toContain('body.simple-yt-tweaks-active.simple-yt-tweaks-default-view');
+  expect(theaterOnlyCss).toContain('body.simple-yt-tweaks-active.simple-yt-tweaks-theater ytd-compact-video-renderer');
+
+  const disabledCss = buildGridHoverCss(settings({
+    generalApplyFeedColumnsToSearch: false,
+    defaultRecommendedHoverGrow: false,
+    theaterRecommendedHoverGrow: false,
+  }));
+
+  expect(disabledCss).not.toContain('simple-yt-tweaks-grid-hover-ready');
+  expect(disabledCss).not.toContain('ytd-compact-video-renderer');
+});


### PR DESCRIPTION
## Summary

- Centralizes the watch recommendation hover-grow selector variants in `src/content/grid-hover.ts`.
- Adds unit coverage for generated grid hover CSS scoping across default/theater watch modes and disabled settings.
- Keeps the change behavior-preserving and fixture-first for GitHub issue #10.

## How to test / what to tell the controller

Human review requested: no

Commands run:

```bash
npm run test:unit
npm run test:e2e
npm run validate:all
```

Expected result: all commands pass. `validate:all` should complete typecheck, lint, `git diff --check`, extension packaging/validation, unit tests, and fixture e2e tests.

Controller feedback format: `SYT-010E review: <Ready to Integrate|Needs Fixes|Blocked> - <notes>`.

Refs #10.