### PR TITLE
Codex: Fix stale Home hover previews

### DIFF
--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,13 +4,13 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active implementation lane: none
+- Active implementation lane: `SYT-031`
 - Last integrated lane: `SYT-010F` implementation
-- GitHub issue: #10 open
-- PR: #28 merged at `fa07c18`; #29 docs follow-up merged at `6580065`
-- Branch: `main` after hot-state repair lands
-- Current status: `SYT-010F` integrated; issue #10 remains open for future bounded hardening
-- Next priority lane: decide whether to plan `SYT-010G` or leave #10 open for later
+- GitHub issues: #31 open; #10 open
+- PR: pending for `SYT-031`
+- Branch: `swarm/syt-031-home-hover-stationary-spa`
+- Current status: `SYT-031` implemented locally and awaiting PR review
+- Next priority lane: review/integrate `SYT-031`; then decide whether to plan `SYT-010G` or leave #10 open for later
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate
 
 ## Hot Files
@@ -20,7 +20,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 - Task queue: `docs/swarm/task-board.md`
 - Agent capacity: `docs/swarm/agent-registry.md`
 - GitHub policy/state: `docs/swarm/github.md`
-- Next handoff: `docs/swarm/handoffs/SYT-010F.md`
+- Next handoff: `docs/swarm/handoffs/SYT-031.md`
 - User steering: `docs/swarm/user-feedback.md`
 
 ## Cold / Archived History
@@ -42,9 +42,10 @@ Full prior handoff text is recoverable through Git history before the 2026-06-10
 
 ## Next Safe Controller Action
 
-Decide whether to plan another #10 hardening lane:
+Review and integrate `SYT-031`:
 
-- `SYT-010F` is integrated; do not respawn it.
-- Start `SYT-010G` only with a narrow source/test target and fresh handoff.
-- Keep issue #10 open until the controller decides the overall hardening pass is complete.
+- Review the #31 branch for native Home/Search preview lifecycle scope and stale preview matching.
+- `npm run validate:all` and `npm run test:e2e:live` passed on the branch.
+- Do not bump version, tag, or release.
+- After `SYT-031` is integrated, start `SYT-010G` only with a narrow source/test target and fresh handoff.
 - Do not restart #8 enhanced hover research.

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -7,7 +7,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 - Active implementation lane: `SYT-031`
 - Last integrated lane: `SYT-010F` implementation
 - GitHub issues: #31 open; #10 open
-- PR: pending for `SYT-031`
+- PR: #32 draft for `SYT-031`
 - Branch: `swarm/syt-031-home-hover-stationary-spa`
 - Current status: `SYT-031` implemented locally and awaiting PR review
 - Next priority lane: review/integrate `SYT-031`; then decide whether to plan `SYT-010G` or leave #10 open for later

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -13,12 +13,12 @@ This file is the repo-local dynamic control plane for the controller chat and an
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `main` after hot-state repair lands
-- Expected Git state: clean `main...origin/main` after `SYT-010F` hot-state repair lands
-- Open PR expectation: none after hot-state repair lands; PR #20 remains paused draft for #8 research
+- Current branch: `swarm/syt-031-home-hover-stationary-spa`
+- Expected Git state: `SYT-031` branch with native Home hover regression fix awaiting review
+- Open PR expectation: PR pending for `SYT-031`; PR #20 remains paused draft for #8 research
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: no active implementation lane; decide whether issue #10 needs another bounded hardening lane or remains open for later
+- Current priority lane: `SYT-031` review/integration for issue #31
 
 ## Controller Lease And Pacing
 
@@ -103,8 +103,9 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010G` | Plan the next small #10 hardening lane only if the controller can name a narrow source/test target | Controller / Planner | TBD | New handoff created or decision to leave #10 open for later |
-| 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+| 1 | `SYT-031` | Review and integrate issue #31 Home native hover regression patch | Reviewer / Integrator | `swarm/syt-031-home-hover-stationary-spa` | PR merged or review returns Needs Fixes |
+| 2 | `SYT-010G` | Plan the next small #10 hardening lane only if the controller can name a narrow source/test target | Controller / Planner | TBD | New handoff created or decision to leave #10 open for later |
+| 3 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
 
@@ -129,3 +130,4 @@ Heartbeat overlap rule:
 - 2026-06-10: PR #26 review passed with no findings; human QA not required.
 - 2026-06-10: PR #26 marked ready and squash-merged into `main` at `66d756f`; issue #10 remains open. Next safe action is `SYT-010F` Sticky Player Senior Runner, not #8.
 - 2026-06-10: PR #28 marked ready and squash-merged into `main` at `fa07c18`; `npm run validate:all` passed; issue #10 remains open. Docs PR #29 recorded integration at `6580065`.
+- 2026-06-10: User reported #21 still failed; controller opened #31 and implemented `SYT-031` on `swarm/syt-031-home-hover-stationary-spa`. `npm run validate:all` and `npm run test:e2e:live` passed.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,14 +4,14 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening; #21, `SYT-010E`, and `SYT-010F` integrated
+- Status: existing repo, post-v0.3.0 hardening; #31 live Home hover regression patch is in review
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
 
 ## Project Brief
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; no active implementation lane after `SYT-010F`
+- Dispatch readiness: swarm packet integrated; `SYT-031` is the active review lane
 
 ## Goal
 
@@ -19,7 +19,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Current Focus
 
-1. Decide whether issue #10 needs another bounded hardening lane or should remain open for later.
+1. Review and integrate `SYT-031` / issue #31 for Home native hover autoplay after watch-to-Home SPA navigation.
 2. Keep #10 hardening in small PRs with `validate:all` as the final gate.
 3. Keep #8 as a future high-risk research lane until tests and product direction justify it.
 4. Keep release-candidate work separate from routine fixture/source hardening.
@@ -54,7 +54,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-010F` is integrated via PR #28 at `fa07c18`, and docs follow-up PR #29 landed at `6580065`. Issue #10 remains open for future bounded hardening lanes. The next useful milestone should be planned as a new lane only if the controller can identify a narrow source/test target.
+`SYT-031` is the active regression lane. It fixes stale/missing Home native hover previews after watch-to-Home SPA navigation without reintroducing #8 enhanced Home/Search hover grow. After #31 integrates, issue #10 remains open for future bounded hardening lanes.
 
 ## Verification Defaults
 
