### PR TITLE
Codex: Plan SYT-010F sticky player hardening

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019eb128-3fca-7111-bbb2-152f11a8747c` / McClintock | `SYT-010F` | Reviewer | In Progress | `swarm/syt-010f-planning` | main worktree | #26 | 2026-06-10 06:48 EDT | 2026-06-10 06:48 EDT | Review PR #26 and report `Ready to Integrate`, `Needs Fixes`, or `Blocked`. | none |
 
 ## Paused / Stale Agents
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -59,6 +59,7 @@ Use this file to track who is working, where they are working, and whether the c
 | `019eb0f1-9608-74f3-af18-2f13569896b5` / Euler | `SYT-010E` | Senior Runner | Opened draft PR #24 | 2026-06-10 05:52 EDT | Narrow grid-hover selector normalization; `npm run test:unit`, `npm run test:e2e`, and `npm run validate:all` passed; issue #10 commented. |
 | `019eb0fc-5137-71b1-ad83-a22a768775ed` / Hilbert | `SYT-010E` | Reviewer | Ready to Integrate | 2026-06-10 05:55 EDT | No findings; `git diff --check origin/main...HEAD` and `npm run test:unit` passed; human QA not required; PR #24 still draft. |
 | `019eb100-fe46-7bc3-b8a5-9c5f563a73b1` / Ramanujan | `SYT-010E` | Integrator | Merged PR #24 | 2026-06-10 06:13 EDT | `npm run validate:all` passed; PR #24 marked ready and squash-merged into `main` at `fae4e5d`; issue #10 remains open; remote/local task branch cleanup completed. |
+| `019eb10d-7fef-7c52-916f-0245bf25d828` / Dalton | `SYT-010F` | Planner | Needs Review | 2026-06-10 06:40 EDT | Chose Sticky Player hardening, created Runner-ready handoff, and opened draft PR #26 for review; #8 remains paused. |
 
 ## Pending Launch
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -21,7 +21,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019eb128-3fca-7111-bbb2-152f11a8747c` / McClintock | `SYT-010F` | Reviewer | In Progress | `swarm/syt-010f-planning` | main worktree | #26 | 2026-06-10 06:48 EDT | 2026-06-10 06:48 EDT | Review PR #26 and report `Ready to Integrate`, `Needs Fixes`, or `Blocked`. | none |
+| `019eb12d-5860-7852-8447-17dfb4db7cc3` / Faraday | `SYT-010F` | Integrator | In Progress | `swarm/syt-010f-planning` | main worktree | #26 | 2026-06-10 06:50 EDT | 2026-06-10 06:50 EDT | Mark PR #26 ready, merge if safe, clean branch, and record integration. | none |
 
 ## Paused / Stale Agents
 
@@ -60,6 +60,7 @@ Use this file to track who is working, where they are working, and whether the c
 | `019eb0fc-5137-71b1-ad83-a22a768775ed` / Hilbert | `SYT-010E` | Reviewer | Ready to Integrate | 2026-06-10 05:55 EDT | No findings; `git diff --check origin/main...HEAD` and `npm run test:unit` passed; human QA not required; PR #24 still draft. |
 | `019eb100-fe46-7bc3-b8a5-9c5f563a73b1` / Ramanujan | `SYT-010E` | Integrator | Merged PR #24 | 2026-06-10 06:13 EDT | `npm run validate:all` passed; PR #24 marked ready and squash-merged into `main` at `fae4e5d`; issue #10 remains open; remote/local task branch cleanup completed. |
 | `019eb10d-7fef-7c52-916f-0245bf25d828` / Dalton | `SYT-010F` | Planner | Needs Review | 2026-06-10 06:40 EDT | Chose Sticky Player hardening, created Runner-ready handoff, and opened draft PR #26 for review; #8 remains paused. |