@@ -91,4 +91,4 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 ## Last Updated
 
 - Date: 2026-06-10
-- By: Controller hot-state repair after `SYT-010F`
+- By: Controller/Runner for `SYT-031`

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `SYT-031` | `swarm/syt-031-home-hover-stationary-spa` | pending | Needs Review | Controller/Runner | Fixes #31; no release/version bump. |
 
 ## Setup Log
 
@@ -65,3 +65,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-06-10: PR #26 marked ready and squash-merged at `66d756f`; issue #10 remains open; remote/local planning branch cleanup completed.
 - 2026-06-10: PR #28 marked ready and squash-merged at `fa07c18` for `SYT-010F`; issue #10 remains open; remote/local task branch cleanup completed.
 - 2026-06-10: PR #29 merged docs-only `SYT-010F` integration record at `6580065`; hot-state repair follows because controller docs still pointed at the completed runner lane.
+- 2026-06-10: Opened issue #31 for the remaining Home native hover regression after watch-to-Home SPA navigation. Implemented `SYT-031` on `swarm/syt-031-home-hover-stationary-spa`; PR pending.

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `SYT-031` | `swarm/syt-031-home-hover-stationary-spa` | pending | Needs Review | Controller/Runner | Fixes #31; no release/version bump. |
+| `SYT-031` | `swarm/syt-031-home-hover-stationary-spa` | #32 draft | Needs Review | Controller/Runner | Fixes #31; no release/version bump. |
 
 ## Setup Log
 
@@ -65,4 +65,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-06-10: PR #26 marked ready and squash-merged at `66d756f`; issue #10 remains open; remote/local planning branch cleanup completed.
 - 2026-06-10: PR #28 marked ready and squash-merged at `fa07c18` for `SYT-010F`; issue #10 remains open; remote/local task branch cleanup completed.
 - 2026-06-10: PR #29 merged docs-only `SYT-010F` integration record at `6580065`; hot-state repair follows because controller docs still pointed at the completed runner lane.
-- 2026-06-10: Opened issue #31 for the remaining Home native hover regression after watch-to-Home SPA navigation. Implemented `SYT-031` on `swarm/syt-031-home-hover-stationary-spa`; PR pending.
+- 2026-06-10: Opened issue #31 for the remaining Home native hover regression after watch-to-Home SPA navigation. Implemented `SYT-031` on `swarm/syt-031-home-hover-stationary-spa`; opened draft PR #32.