+| `019eb128-3fca-7111-bbb2-152f11a8747c` / McClintock | `SYT-010F` | Reviewer | Ready to Integrate | 2026-06-10 06:49 EDT | No findings; `git diff --check origin/main...HEAD` passed; human QA not required; PR #26 still draft. |
 
 ## Pending Launch
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,13 +4,13 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active implementation lane: none; `SYT-010F` planning is ready for review
+- Active implementation lane: `SYT-010F` planning review
 - Last integrated lane: `SYT-010E`
 - GitHub issue: #10 open
 - PR: #26 draft planning PR; #24 merged at `fae4e5d`
 - Branch: `swarm/syt-010f-planning`
-- Current status: `SYT-010F` Needs Review
-- Next priority lane: review/merge the planning docs, then route the Sticky Player Senior Runner
+- Current status: `SYT-010F` Review in progress
+- Next priority lane: wait for active PR #26 reviewer
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate
 
 ## Hot Files
@@ -39,9 +39,9 @@ Full prior handoff text is recoverable through Git history before the 2026-06-10
 
 ## Next Safe Controller Action
 
-Review the `SYT-010F` planning result, then route implementation:
+Wait for the active `SYT-010F` reviewer on PR #26:
 
-- Target `src/content/sticky-player.ts` with behavior-preserving visibility/resize helper coverage and one deterministic dock/restore fixture if feasible.
-- Spawn a Senior Runner on `swarm/syt-010f-sticky-player-hardening` after planning docs land.
+- Confirm the Sticky Player hardening handoff is bounded and Runner-ready.
+- After review/merge, spawn a Senior Runner on `swarm/syt-010f-sticky-player-hardening`.
 - Keep issue #10 open until the controller decides the overall hardening pass is complete.
 - Do not restart #8 enhanced hover research.

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -9,8 +9,8 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 - GitHub issue: #10 open
 - PR: #26 draft planning PR; #24 merged at `fae4e5d`
 - Branch: `swarm/syt-010f-planning`
-- Current status: `SYT-010F` Review in progress
-- Next priority lane: wait for active PR #26 reviewer
+- Current status: `SYT-010F` Integration in progress
+- Next priority lane: wait for active PR #26 Integrator
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate
 
 ## Hot Files
@@ -39,9 +39,9 @@ Full prior handoff text is recoverable through Git history before the 2026-06-10
 
 ## Next Safe Controller Action
 
-Wait for the active `SYT-010F` reviewer on PR #26:
+Wait for the active `SYT-010F` Integrator on PR #26:
 
-- Confirm the Sticky Player hardening handoff is bounded and Runner-ready.
-- After review/merge, spawn a Senior Runner on `swarm/syt-010f-sticky-player-hardening`.
+- Mark the draft planning PR ready and merge if safe.
+- After merge, spawn a Senior Runner on `swarm/syt-010f-sticky-player-hardening`.
 - Keep issue #10 open until the controller decides the overall hardening pass is complete.
 - Do not restart #8 enhanced hover research.

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,13 +4,13 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active implementation lane: none
+- Active implementation lane: none; `SYT-010F` planning is ready for review
 - Last integrated lane: `SYT-010E`
 - GitHub issue: #10 open
-- PR: #24 merged at `fae4e5d`
-- Branch: `swarm/syt-010e-code-hardening` cleaned locally and remotely
-- Current status: `SYT-010E` Integrated
-- Next priority lane: plan/route the next small #10 hardening lane (`SYT-010F`) if issue #10 remains open
+- PR: #26 draft planning PR; #24 merged at `fae4e5d`
+- Branch: `swarm/syt-010f-planning`
+- Current status: `SYT-010F` Needs Review
+- Next priority lane: review/merge the planning docs, then route the Sticky Player Senior Runner
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate
 
 ## Hot Files
@@ -20,7 +20,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 - Task queue: `docs/swarm/task-board.md`
 - Agent capacity: `docs/swarm/agent-registry.md`
 - GitHub policy/state: `docs/swarm/github.md`
-- Next handoff: `docs/swarm/handoffs/SYT-010E.md`
+- Next handoff: `docs/swarm/handoffs/SYT-010F.md`
 - User steering: `docs/swarm/user-feedback.md`
 
 ## Cold / Archived History
@@ -39,9 +39,9 @@ Full prior handoff text is recoverable through Git history before the 2026-06-10
 
 ## Next Safe Controller Action
 
-After this integration-record docs follow-up lands and the worktree is clean, plan or route one more small #10 hardening lane (`SYT-010F`):
+Review the `SYT-010F` planning result, then route implementation:
 
-- Pick one bounded target from the remaining high-risk modules; do not start a broad rewrite.
-- Preserve the `npm run validate:all` final gate.
+- Target `src/content/sticky-player.ts` with behavior-preserving visibility/resize helper coverage and one deterministic dock/restore fixture if feasible.
+- Spawn a Senior Runner on `swarm/syt-010f-sticky-player-hardening` after planning docs land.
 - Keep issue #10 open until the controller decides the overall hardening pass is complete.
 - Do not restart #8 enhanced hover research.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,9 +16,9 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010f-planning`
 - Expected Git state: clean `swarm/syt-010f-planning...origin/swarm/syt-010f-planning` after planner-route docs follow-up is pushed
 - Open PR expectation: draft PR #26 for `SYT-010F` planning until reviewed/merged
-- Active agents expectation: none after Planner reports final result
+- Active agents expectation: one Reviewer for `SYT-010F` / PR #26
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: review/merge `SYT-010F` planning, then route Sticky Player hardening while issue #10 remains open
+- Current priority lane: `SYT-010F` planning review in progress
 
 ## Controller Lease And Pacing
 
@@ -103,7 +103,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010F` | Review/merge planning docs, then spawn Sticky Player hardening Runner | Reviewer / Senior Runner | `swarm/syt-010f-planning`, then `swarm/syt-010f-sticky-player-hardening` | Planning docs reviewed/merged and Runner launched, or blocker recorded |
+| 1 | `SYT-010F` | Wait for active PR #26 Reviewer | Reviewer | `swarm/syt-010f-planning` | Reviewer result recorded |
 | 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
@@ -125,3 +125,4 @@ Heartbeat overlap rule:
 - 2026-06-10: PR #24 marked ready and squash-merged into `main` at `fae4e5d`; issue #10 remains open; remote/local task branch cleanup completed. Next safe action is `SYT-010F` planning/routing, not #8.
 - 2026-06-10: Controller routed `SYT-010F` to Planner Dalton on `swarm/syt-010f-planning`.
 - 2026-06-10: `SYT-010F` planning selected Sticky Player hardening: pure visibility/resize helper coverage plus one deterministic dock/restore fixture if feasible.
+- 2026-06-10: Controller routed `SYT-010F` planning PR #26 to Reviewer McClintock.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -16,9 +16,9 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Current branch: `swarm/syt-010f-planning`
 - Expected Git state: clean `swarm/syt-010f-planning...origin/swarm/syt-010f-planning` after planner-route docs follow-up is pushed
 - Open PR expectation: draft PR #26 for `SYT-010F` planning until reviewed/merged
-- Active agents expectation: one Reviewer for `SYT-010F` / PR #26
+- Active agents expectation: one Integrator for `SYT-010F` / PR #26
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010F` planning review in progress
+- Current priority lane: `SYT-010F` planning integration in progress
 
 ## Controller Lease And Pacing
 