--- a/docs/swarm/handoffs/SYT-031.md
+++ b/docs/swarm/handoffs/SYT-031.md
@@ -1,0 +1,41 @@
+# SYT-031: Home Hover Autoplay After Watch-To-Home SPA
+
+## Status
+
+- Task ID: `SYT-031`
+- GitHub issue: #31
+- Branch: `swarm/syt-031-home-hover-stationary-spa`
+- State: Needs Review
+- Role: Controller/Runner
+
+## Scope
+
+Fix the live Home native hover preview regression that remains after #21: after navigating from a watch page back to Home through YouTube SPA navigation, Home cards can sit under a stationary pointer or under a stale preview overlay and fail to start the correct native preview.
+
+## Changes
+
+- Added native feed hover lifecycle recovery in `src/content/grid-hover.ts`.
+- The recovery stays limited to Home/Search native feed pages and does not reintroduce enhanced Home/Search grow/highlight behavior.
+- The recovery identifies the feed card geometrically under the pointer when a stale YouTube preview overlay is intercepting `elementFromPoint`.
+- Existing preview videos are resumed only when their watch video id matches the card under the pointer; stale mismatched preview overlays are ignored and the underlying card receives a small synthetic hover/move nudge.
+- Added fixture coverage for stationary-pointer watch-to-Home SPA navigation with a stale preview overlay.
+- Tightened optional live smoke to attempt watch-to-Home native preview and compare preview/card video ids when YouTube exposes both.
+
+## Verification
+
+- `npm run typecheck` passed.
+- `npm run lint` passed.
+- `npm run test:unit` passed.
+- `npm run test:e2e` passed.
+- `npm run test:e2e:live` passed.
+- `npm run validate:all` passed.
+
+## Notes
+
+- Signed-in Chrome supplemental inspection reproduced the stale preview overlay: after watch-to-Home, Home had cards mounted while `ytd-watch-flexy` and a visible paused/mismatched preview layer still existed.
+- Chrome automation cannot visit `chrome://extensions` to reload the unpacked extension, so authoritative current-build live verification used the repo isolated Chromium extension harness.
+- Do not revive #8 enhanced Home/Search hover grow/highlight in this lane.
+
+## Next Action
+
+Review PR for #31, focusing on native preview lifecycle scope, stale preview matching, and fixture/live coverage. If clean, integrate through the normal PR path; no version bump or release.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -25,6 +25,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-021` | Native hover SPA regression and live recommendation drift | Integrator | Integrated | `swarm/syt-008b-native-hover-spa-regression` | #21 native Home/Search preview repair, watch click fallback hardening, modern recommendation selector drift | serial-required | v0.3.0 baseline | high, live YouTube SPA/player behavior | `docs/swarm/handoffs/SYT-021.md` | #22 merged |
 | `SYT-010E` | Code-hardening lane after #21 | Integrator | Integrated | `swarm/syt-010e-code-hardening` | Grid-hover selector normalization with unit coverage | serial-required | `SYT-021` | medium/high, runtime source hardening | `docs/swarm/handoffs/SYT-010E.md` | #24 merged |
 | `SYT-010F` | Sticky Player hardening | Integrator | Integrated | `swarm/syt-010f-sticky-player-hardening` | Sticky Player visibility/resize helpers and deterministic dock/restore fixture coverage | serial-required | `SYT-010F` planning PR #26 merged | medium/high, player DOM docking | `docs/swarm/handoffs/SYT-010F.md` | #28 merged |
+| `SYT-031` | Home native hover autoplay after watch-to-Home SPA | Controller/Runner | Needs Review | `swarm/syt-031-home-hover-stationary-spa` | #31 stale/missing Home native preview recovery, fixture/live coverage | serial-required | `SYT-021` | high, live YouTube SPA preview lifecycle | `docs/swarm/handoffs/SYT-031.md` | pending |
 
 ## Backlog
 
@@ -69,7 +70,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; decide whether to plan `SYT-010G` or leave #10 open for later.
+- Current controller phase: Phase 4 active; review/integrate `SYT-031`, then decide whether to plan `SYT-010G` or leave #10 open for later.
 - 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and draft PR #22 for `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`.
 - 2026-06-10: User requested compact context/docs and more frequent automation. Completed historical handoffs were compacted to stubs with `docs/swarm/archive/README.md` reference mapping; `docs/swarm/context-map.md` is now the hot context entrypoint.
 - 2026-06-10: PR #22 squash-merged at `8f90ef1`, closing #21. Remote/local task branch cleanup completed. Route `SYT-010E` next.
@@ -77,3 +78,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - 2026-06-10: `SYT-010F` planning selected Sticky Player hardening: pure visibility/resize helper coverage plus one deterministic dock/restore fixture if feasible. Keep #8 paused.
 - 2026-06-10: PR #26 squash-merged at `66d756f`, leaving #10 open. Next safe action is Senior Runner on `swarm/syt-010f-sticky-player-hardening`.
 - 2026-06-10: PR #28 squash-merged at `fa07c18`, adding Sticky Player geometry/unit/fixture hardening. PR #29 docs follow-up merged at `6580065`. Issue #10 remains open; #8 remains paused.
+- 2026-06-10: User reported #21 still failed after watch-to-Home SPA navigation. Controller opened #31 and implemented `SYT-031` to recover stale/missing native Home previews without reintroducing #8 hover grow.

--- a/docs/swarm/user-feedback.md
+++ b/docs/swarm/user-feedback.md
@@ -14,6 +14,7 @@ Use this file for durable human steering that should survive across controller t
 - 2026-06-10: Use the signed-in Chrome profile for supplemental live YouTube usability audits when behavior depends on real YouTube SPA/player state. Keep repo-owned tests and `validate:all` as the required gate.
 - 2026-06-10: For #21, fix the watch-to-Home native hover autoplay regression, audit other live features/settings, patch regressions found during audit, and keep automation running while the user sleeps.
 - 2026-06-10: Keep repo docs compact so controller passes do not repeatedly compact; archive completed-lane detail with clear reference maps. Run the heartbeat more frequently, around every 30 minutes, while active work is moving.
+- 2026-06-10: #21 was not actually fixed in live use. User reported Home hover autoplay still failing after watch-to-Home navigation and explicitly asked to stop deferring, avoid bypassing blocked browser surfaces, and finish the fix with real validation.
 
 ## Product Ideas
 