@@ -103,7 +103,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010F` | Wait for active PR #26 Reviewer | Reviewer | `swarm/syt-010f-planning` | Reviewer result recorded |
+| 1 | `SYT-010F` | Wait for active PR #26 Integrator | Integrator | `swarm/syt-010f-planning` | Integration result recorded |
 | 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
@@ -126,3 +126,4 @@ Heartbeat overlap rule:
 - 2026-06-10: Controller routed `SYT-010F` to Planner Dalton on `swarm/syt-010f-planning`.
 - 2026-06-10: `SYT-010F` planning selected Sticky Player hardening: pure visibility/resize helper coverage plus one deterministic dock/restore fixture if feasible.
 - 2026-06-10: Controller routed `SYT-010F` planning PR #26 to Reviewer McClintock.
+- 2026-06-10: PR #26 review passed with no findings; human QA not required. Integrator Faraday is active.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,17 +8,17 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-06-10 06:13 EDT
+- Last reviewed by controller: 2026-06-10 06:18 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `main`
-- Expected Git state: clean `main...origin/main` after the `SYT-010E` integration-record docs follow-up lands
-- Open PR expectation: none after the `SYT-010E` integration-record docs follow-up lands
-- Active agents expectation: none
+- Current branch: `swarm/syt-010f-planning`
+- Expected Git state: clean `swarm/syt-010f-planning...origin/swarm/syt-010f-planning` after planner-route docs follow-up is pushed
+- Open PR expectation: draft PR #26 for `SYT-010F` planning until reviewed/merged
+- Active agents expectation: none after Planner reports final result
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010F` planning/routing for the next #10 code-hardening lane while issue #10 remains open
+- Current priority lane: review/merge `SYT-010F` planning, then route Sticky Player hardening while issue #10 remains open
 
 ## Controller Lease And Pacing
 
@@ -103,7 +103,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010F` | Plan and route the next small #10 code-hardening lane if issue #10 remains open | Planner / Senior Runner | TBD | Scoped hardening lane created with verification, or heartbeat slowed if no safe lane is ready |
+| 1 | `SYT-010F` | Review/merge planning docs, then spawn Sticky Player hardening Runner | Reviewer / Senior Runner | `swarm/syt-010f-planning`, then `swarm/syt-010f-sticky-player-hardening` | Planning docs reviewed/merged and Runner launched, or blocker recorded |
 | 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
@@ -123,3 +123,5 @@ Heartbeat overlap rule:
 - 2026-06-10: PR #22 squash-merged into `main` at `8f90ef1`; issue #21 auto-closed; remote/local task branch cleanup completed. Next lane is `SYT-010E`.
 - 2026-06-10: PR #24 review passed with no findings; human QA not required.
 - 2026-06-10: PR #24 marked ready and squash-merged into `main` at `fae4e5d`; issue #10 remains open; remote/local task branch cleanup completed. Next safe action is `SYT-010F` planning/routing, not #8.
+- 2026-06-10: Controller routed `SYT-010F` to Planner Dalton on `swarm/syt-010f-planning`.
+- 2026-06-10: `SYT-010F` planning selected Sticky Player hardening: pure visibility/resize helper coverage plus one deterministic dock/restore fixture if feasible.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,14 +4,14 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening; #21 and `SYT-010E` integrated
+- Status: existing repo, post-v0.3.0 hardening; #21 and `SYT-010E` integrated; `SYT-010F` planning selected Sticky Player hardening
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
 
 ## Project Brief
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; `SYT-010E` grid-hover selector hardening lane is integrated
+- Dispatch readiness: swarm packet integrated; `SYT-010F` Sticky Player implementation lane is ready after planning PR review/merge
 
 ## Goal
 
@@ -19,7 +19,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Current Focus
 
-1. Plan or route the next small #10 code-hardening lane (`SYT-010F`) while issue #10 remains open.
+1. Review/merge the `SYT-010F` planning PR, then route Sticky Player hardening while issue #10 remains open.
 2. Keep #10 hardening in small PRs with `validate:all` as the final gate.
 3. Keep #8 as a future high-risk research lane until tests and product direction justify it.
 4. Keep release-candidate work separate from routine fixture/source hardening.
@@ -54,7 +54,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-010E` is integrated via PR #24 at `fae4e5d`, and issue #10 remains open. The next useful milestone is one more small #10 code-hardening lane, tentatively `SYT-010F`, that preserves `validate:all` as the final gate and does not reopen #8 enhanced hover research.
+`SYT-010E` is integrated via PR #24 at `fae4e5d`, and issue #10 remains open. The next useful milestone is `SYT-010F`: Sticky Player visibility/resize helper hardening plus deterministic dock/restore fixture coverage where feasible.
 
 ## Verification Defaults
 
@@ -83,7 +83,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 - Execution strategy: paced controller with direct subagents only after lane readiness.
 - Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none after `SYT-010E` integration.