--- a/src/content/grid-hover.ts
+++ b/src/content/grid-hover.ts
@@ -8,6 +8,8 @@ const GRID_EDGE_END_CLASS = 'simple-yt-tweaks-grid-edge-end';
 const SEARCH_BADGE_ROW_CLASS = 'simple-yt-tweaks-search-badges';
 const SIDEBAR_HOVER_DELAY_MS = 560;
 const FALLBACK_HOVER_DELAY_MS = 250;
+const NATIVE_FEED_HOVER_NUDGE_DELAYS_MS = [80, 260, 620];
+const NATIVE_FEED_HOVER_NUDGE_COOLDOWN_MS = 1_400;
 const PREVIEW_CONTAINER_SELECTOR = [
   'ytd-moving-thumbnail-renderer',
   'ytd-thumbnail-overlay-loading-preview-renderer',
@@ -77,12 +79,33 @@ const HOVER_MEDIA_SELECTOR = [
   'ytd-watch-next-secondary-results-renderer yt-lockup-view-model yt-thumbnail-view-model',
   '#secondary yt-lockup-view-model yt-thumbnail-view-model',
 ].join(',');
+const NATIVE_FEED_CARD_SELECTORS = [
+  'ytd-browse[page-subtype="home"] ytd-rich-item-renderer',
+  'ytd-search ytd-video-renderer',
+  'ytd-search ytd-grid-video-renderer',
+  'ytd-search yt-lockup-view-model',
+];
+const NATIVE_FEED_CARD_SELECTOR = NATIVE_FEED_CARD_SELECTORS.join(',');
+const NATIVE_FEED_CARD_HOVER_SELECTOR = NATIVE_FEED_CARD_SELECTORS.map((selector) => `${selector}:hover`).join(',');
+const NATIVE_FEED_HOVER_TARGET_SELECTOR = [
+  'a#thumbnail[href*="/watch"]',
+  '.ytLockupViewModelContentImage[href*="/watch"]',
+  'a[href^="/watch"]',
+  'a[href*="youtube.com/watch"]',
+  'ytd-thumbnail',
+  'yt-thumbnail-view-model',
+].join(',');
 
 let handlersBound = false;
 let activeHoverCard: HTMLElement | null = null;
 let hoverReadyTimer: number | null = null;
 let hoverClearTimer: number | null = null;
 let nativePreviewPlayTimer: number | null = null;
+let nativeFeedHoverNudgeTimers: number[] = [];
+let nativeFeedHoverNudgeHref = typeof location === 'undefined' ? '' : location.href;
+let nativeFeedHoverNudgeKey = '';
+let nativeFeedHoverNudgeAt = 0;
+let dispatchingNativeFeedHoverNudge = false;
 let lastPointerX = Number.POSITIVE_INFINITY;
 let lastPointerY = Number.POSITIVE_INFINITY;
 
@@ -486,6 +509,14 @@ function clearNativePreviewPlayTimer(): void {
   nativePreviewPlayTimer = null;
 }
 
+function clearNativeFeedHoverNudges(): void {
+  for (const timer of nativeFeedHoverNudgeTimers) {
+    window.clearTimeout(timer);
+  }
+
+  nativeFeedHoverNudgeTimers = [];
+}
+
 function clearActiveHoverCard(): void {
   clearHoverReadyTimer();
   clearHoverClearTimer();
@@ -521,6 +552,15 @@ function isNativeFeedPreviewPage(): boolean {
   return location.pathname === '/' || location.pathname === '/results';
 }
 
+function resetNativeFeedHoverNudgeForNavigation(): void {
+  if (nativeFeedHoverNudgeHref === location.href) return;
+
+  nativeFeedHoverNudgeHref = location.href;
+  nativeFeedHoverNudgeKey = '';
+  nativeFeedHoverNudgeAt = 0;
+  clearNativeFeedHoverNudges();
+}
+
 function getNativePreviewVideoUnderPointer(): HTMLVideoElement | null {
   if (!isNativeFeedPreviewPage()) return null;
   if (!Number.isFinite(lastPointerX) || !Number.isFinite(lastPointerY)) return null;
@@ -539,6 +579,197 @@ function getNativePreviewVideoUnderPointer(): HTMLVideoElement | null {
   }
 
   return null;
+}
+
+function getNativeFeedCard(target: Element | null): HTMLElement | null {
+  const card = target?.closest<HTMLElement>(NATIVE_FEED_CARD_SELECTOR) ?? null;
+  if (!card || card.classList.contains(GENERAL_HIDDEN_CLASS) || card.hidden) return null;
+  if (!hasWatchTarget(card)) return null;
+  if (card.querySelector('a[href*="/shorts/"], a[href="/shorts"]')) return null;
+  if (
+    card.querySelector(
+      [
+        'a[href*="list=RD"]',
+        'a[href*="start_radio=1"]',
+        'a[href*="/playlist?list="]',
+        'a[href^="/playlist"]',
+      ].join(','),
+    )
+  ) {
+    return null;
+  }
+
+  return card;
+}
+
+function getWatchHref(element: Element): string {
+  return element.querySelector<HTMLAnchorElement>('a[href*="/watch"]')?.href ?? '';
+}
+
+function getWatchVideoId(href: string): string {
+  if (!href) return '';
+
+  try {
+    const url = new URL(href, location.origin);
+    if (url.pathname !== '/watch') return '';
+    return url.searchParams.get('v') ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function getNativeFeedCardByPointerGeometry(): HTMLElement | null {
+  if (!Number.isFinite(lastPointerX) || !Number.isFinite(lastPointerY)) return null;
+
+  for (const candidate of document.querySelectorAll<HTMLElement>(NATIVE_FEED_CARD_SELECTOR)) {
+    const card = getNativeFeedCard(candidate);
+    if (!card) continue;
+
+    const rect = card.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) continue;
+    if (
+      lastPointerX >= rect.left &&
+      lastPointerX <= rect.right &&
+      lastPointerY >= rect.top &&
+      lastPointerY <= rect.bottom
+    ) {
+      return card;
+    }
+  }
+
+  return null;
+}
+
+function getNativeFeedCardUnderPointer(): HTMLElement | null {
+  if (!isNativeFeedPreviewPage()) return null;
+
+  const target = getElementUnderPointer();
+  const cardAtPointer = getNativeFeedCard(target);
+  if (cardAtPointer) return cardAtPointer;
+
+  const cardAtPointerGeometry = getNativeFeedCardByPointerGeometry();
+  if (cardAtPointerGeometry) return cardAtPointerGeometry;
+
+  return getNativeFeedCard(document.querySelector(NATIVE_FEED_CARD_HOVER_SELECTOR));
+}
+
+function getNativeFeedHoverTarget(card: HTMLElement): HTMLElement {
+  const targetAtPointer = getElementUnderPointer();
+  if (targetAtPointer && card.contains(targetAtPointer)) {
+    const mediaTarget = targetAtPointer.closest<HTMLElement>(NATIVE_FEED_HOVER_TARGET_SELECTOR);
+    if (mediaTarget && card.contains(mediaTarget)) return mediaTarget;
+  }
+
+  return card.querySelector<HTMLElement>(NATIVE_FEED_HOVER_TARGET_SELECTOR) ?? card;
+}
+
+function getNativeFeedHoverPoint(card: HTMLElement, target: HTMLElement): { x: number; y: number } {
+  if (Number.isFinite(lastPointerX) && Number.isFinite(lastPointerY)) {
+    const cardRect = card.getBoundingClientRect();
+    if (
+      lastPointerX >= cardRect.left &&
+      lastPointerX <= cardRect.right &&
+      lastPointerY >= cardRect.top &&
+      lastPointerY <= cardRect.bottom
+    ) {
+      return { x: lastPointerX, y: lastPointerY };
+    }
+  }
+
+  const rect = target.getBoundingClientRect();
+  return {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  };
+}
+
+function getNativeFeedHoverNudgeKey(card: HTMLElement): string {
+  const href = getWatchHref(card) || card.textContent?.trim() || '';
+  const rect = card.getBoundingClientRect();
+  return `${location.href}|${href}|${Math.round(rect.left)}:${Math.round(rect.top)}`;
+}
+
+function nativePreviewMatchesCard(video: HTMLVideoElement, card: HTMLElement): boolean {
+  const cardVideoId = getWatchVideoId(getWatchHref(card));
+  const previewRoot = video.closest('ytd-video-preview');
+  const previewVideoId = previewRoot ? getWatchVideoId(getWatchHref(previewRoot)) : '';
+
+  if (!cardVideoId || !previewVideoId) return true;
+  return cardVideoId === previewVideoId;
+}
+
+function dispatchNativeFeedHoverNudge(card: HTMLElement): void {
+  if (!document.body.contains(card) || !isPointerInsideCard(card)) return;
+  const previewVideo = getNativePreviewVideoUnderPointer();
+  if (previewVideo && nativePreviewMatchesCard(previewVideo, card)) {
+    scheduleNativePreviewPlaybackFallback();
+    return;
+  }
+
+  const target = getNativeFeedHoverTarget(card);
+  const point = getNativeFeedHoverPoint(card, target);
+  const mouseOptions: MouseEventInit = {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    clientX: point.x,
+    clientY: point.y,
+    screenX: point.x,
+    screenY: point.y,
+    view: window,
+  };
+  const pointerOptions: PointerEventInit = {
+    ...mouseOptions,
+    pointerId: 1,
+    pointerType: 'mouse',
+    isPrimary: true,
+    buttons: 0,
+    pressure: 0,
+  };
+
+  dispatchingNativeFeedHoverNudge = true;
+  try {
+    target.dispatchEvent(new PointerEvent('pointerover', pointerOptions));
+    target.dispatchEvent(new MouseEvent('mouseover', mouseOptions));
+    target.dispatchEvent(new PointerEvent('pointerenter', { ...pointerOptions, bubbles: false }));
+    target.dispatchEvent(new MouseEvent('mouseenter', { ...mouseOptions, bubbles: false }));
+    target.dispatchEvent(new PointerEvent('pointermove', pointerOptions));
+    target.dispatchEvent(new MouseEvent('mousemove', mouseOptions));
+  } finally {
+    dispatchingNativeFeedHoverNudge = false;
+  }
+
+  window.setTimeout(scheduleNativePreviewPlaybackFallback, 120);
+}
+
+function scheduleNativeFeedHoverLifecycleRecovery(): void {
+  resetNativeFeedHoverNudgeForNavigation();
+
+  if (!isNativeFeedPreviewPage()) {
+    clearNativeFeedHoverNudges();
+    return;
+  }
+
+  const card = getNativeFeedCardUnderPointer();
+  if (!card) return;
+  const previewVideo = getNativePreviewVideoUnderPointer();
+  if (previewVideo && nativePreviewMatchesCard(previewVideo, card)) {
+    scheduleNativePreviewPlaybackFallback();
+    return;
+  }
+
+  const now = Date.now();
+  const key = getNativeFeedHoverNudgeKey(card);
+  if (key === nativeFeedHoverNudgeKey && now - nativeFeedHoverNudgeAt < NATIVE_FEED_HOVER_NUDGE_COOLDOWN_MS) {
+    return;
+  }
+
+  nativeFeedHoverNudgeKey = key;
+  nativeFeedHoverNudgeAt = now;
+  clearNativeFeedHoverNudges();
+  nativeFeedHoverNudgeTimers = NATIVE_FEED_HOVER_NUDGE_DELAYS_MS.map((delay) =>
+    window.setTimeout(() => dispatchNativeFeedHoverNudge(card), delay),
+  );
 }
 
 function scheduleNativePreviewPlaybackFallback(): void {
@@ -682,6 +913,7 @@ function isRecommendedHoverGrowEnabled(settings: Settings): boolean {
 export function syncGridHoverState(settings: Settings): void {
   // Home/search feed previews stay native; avoid writing YouTube's own column metadata during preview startup.
   scheduleNativePreviewPlaybackFallback();
+  scheduleNativeFeedHoverLifecycleRecovery();
 
   if (settings.generalApplyFeedColumnsToSearch) {
     moveSearchBadgesToChannelRow();
@@ -719,6 +951,9 @@ export function bindGridHoverHandlers(getSettings: () => Settings): void {
       lastPointerX = event.clientX;
       lastPointerY = event.clientY;
       scheduleNativePreviewPlaybackFallback();
+      if (!dispatchingNativeFeedHoverNudge) {
+        scheduleNativeFeedHoverLifecycleRecovery();
+      }
       if (!isRecommendedHoverGrowEnabled(getSettings())) return;
 
       const card = getHoverCard(event.target);
@@ -739,6 +974,9 @@ export function bindGridHoverHandlers(getSettings: () => Settings): void {
       lastPointerX = event.clientX;
       lastPointerY = event.clientY;
       scheduleNativePreviewPlaybackFallback();
+      if (!dispatchingNativeFeedHoverNudge) {
+        scheduleNativeFeedHoverLifecycleRecovery();
+      }
       if (!isRecommendedHoverGrowEnabled(getSettings())) return;
 
       const card = activeHoverCard ?? getHoverCard(event.target);
@@ -760,6 +998,7 @@ export function bindGridHoverHandlers(getSettings: () => Settings): void {
       lastPointerX = event.clientX;
       lastPointerY = event.clientY;
       clearNativePreviewPlayTimer();
+      clearNativeFeedHoverNudges();
       const card = activeHoverCard;
       if (!card) return;
       if (event.relatedTarget instanceof Node && card.contains(event.relatedTarget)) {
@@ -801,6 +1040,7 @@ export function bindGridHoverHandlers(getSettings: () => Settings): void {
     () => {
       lastPointerX = Number.POSITIVE_INFINITY;
       lastPointerY = Number.POSITIVE_INFINITY;
+      clearNativeFeedHoverNudges();
       clearActiveHoverCard();
     },
     { passive: true },

--- a/tests/e2e/extension.fixture.spec.ts
+++ b/tests/e2e/extension.fixture.spec.ts
@@ -4,6 +4,7 @@ import { routeYouTubeFixture } from './youtube-fixtures';
 
 declare global {
   interface Window {
+    __simpleYtTweaksNativePreviewEvents?: string[];
     __simpleYtTweaksPlaybackEvents?: string[];
     __simpleYtTweaksSimulateTransientClick?: boolean;
   }
@@ -119,6 +120,52 @@ test('home fixture defers destructive cleanup briefly after watch-to-home naviga
 
   await expect(page.locator('[data-testid="deferred-sponsored"]')).toHaveCount(1);
   await expect(page.locator('[data-testid="deferred-sponsored"]')).toHaveCount(0, { timeout: 3_000 });
+  expect(extensionErrors(errors)).toEqual([]);
+});
+
+test('home fixture wakes native preview when SPA navigation leaves pointer over a new card', async ({ context }) => {
+  const page = await context.newPage();
+  const errors = await openFixture(page, 'home', 'https://www.youtube.com/');
+
+  await page.mouse.move(80, 80);
+  await page.evaluate(() => {
+    history.pushState({}, '', '/watch?v=fixture');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  });
+  await page.waitForTimeout(220);
+  await page.evaluate(() => {
+    const stalePreview = document.createElement('ytd-video-preview');
+    stalePreview.setAttribute('data-testid', 'stale-home-preview');
+    stalePreview.innerHTML = `
+      <a id="media-container-link" href="/watch?v=stale-preview">
+        <div id="inline-preview-player">
+          <video data-testid="stale-home-preview-video" style="position: fixed; left: 0; top: 0; width: 220px; height: 140px;"></video>
+        </div>
+      </a>
+    `;
+    document.querySelector('#video-preview')?.append(stalePreview);
+
+    const stationaryCard = document.createElement('ytd-rich-item-renderer');
+    stationaryCard.setAttribute('data-testid', 'stationary-hover-video');
+    stationaryCard.setAttribute('items-per-row', '3');
+    stationaryCard.innerHTML = `
+      <a class="ytLockupViewModelContentImage" href="/watch?v=stationary-hover">
+        <yt-thumbnail-view-model></yt-thumbnail-view-model>
+      </a>
+      <h3>Stationary hover fixture</h3>
+    `;
+    document.querySelector('ytd-browse[page-subtype="home"] ytd-rich-grid-renderer #contents')?.prepend(stationaryCard);
+    history.pushState({}, '', '/');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  });
+
+  await expect
+    .poll(() => page.evaluate(() => window.__simpleYtTweaksNativePreviewEvents ?? []), { timeout: 2_500 })
+    .toContainEqual('mousemove:synthetic');
+  await expect(page.locator('[data-testid="stationary-preview-started"]')).toHaveCount(1);
+  await expect(page.locator('[data-testid="stationary-hover-video"]')).not.toHaveClass(
+    /simple-yt-tweaks-grid-hover-ready/,
+  );
   expect(extensionErrors(errors)).toEqual([]);
 });
 

--- a/tests/e2e/extension.live.spec.ts
+++ b/tests/e2e/extension.live.spec.ts
@@ -1,5 +1,75 @@
 import { collectPageErrors, expect, extensionErrors, test, waitForExtensionReady } from './extension-fixture';
 
+type LiveCardTarget = {
+  href: string;
+  title: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+function getWatchVideoId(href: string): string {
+  try {
+    return new URL(href).searchParams.get('v') ?? '';
+  } catch {
+    return '';
+  }
+}
+
+async function getVisibleHomeCardTargets(page: import('@playwright/test').Page): Promise<LiveCardTarget[]> {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll<HTMLElement>('ytd-browse[page-subtype="home"] ytd-rich-item-renderer'))
+      .map((card) => {
+        const link = card.querySelector<HTMLAnchorElement>('a[href*="/watch"]');
+        const rect = card.getBoundingClientRect();
+        return {
+          title: card.textContent?.trim().replace(/\s+/g, ' ').slice(0, 120) ?? '',
+          href: link?.href ?? '',
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+          visible: rect.width > 120 && rect.height > 100 && rect.bottom > 0 && rect.top < window.innerHeight,
+        };
+      })
+      .filter((card) => card.visible && card.href.includes('/watch') && !card.href.includes('/shorts/'))
+      .map(({ href, title, x, y, width, height }) => ({ href, title, x, y, width, height })),
+  );
+}
+
+async function getVisiblePreviewState(page: import('@playwright/test').Page): Promise<{
+  currentTime: number;
+  href: string;
+  paused: boolean;
+  title: string;
+  visible: boolean;
+}> {
+  return page.evaluate(() => {
+    for (const video of document.querySelectorAll<HTMLVideoElement>('ytd-video-preview video, #inline-preview-player video')) {
+      const rect = video.getBoundingClientRect();
+      const visible = rect.width > 80 && rect.height > 60 && rect.bottom > 0 && rect.top < window.innerHeight;
+      if (!visible) continue;
+
+      return {
+        currentTime: video.currentTime,
+        href: video.closest('ytd-video-preview')?.querySelector<HTMLAnchorElement>('a[href*="/watch"]')?.href ?? '',
+        paused: video.paused,
+        title: video.closest('ytd-video-preview')?.textContent?.trim().replace(/\s+/g, ' ').slice(0, 120) ?? '',
+        visible: true,
+      };
+    }
+
+    return {
+      currentTime: 0,
+      href: '',
+      paused: true,
+      title: '',
+      visible: false,
+    };
+  });
+}
+
 test.describe('live YouTube smoke', () => {
   test.skip(!process.env.SIMPLE_YT_TWEAKS_LIVE, 'Set SIMPLE_YT_TWEAKS_LIVE=1 to run live YouTube smoke checks.');
 
@@ -29,5 +99,73 @@ test.describe('live YouTube smoke', () => {
     await expect(popup.locator('#versionLabel')).toHaveText(/^v\d+\.\d+\.\d+$/);
 
     expect(extensionErrors([...errors, ...popupErrors])).toEqual([]);
+  });
+
+  test('tries watch-to-home native hover preview on the current YouTube surface', async ({ context }) => {
+    const page = await context.newPage();
+    const errors = collectPageErrors(page);
+
+    try {
+      await page.goto('https://www.youtube.com/', { waitUntil: 'domcontentloaded', timeout: 20_000 });
+      await waitForExtensionReady(page);
+    } catch (error) {
+      test.info().annotations.push({
+        type: 'live-smoke-skipped',
+        description: `Live YouTube Home could not load in this environment: ${String(error)}`,
+      });
+      return;
+    }
+
+    const initialTargets = await getVisibleHomeCardTargets(page);
+    if (!initialTargets.length) {
+      test.info().annotations.push({
+        type: 'live-smoke-skipped',
+        description: 'Live YouTube Home did not expose visible watch cards.',
+      });
+      return;
+    }
+
+    const initialTarget = initialTargets[0];
+    await page.mouse.click(initialTarget.x + initialTarget.width / 2, initialTarget.y + Math.min(90, initialTarget.height / 2));
+    await page.waitForURL(/\/watch/, { timeout: 20_000 });
+    await waitForExtensionReady(page);
+
+    const logo = page.locator('a#logo[href="/"], ytd-topbar-logo-renderer a[href="/"]');
+    if ((await logo.count()) === 0) {
+      test.info().annotations.push({
+        type: 'live-smoke-skipped',
+        description: 'Live YouTube logo link was not available for SPA Home navigation.',
+      });
+      return;
+    }
+
+    await logo.first().click();
+    await page.waitForURL('https://www.youtube.com/', { timeout: 20_000 });
+    await waitForExtensionReady(page);
+
+    const homeTargets = await getVisibleHomeCardTargets(page);
+    if (!homeTargets.length) {
+      test.info().annotations.push({
+        type: 'live-smoke-skipped',
+        description: 'Live YouTube Home did not expose visible watch cards after SPA navigation.',
+      });
+      return;
+    }
+
+    const hoverTarget = homeTargets[0];
+    await page.mouse.move(hoverTarget.x + hoverTarget.width / 2, hoverTarget.y + Math.min(90, hoverTarget.height / 2));
+    const preview = await expect
+      .poll(() => getVisiblePreviewState(page), { timeout: 4_000 })
+      .toHaveProperty('visible', true)
+      .then(() => getVisiblePreviewState(page));
+
+    const hoverTargetVideoId = getWatchVideoId(hoverTarget.href);
+    const previewVideoId = getWatchVideoId(preview.href);
+    if (hoverTargetVideoId && previewVideoId) {
+      expect(previewVideoId).toBe(hoverTargetVideoId);
+    }
+
+    expect(preview.paused || preview.currentTime > 0).toBeTruthy();
+    expect(extensionErrors(errors)).toEqual([]);
   });
 });

--- a/tests/e2e/youtube-fixtures.ts
+++ b/tests/e2e/youtube-fixtures.ts
@@ -68,6 +68,7 @@ function homeFixture(): string {
     'YouTube Fixture Home',
     `
       <ytd-app>
+        <div id="video-preview" data-testid="home-video-preview-host"></div>
         <ytd-browse page-subtype="home">
           <ytd-rich-grid-renderer>
             <div id="contents">
@@ -112,6 +113,22 @@ function homeFixture(): string {
           </ytd-rich-grid-renderer>
         </ytd-browse>
       </ytd-app>
+      <script>
+        window.__simpleYtTweaksNativePreviewEvents = [];
+        document.addEventListener('mousemove', (event) => {
+          if (!(event.target instanceof Element)) return;
+          const card = event.target.closest('[data-testid="stationary-hover-video"]');
+          if (!card) return;
+
+          window.__simpleYtTweaksNativePreviewEvents.push(event.isTrusted ? 'mousemove:trusted' : 'mousemove:synthetic');
+          if (document.querySelector('[data-testid="stationary-preview-started"]')) return;
+
+          const marker = document.createElement('div');
+          marker.setAttribute('data-testid', 'stationary-preview-started');
+          marker.textContent = 'native preview started';
+          document.querySelector('#video-preview')?.append(marker);
+        });
+      </script>
     `,
   );
 }


### PR DESCRIPTION
## Summary
- Fixes #31 by recovering native Home/Search feed hover previews after watch-to-Home SPA navigation when the pointer is already over a feed card.
- Detects stale YouTube preview overlays by comparing preview/card watch video ids before calling play on an existing preview video.
- Falls back to the feed card geometrically under the pointer when a stale preview overlay intercepts elementFromPoint.
- Adds fixture coverage for stationary-pointer SPA navigation with a stale preview overlay and tightens optional live smoke to compare preview/card ids.

## How to test / what to tell the controller
Human review requested: no.

Commands run:
- npm run typecheck
- npm run lint
- npm run test:unit
- npm run test:e2e
- npm run test:e2e:live
- npm run validate:all

Expected result:
- All commands pass.
- Home/Search do not reintroduce enhanced grow/highlight behavior.
- After watch-to-Home SPA navigation, hovering a Home card starts the matching native YouTube preview instead of playing a stale preview overlay from another card.

Feedback format if reviewed:
- Ready to Integrate for PR #<number>
- Needs Fixes for PR #<number>: <blocking findings>