+- Active subagents: none expected after the `SYT-010F` planning PR is reviewed/merged.
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
@@ -91,4 +91,4 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 ## Last Updated
 
 - Date: 2026-06-10
-- By: Ramanujan, `SYT-010E` Integrator
+- By: Planner, `SYT-010F`

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `SYT-010F` | `swarm/syt-010f-planning` | #26 | Draft | Planner | Docs-only planning PR; human review requested no. |
 
 ## Setup Log
 
@@ -61,3 +61,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-06-10: Opened issue #21 for native Home/Search hover preview stall after watch-to-Home SPA navigation and modern `#secondary yt-lockup-view-model` recommendation selector drift. Opened draft PR #22 from `swarm/syt-008b-native-hover-spa-regression`.
 - 2026-06-10: PR #22 marked ready and squash-merged at `8f90ef1`; issue #21 auto-closed; remote/local task branch cleanup completed.
 - 2026-06-10: PR #24 marked ready and squash-merged at `fae4e5d` for `SYT-010E`; issue #10 remains open; remote/local task branch cleanup completed.
+- 2026-06-10: Opened draft PR #26 for docs-only `SYT-010F` planning; chosen target is Sticky Player hardening under issue #10.

--- a/docs/swarm/handoffs/SYT-010F.md
+++ b/docs/swarm/handoffs/SYT-010F.md
@@ -2,13 +2,13 @@
 
 ## Status
 
-- State: Needs Review; Ready for Runner after planning PR review/merge
+- State: In Progress; Ready for Runner after planning PR merge
 - GitHub issue: #10
 - Planning PR: #26, https://github.com/cryptoteatime/simple-yt-tweaks/pull/26
 - Planning branch: `swarm/syt-010f-planning`
 - Recommended implementation branch: `swarm/syt-010f-sticky-player-hardening`
-- Role: Planner
-- Updated: 2026-06-10 by Planner
+- Role: Integrator
+- Updated: 2026-06-10 by Controller
 
 ## Goal
 

--- a/docs/swarm/handoffs/SYT-010F.md
+++ b/docs/swarm/handoffs/SYT-010F.md
@@ -1,0 +1,153 @@
+# SYT-010F: Sticky Player Hardening Plan
+
+## Status
+
+- State: Needs Review; Ready for Runner after planning PR review/merge
+- GitHub issue: #10
+- Planning PR: #26, https://github.com/cryptoteatime/simple-yt-tweaks/pull/26
+- Planning branch: `swarm/syt-010f-planning`
+- Recommended implementation branch: `swarm/syt-010f-sticky-player-hardening`
+- Role: Planner
+- Updated: 2026-06-10 by Planner
+
+## Goal
+
+Continue the post-harness #10 hardening pass with one small, behavior-preserving Sticky Player lane. Reduce regression risk in `src/content/sticky-player.ts` by making its scroll/visibility/resize decisions testable and adding deterministic fixture coverage for dock/restore behavior.
+
+## Chosen Target
+
+`src/content/sticky-player.ts`
+
+Why this target:
+
+- It is one of the largest remaining content modules, at roughly 726 lines.
+- Current tests cover the Sticky Player setting in the popup, but not Sticky Player dock/restore behavior.
+- The integration log already records Sticky Player dock/undock as a deterministic fixture gap from earlier #10 work.
+- The module contains pure decision/geometry logic inside private functions (`isPlayerScrolledAway`, `isPlayerMostlyVisible`, `resolveResizedRect`) that can be extracted and unit-tested without live YouTube.
+- The existing watch fixture already has the needed player shape (`#movie_player`, video, controls, `#player-container-outer`), so fixture coverage should be possible with a small scrollable-height adjustment.
+
+## Scope
+
+- Add a narrow source hardening change for Sticky Player decision/geometry logic.
+- Prefer extracting pure helpers into a small adjacent module such as `src/content/sticky-player-geometry.ts` if importing `src/content/sticky-player.ts` directly would pull in browser globals or state too early for unit tests.
+- Keep `src/content/sticky-player.ts` as the owner of DOM mutation, docking, timers, PiP coordination, and event binding.
+- Add unit tests for the extracted pure logic:
+  - default-view sticky threshold
+  - theater-view sticky threshold
+  - mostly-visible restore threshold
+  - resize rectangle clamping/aspect-ratio behavior for representative directions
+- Add one fixture test for the watch page Sticky Player dock/restore path if it stays deterministic:
+  - make the watch fixture scrollable
+  - scroll until the player is eligible to dock
+  - assert `#simple-yt-tweaks-sticky-player-shell #movie_player`, placeholder, and body class are present
+  - scroll back to the visible player position and assert the player restores and the shell is removed
+- Update only handoff/docs needed to report the implementation result.
+
+## Non-Scope
+
+- Do not reintroduce enhanced Home/Search hover grow or highlight.
+- Do not change settings defaults, labels, storage keys, popup behavior, or version metadata.
+- Do not broaden into a Sticky Player redesign.
+- Do not change browser Picture-in-Picture behavior except where an existing call path needs to keep compiling after helper extraction.
+- Do not add live YouTube smoke as a required gate.
+- Do not bump version, tag, release, or edit Web Store assets.
+- Do not merge.
+
+## Dependencies
+
+- Depends on `SYT-010E` / PR #24 integration, already complete.
+- Depends on issue #10 remaining open, confirmed open on 2026-06-10.
+- No dependency on #8; keep #8 paused.
+
+## Parallelization Metadata
+
+- Parallel-safe: no by default under current capacity.
+- Serial-required: yes for runtime source hardening in large content modules.
+- Depends-on: `SYT-010E` integrated; clean main/planning PR review path.
+- Conflict-risk: medium/high because Sticky Player moves live YouTube player DOM nodes and interacts with PiP/fullscreen/theater state.
+
+## Write Scope
+
+Expected implementation files:
+
+- `src/content/sticky-player.ts`
+- Optional: `src/content/sticky-player-geometry.ts`
+- `tests/unit/sticky-player.unit.spec.ts`
+- `tests/e2e/extension.fixture.spec.ts`
+- `tests/e2e/youtube-fixtures.ts`
+- `docs/swarm/handoffs/SYT-010F.md`
+
+Do not edit unrelated content modules unless a compile/test failure directly requires a small import/type follow-up.
+
+## Verification
+
+Runner focused checks:
+
+- `npm run test:unit`
+- `npm run test:e2e`
+- `npm run typecheck`
+- `npm run lint`
+- `git diff --check`
+
+Integrator full gate:
+
+- `npm run validate:all`
+
+Do not run live YouTube for this lane unless the Runner uncovers behavior that cannot be represented in fixtures and records why.
+
+## Risks
+
+- Sticky Player fixture behavior depends on reliable player geometry after scrolling. If Chromium fixture geometry is flaky, keep the helper extraction/unit tests and record the exact fixture blocker rather than forcing a fragile test.
+- Helper extraction should preserve the existing thresholds exactly unless a failing test proves an existing threshold is wrong.
+- `src/content/sticky-player.ts` imports `state`, which initializes browser-dependent state. Unit tests should avoid importing that module directly if it makes tests depend on global `location` or `document` setup.
+- Dock/restore moves the real player node; assertions must verify the node is restored to the watch fixture, not recreated or duplicated.
+
+## Exact Runner Prompt
+
+You are Senior Runner for Simple YT Tweaks task `SYT-010F`.
+
+Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+Issue: #10, Post-harness code hardening pass
+Branch to create/use: `swarm/syt-010f-sticky-player-hardening` from current `main`
+
+Required reading, in order:
+
+1. `/Users/d4ngl/Git Repos/Codex/AGENTS.md`
+2. `SWARM.md`
+3. `docs/swarm/controller-directives.md`
+4. `docs/swarm/context-map.md`
+5. `docs/swarm/github.md`
+6. `docs/swarm/task-board.md`
+7. `docs/swarm/user-feedback.md`
+8. `docs/swarm/handoffs/SYT-010F.md`
+9. Relevant source/tests you inspect
+
+Scope:
+
+- Implement the Sticky Player hardening lane described in `docs/swarm/handoffs/SYT-010F.md`.
+- Keep changes behavior-preserving.
+- Prefer extracting pure Sticky Player visibility/resize helpers into a small adjacent module so unit tests can cover thresholds without importing DOM state.
+- Add deterministic unit coverage and one fixture dock/restore test if feasible.
+- Update this handoff with files touched, commands run, decisions, blockers, and next role.
+
+Non-scope:
+
+- Do not reintroduce #8 enhanced Home/Search hover grow/highlight.
+- Do not change settings defaults, version, release assets, or Web Store assets.
+- Do not merge.
+- Do not run live YouTube unless a fixture gap forces a documented optional smoke.
+
+Verification:
+
+- Run `npm run test:unit`.
+- Run `npm run test:e2e`.
+- Run `npm run typecheck`.
+- Run `npm run lint`.
+- Run `git diff --check`.
+- If all focused checks pass and time permits, run `npm run validate:all`; otherwise leave it as the Integrator gate.
+
+Expected final state:
+
+- If implementation and focused checks pass, push the branch and open/update a draft PR with title starting `Codex: `.
+- PR body must include `How to test / what to tell the controller`, human review requested: `no`, exact commands, expected results, and feedback format if any.
+- Report `Needs Review` to the controller.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: `SYT-010F` planning selected Sticky Player hardening; review/merge planning docs before spawning the Senior Runner.
+- Implementation dispatch: `SYT-010F` planning reviewer is active for PR #26.
 
 ## Active Tasks
 
@@ -59,7 +59,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none after Dalton completed `SYT-010F` planning.
+- Active controller-spawned subagents: McClintock reviewing `SYT-010F` / PR #26.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: `SYT-010F` planning reviewer is active for PR #26.
+- Implementation dispatch: `SYT-010F` Integrator is active for PR #26.
 
 ## Active Tasks
 
@@ -24,7 +24,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 | `SYT-021` | Native hover SPA regression and live recommendation drift | Integrator | Integrated | `swarm/syt-008b-native-hover-spa-regression` | #21 native Home/Search preview repair, watch click fallback hardening, modern recommendation selector drift | serial-required | v0.3.0 baseline | high, live YouTube SPA/player behavior | `docs/swarm/handoffs/SYT-021.md` | #22 merged |
 | `SYT-010E` | Code-hardening lane after #21 | Integrator | Integrated | `swarm/syt-010e-code-hardening` | Grid-hover selector normalization with unit coverage | serial-required | `SYT-021` | medium/high, runtime source hardening | `docs/swarm/handoffs/SYT-010E.md` | #24 merged |
-| `SYT-010F` | Sticky Player hardening plan | Planner | Needs Review | `swarm/syt-010f-planning` | Plan next #10 lane: Sticky Player visibility/resize helpers and deterministic dock/restore fixture coverage | serial-required | `SYT-010E` | medium/high, player DOM docking | `docs/swarm/handoffs/SYT-010F.md` | #26 draft |
+| `SYT-010F` | Sticky Player hardening plan | Integrator | In Progress | `swarm/syt-010f-planning` | Plan next #10 lane: Sticky Player visibility/resize helpers and deterministic dock/restore fixture coverage | serial-required | `SYT-010E` | medium/high, player DOM docking | `docs/swarm/handoffs/SYT-010F.md` | #26 draft |
 
 ## Backlog
 
@@ -59,7 +59,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: McClintock reviewing `SYT-010F` / PR #26.
+- Active controller-spawned subagents: Faraday integrating `SYT-010F` planning PR #26.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - First milestone plan: Ready
-- Implementation dispatch: Idle after `SYT-010E` integration; next action is planning/routing another small #10 lane if issue #10 remains open.
+- Implementation dispatch: `SYT-010F` planning selected Sticky Player hardening; review/merge planning docs before spawning the Senior Runner.
 
 ## Active Tasks
 
@@ -24,12 +24,12 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
 | `SYT-021` | Native hover SPA regression and live recommendation drift | Integrator | Integrated | `swarm/syt-008b-native-hover-spa-regression` | #21 native Home/Search preview repair, watch click fallback hardening, modern recommendation selector drift | serial-required | v0.3.0 baseline | high, live YouTube SPA/player behavior | `docs/swarm/handoffs/SYT-021.md` | #22 merged |
 | `SYT-010E` | Code-hardening lane after #21 | Integrator | Integrated | `swarm/syt-010e-code-hardening` | Grid-hover selector normalization with unit coverage | serial-required | `SYT-021` | medium/high, runtime source hardening | `docs/swarm/handoffs/SYT-010E.md` | #24 merged |
+| `SYT-010F` | Sticky Player hardening plan | Planner | Needs Review | `swarm/syt-010f-planning` | Plan next #10 lane: Sticky Player visibility/resize helpers and deterministic dock/restore fixture coverage | serial-required | `SYT-010E` | medium/high, player DOM docking | `docs/swarm/handoffs/SYT-010F.md` | #26 draft |
 
 ## Backlog
 
 | Task ID | Title | Reason | Notes |
 | --- | --- | --- | --- |
-| `SYT-010F` | Next #10 code-hardening lane | Reduce runtime risk in large content modules only where it lowers real maintenance cost. | Plan one small scoped target with `validate:all`, not broad aesthetic splitting. |
 | `SYT-RC-001` | Next release-candidate checklist | Make future version bump/package/release flow smoother. | Human QA required before release. |
 
 ## Blocked
@@ -42,7 +42,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010F` | `swarm/syt-010f-planning` | Handoff is bounded, no #8 scope leakage, Runner prompt has write scope and verification | docs-only, `git diff --check` | `docs/swarm/handoffs/SYT-010F.md` |
 
 ## Ready To Integrate
 
@@ -59,7 +59,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none after Ramanujan integrated `SYT-010E` / PR #24.
+- Active controller-spawned subagents: none after Dalton completed `SYT-010F` planning.
 - Active cron bursts: none; cron is a failsafe, not the normal execution path.
 - Parallel worktree root: none yet.
 - Batch dispatch policy: disabled by default because max active subagents is 1.
@@ -68,8 +68,9 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; `SYT-010E` integrated and no new implementation lane started by the Integrator.
+- Current controller phase: Phase 4 active; `SYT-010F` planning ready for review, then Senior Runner dispatch.
 - 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and draft PR #22 for `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`.
 - 2026-06-10: User requested compact context/docs and more frequent automation. Completed historical handoffs were compacted to stubs with `docs/swarm/archive/README.md` reference mapping; `docs/swarm/context-map.md` is now the hot context entrypoint.
 - 2026-06-10: PR #22 squash-merged at `8f90ef1`, closing #21. Remote/local task branch cleanup completed. Route `SYT-010E` next.
 - 2026-06-10: PR #24 squash-merged at `fae4e5d`, leaving #10 open for future hardening lanes. Remote/local task branch cleanup completed. Plan/route `SYT-010F` next if work remains safe and bounded.
+- 2026-06-10: `SYT-010F` planning selected Sticky Player hardening: pure visibility/resize helper coverage plus one deterministic dock/restore fixture if feasible. Keep #8 paused.


### PR DESCRIPTION
## Summary

- Adds the SYT-010F planning handoff for the next #10 hardening lane.
- Chooses `src/content/sticky-player.ts` as the bounded target.
- Updates hot swarm docs so the controller can review this planning PR and then spawn a Senior Runner for Sticky Player visibility/resize helper coverage plus deterministic dock/restore fixture coverage where feasible.

## How to test / what to tell the controller

Human review requested: no

Commands:

```sh
git diff --check
```

Expected result:

- `git diff --check` exits 0 with no whitespace errors.
- Diff is docs-only.
- #8 remains paused and no runtime/source/test files are changed in this planning lane.

Controller feedback format:

- If acceptable: `Ready to integrate SYT-010F planning PR; then spawn Senior Runner from docs/swarm/handoffs/SYT-010F.md`.
- If not acceptable: `Needs fixes for SYT-010F planning PR: <specific doc/handoff issue>`.

Refs #10