### PR TITLE
Codex: Harden fullscreen player UI geometry

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -65,6 +65,7 @@ Use this file to track who is working, where they are working, and whether the c
 | `019eb145-89d5-7e93-ae8e-46819bfb6ac0` / Harvey | `SYT-010F` | Senior Runner | Needs Review | 2026-06-10 07:47 EDT | Opened draft PR #28; full validation passed; issue #10 commented. |
 | `019eb18b-2df6-74b3-baba-68adfc94427a` / Newton | `SYT-010F` | Reviewer | Ready to Integrate | 2026-06-10 08:56 EDT | Final PR #28 review passed with no findings; unit/e2e/typecheck/lint and diff checks passed. |
 | `019eb1a5-f3e6-7520-86aa-956ea3bd2de6` / Hume | `SYT-010F` | Integrator | Merged PR #28 | 2026-06-10 09:02 EDT | `npm run validate:all` passed; PR #28 squash-merged at `fa07c18`; docs follow-up PR #29 merged at `6580065`; issue #10 remains open. |
+| `019eb293-9f5e-7ca2-ada8-6bad5f84c002` / Russell | `SYT-010G` | Reviewer | Ready to Integrate | 2026-06-10 13:35 EDT | No findings; `git diff --check origin/main...origin/swarm/syt-010g-fullscreen-ui-geometry` and `npm run test:unit` passed; human QA not required. |
 
 ## Pending Launch
 

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -13,12 +13,12 @@ This file is the repo-local dynamic control plane for the controller chat and an
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `main`
-- Expected Git state: clean `main...origin/main` after `SYT-031` hot-state repair lands
-- Open PR expectation: none after `SYT-031` hot-state repair lands; PR #20 remains paused draft for #8 research
+- Current branch: `swarm/syt-010g-fullscreen-ui-geometry`
+- Expected Git state: `SYT-010G` branch with fullscreen/player UI geometry hardening awaiting review
+- Open PR expectation: PR #34 draft for `SYT-010G`; PR #20 remains paused draft for #8 research
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: no active implementation lane; decide whether issue #10 needs another bounded hardening lane or remains open for later
+- Current priority lane: `SYT-010G` integration for issue #10
 
 ## Controller Lease And Pacing
 
@@ -103,8 +103,9 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010G` | Plan the next small #10 hardening lane only if the controller can name a narrow source/test target | Controller / Planner | TBD | New handoff created or decision to leave #10 open for later |
-| 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+| 1 | `SYT-010G` | Integrate fullscreen/player UI geometry hardening | Integrator | `swarm/syt-010g-fullscreen-ui-geometry` | PR merged or final checks fail |
+| 2 | `SYT-010H` | Plan the next small #10 hardening lane only if the controller can name a narrow source/test target | Controller / Planner | TBD | New handoff created or decision to leave #10 open for later |
+| 3 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
 
@@ -131,3 +132,5 @@ Heartbeat overlap rule:
 - 2026-06-10: PR #28 marked ready and squash-merged into `main` at `fa07c18`; `npm run validate:all` passed; issue #10 remains open. Docs PR #29 recorded integration at `6580065`.
 - 2026-06-10: User reported #21 still failed; controller opened #31 and implemented `SYT-031` on `swarm/syt-031-home-hover-stationary-spa`. `npm run validate:all` and `npm run test:e2e:live` passed.
 - 2026-06-10: PR #32 marked ready and squash-merged into `main` at `8e881c9`; issue #31 closed. Hot-state repair follows because controller docs still pointed at the completed regression lane.
+- 2026-06-10: `SYT-010G` selected fullscreen/player UI geometry hardening under issue #10; draft PR #34 opened after `npm run validate:all` passed. Next safe action is review, not #8.
+- 2026-06-10: Reviewer Russell marked PR #34 Ready to Integrate with no findings. Next safe action is integration with `npm run validate:all`.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,14 +4,14 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening; #31 live Home hover regression patch integrated
+- Status: existing repo, post-v0.3.0 hardening; `SYT-010G` fullscreen/player UI geometry hardening is ready for review
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
 
 ## Project Brief
 
 - Brief: `docs/swarm/project-brief.md`
 - Question gate: deferred, not blocking
-- Dispatch readiness: swarm packet integrated; no active implementation lane after `SYT-031`
+- Dispatch readiness: swarm packet integrated; `SYT-010G` is the active review lane
 
 ## Goal
 
@@ -19,7 +19,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Current Focus
 
-1. Decide whether issue #10 needs another bounded hardening lane or should remain open for later.
+1. Review and integrate `SYT-010G`, a bounded #10 hardening lane for fullscreen/player UI geometry.
 2. Keep #10 hardening in small PRs with `validate:all` as the final gate.
 3. Keep #8 as a future high-risk research lane until tests and product direction justify it.
 4. Keep release-candidate work separate from routine fixture/source hardening.
@@ -54,7 +54,7 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 
 ## Recommended First Milestone
 
-`SYT-031` is integrated via PR #32 at `8e881c9`, closing #31. Issue #10 remains open for future bounded hardening lanes.
+`SYT-010G` extracts fullscreen/player UI hover reveal geometry into a pure helper with unit coverage. Issue #10 remains open until the controller decides the hardening pass is complete.
 
 ## Verification Defaults
 
@@ -91,4 +91,4 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 ## Last Updated
 
 - Date: 2026-06-10
-- By: Controller/Runner for `SYT-031`
+- By: Controller/Runner for `SYT-010G`

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `SYT-010G` | `swarm/syt-010g-fullscreen-ui-geometry` | #34 | Draft / Needs Review | Controller/Runner | Fullscreen/player UI geometry hardening for #10. |
 
 ## Setup Log
 
@@ -67,3 +67,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-06-10: PR #29 merged docs-only `SYT-010F` integration record at `6580065`; hot-state repair follows because controller docs still pointed at the completed runner lane.
 - 2026-06-10: Opened issue #31 for the remaining Home native hover regression after watch-to-Home SPA navigation. Implemented `SYT-031` on `swarm/syt-031-home-hover-stationary-spa`; opened draft PR #32.
 - 2026-06-10: PR #32 marked ready and squash-merged at `8e881c9`; issue #31 closed; remote task branch deleted by merge.
+- 2026-06-10: Opened draft PR #34 for `SYT-010G` fullscreen/player UI geometry hardening under issue #10.

--- a/docs/swarm/handoffs/SYT-010G.md
+++ b/docs/swarm/handoffs/SYT-010G.md
@@ -1,0 +1,74 @@
+# SYT-010G: Fullscreen Player UI Geometry Hardening
+
+## Status
+
+- Task ID: `SYT-010G`
+- GitHub issue: #10
+- Branch: `swarm/syt-010g-fullscreen-ui-geometry`
+- PR: #34
+- State: Ready to Integrate
+- Role: Controller/Runner/Reviewer
+
+## Scope
+
+Extract and test the player UI hover/reveal geometry used by fullscreen and theater player UI hiding. This is a behavior-preserving #10 hardening slice.
+
+## Non-Scope
+
+- Do not change shipped player UI behavior.
+- Do not touch Home/Search enhanced hover grow or #8.
+- Do not change settings defaults, popup UI, version, release, tag, or Web Store assets.
+- Do not require human QA unless review finds a live player behavior risk.
+
+## Parallelization
+
+- `parallel-safe`: no, keep serial with other runtime hardening.
+- `serial-required`: yes, touches shared player UI behavior.
+- `depends-on`: `SYT-031` integrated.
+- `conflict-risk`: medium, `src/content/fullscreen.ts` is a fragile watch-page runtime module.
+
+## Files Touched
+
+- `src/content/fullscreen.ts`
+- `src/content/fullscreen-geometry.ts`
+- `tests/unit/fullscreen-geometry.unit.spec.ts`
+- `docs/swarm/handoffs/SYT-010G.md`
+- `docs/swarm/task-board.md`
+- `docs/swarm/current-state.md`
+- `docs/swarm/controller-directives.md`
+
+## Changes
+
+- Extracted fullscreen/theater player UI control-zone math into `src/content/fullscreen-geometry.ts`.
+- Kept DOM querying and class toggling in `src/content/fullscreen.ts`.
+- Added unit coverage for:
+  - mode-specific control-zone offsets,
+  - chrome-bottom clamping,
+  - fallback zone heights,
+  - pointer-inside-player and reveal threshold behavior.
+
+## Verification
+
+- `npm run test:unit`: PASS, 22 tests.
+- `npm run typecheck`: PASS.
+- `npm run lint`: PASS.
+- `git diff --check`: PASS.
+- `npm run validate:all`: PASS, including package validation, 22 unit tests, and 12 fixture tests.
+
+## Review
+
+- Reviewer: Russell (`019eb293-9f5e-7ca2-ada8-6bad5f84c002`)
+- Result: Ready to Integrate, no findings.
+- Commands run by reviewer:
+  - `git fetch origin main swarm/syt-010g-fullscreen-ui-geometry --prune`: PASS.
+  - `git diff --check origin/main...origin/swarm/syt-010g-fullscreen-ui-geometry`: PASS.
+  - `npm run test:unit`: PASS, 22 tests.
+- Reviewer confirmed the extraction preserved the old 18/14 chrome offset, 44px clamp, 94/118 fallback heights, inclusive pointer bounds, and scope boundaries.
+
+## Risks
+
+- Low/medium. The runtime behavior should be unchanged, but the code protects recent player UI/play-pause behavior, so reviewer should confirm the extraction is mathematically equivalent to the old inline logic.
+
+## Next Action
+
+Integrator should mark PR #34 ready, run `npm run validate:all`, then squash-merge if the PR remains clean.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -26,13 +26,14 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010E` | Code-hardening lane after #21 | Integrator | Integrated | `swarm/syt-010e-code-hardening` | Grid-hover selector normalization with unit coverage | serial-required | `SYT-021` | medium/high, runtime source hardening | `docs/swarm/handoffs/SYT-010E.md` | #24 merged |
 | `SYT-010F` | Sticky Player hardening | Integrator | Integrated | `swarm/syt-010f-sticky-player-hardening` | Sticky Player visibility/resize helpers and deterministic dock/restore fixture coverage | serial-required | `SYT-010F` planning PR #26 merged | medium/high, player DOM docking | `docs/swarm/handoffs/SYT-010F.md` | #28 merged |
 | `SYT-031` | Home native hover autoplay after watch-to-Home SPA | Integrator | Integrated | `swarm/syt-031-home-hover-stationary-spa` | #31 stale/missing Home native preview recovery, fixture/live coverage | serial-required | `SYT-021` | high, live YouTube SPA preview lifecycle | `docs/swarm/handoffs/SYT-031.md` | #32 merged |
+| `SYT-010G` | Fullscreen player UI geometry hardening | Controller/Runner/Reviewer | Ready to Integrate | `swarm/syt-010g-fullscreen-ui-geometry` | Extract/test player UI hover reveal geometry | serial-required | `SYT-031` | medium, watch-page player UI behavior | `docs/swarm/handoffs/SYT-010G.md` | #34 draft |
 
 ## Backlog
 
 | Task ID | Title | Reason | Notes |
 | --- | --- | --- | --- |
 | `SYT-RC-001` | Next release-candidate checklist | Make future version bump/package/release flow smoother. | Human QA required before release. |
-| `SYT-010G` | Next bounded #10 hardening lane | Issue #10 remains open after `SYT-010F`. | Proposed only; requires a narrow source/test target and handoff before dispatch. |
+| `SYT-010H` | Next bounded #10 hardening lane | Issue #10 remains open after `SYT-010G` unless the controller closes it. | Proposed only; requires a narrow source/test target and handoff before dispatch. |
 
 ## Blocked
 
@@ -50,7 +51,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Branch | Checks | Cleanup Plan | Handoff |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010G` | `swarm/syt-010g-fullscreen-ui-geometry` | Reviewer passed; runner `npm run validate:all` passed | Mark PR ready, rerun `npm run validate:all`, squash merge, clean branch | `docs/swarm/handoffs/SYT-010G.md` |
 
 ## Human QA
 
@@ -70,7 +71,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; decide whether to plan `SYT-010G` or leave #10 open for later.
+- Current controller phase: Phase 4 active; `SYT-010G` is ready to integrate.
 - 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and draft PR #22 for `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`.
 - 2026-06-10: User requested compact context/docs and more frequent automation. Completed historical handoffs were compacted to stubs with `docs/swarm/archive/README.md` reference mapping; `docs/swarm/context-map.md` is now the hot context entrypoint.
 - 2026-06-10: PR #22 squash-merged at `8f90ef1`, closing #21. Remote/local task branch cleanup completed. Route `SYT-010E` next.
@@ -80,3 +81,5 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - 2026-06-10: PR #28 squash-merged at `fa07c18`, adding Sticky Player geometry/unit/fixture hardening. PR #29 docs follow-up merged at `6580065`. Issue #10 remains open; #8 remains paused.
 - 2026-06-10: User reported #21 still failed after watch-to-Home SPA navigation. Controller opened #31 and implemented `SYT-031` to recover stale/missing native Home previews without reintroducing #8 hover grow.
 - 2026-06-10: PR #32 squash-merged at `8e881c9`, closing #31. Route `SYT-010G` next only if a narrow #10 hardening target is identified.
+- 2026-06-10: `SYT-010G` selected fullscreen/player UI geometry hardening. Unit/type/diff checks passed; route review next.
+- 2026-06-10: Reviewer Russell marked PR #34 Ready to Integrate with no findings; route Integrator next.

--- a/src/content/fullscreen-geometry.ts
+++ b/src/content/fullscreen-geometry.ts
@@ -1,0 +1,60 @@
+export interface PlayerUiRect {
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+}
+
+export interface PlayerControlZoneInput {
+  chromeBottomRect: PlayerUiRect | null;
+  fullscreenActive: boolean;
+  playerRect: PlayerUiRect;
+}
+
+export interface PlayerUiPointerInput extends PlayerControlZoneInput {
+  pointerX: number;
+  pointerY: number;
+}
+
+export function resolvePlayerControlZoneTop({
+  chromeBottomRect,
+  fullscreenActive,
+  playerRect,
+}: PlayerControlZoneInput): number {
+  if (
+    chromeBottomRect &&
+    chromeBottomRect.height > 0 &&
+    chromeBottomRect.bottom > playerRect.top &&
+    chromeBottomRect.top < playerRect.bottom
+  ) {
+    return Math.max(
+      playerRect.top,
+      Math.min(playerRect.bottom - 44, chromeBottomRect.top - (fullscreenActive ? 18 : 14)),
+    );
+  }
+
+  const fallbackZoneHeight = fullscreenActive ? 94 : 118;
+  return playerRect.bottom - fallbackZoneHeight;
+}
+
+export function isPointerInsidePlayerRect({
+  playerRect,
+  pointerX,
+  pointerY,
+}: Pick<PlayerUiPointerInput, 'playerRect' | 'pointerX' | 'pointerY'>): boolean {
+  return (
+    pointerX >= playerRect.left &&
+    pointerX <= playerRect.right &&
+    pointerY >= playerRect.top &&
+    pointerY <= playerRect.bottom
+  );
+}
+
+export function shouldRevealPlayerUiFromPointer(input: PlayerUiPointerInput): boolean {
+  return (
+    isPointerInsidePlayerRect(input) &&
+    input.pointerY >= resolvePlayerControlZoneTop(input)
+  );
+}

--- a/src/content/fullscreen.ts
+++ b/src/content/fullscreen.ts
@@ -1,4 +1,5 @@
 import { debounce, getPlayer, isNativeFullscreenActive, isVisibleNode, isWatchPage, query, queryAll } from './dom';
+import { shouldRevealPlayerUiFromPointer } from './fullscreen-geometry';
 import {
   FULLSCREEN_ACTION_DOCK_ID,
   FULLSCREEN_ACTION_TARGET_CLASS,
@@ -272,26 +273,6 @@ export function updatePlayerUiFocusState(): void {
   );
 }
 
-function getPlayerControlZoneTop(playerRect: DOMRect, fullscreenActive: boolean): number {
-  const chromeBottom = query<HTMLElement>(SELECTORS.chromeBottom);
-  const chromeRect = chromeBottom?.getBoundingClientRect();
-
-  if (
-    chromeRect &&
-    chromeRect.height > 0 &&
-    chromeRect.bottom > playerRect.top &&
-    chromeRect.top < playerRect.bottom
-  ) {
-    return Math.max(
-      playerRect.top,
-      Math.min(playerRect.bottom - 44, chromeRect.top - (fullscreenActive ? 18 : 14)),
-    );
-  }
-
-  const fallbackZoneHeight = fullscreenActive ? 94 : 118;
-  return playerRect.bottom - fallbackZoneHeight;
-}
-
 export function updatePlayerUiHoverState(pointerX: number, pointerY: number): void {
   const theaterActive = isWatchPage() && document.body.classList.contains('simple-yt-tweaks-theater') && state.settings.theaterHidePlayerUI;
   const fullscreenActive =
@@ -312,14 +293,14 @@ export function updatePlayerUiHoverState(pointerX: number, pointerY: number): vo
   }
 
   const rect = player.getBoundingClientRect();
-  const isInsidePlayer =
-    pointerX >= rect.left &&
-    pointerX <= rect.right &&
-    pointerY >= rect.top &&
-    pointerY <= rect.bottom;
-  const controlZoneTop = getPlayerControlZoneTop(rect, fullscreenActive);
-  const isInControlZone = pointerY >= controlZoneTop;
-  const shouldRevealPlayerUi = isInsidePlayer && isInControlZone;
+  const chromeBottom = query<HTMLElement>(SELECTORS.chromeBottom);
+  const shouldRevealPlayerUi = shouldRevealPlayerUiFromPointer({
+    chromeBottomRect: chromeBottom?.getBoundingClientRect() ?? null,
+    fullscreenActive,
+    playerRect: rect,
+    pointerX,
+    pointerY,
+  });
 
   document.body.classList.toggle('simple-yt-tweaks-player-ui-hover', shouldRevealPlayerUi);
 

--- a/tests/unit/fullscreen-geometry.unit.spec.ts
+++ b/tests/unit/fullscreen-geometry.unit.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  isPointerInsidePlayerRect,
+  resolvePlayerControlZoneTop,
+  shouldRevealPlayerUiFromPointer,
+  type PlayerUiRect,
+} from '../../src/content/fullscreen-geometry';
+
+function rect(overrides: Partial<PlayerUiRect>): PlayerUiRect {
+  const width = overrides.width ?? 1_280;
+  const height = overrides.height ?? 720;
+  const left = overrides.left ?? 0;
+  const top = overrides.top ?? 0;
+
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    ...overrides,
+  };
+}
+
+test('player UI control zone follows visible chrome bottom with mode-specific reveal gap', () => {
+  const playerRect = rect({ top: 100, bottom: 820, height: 720 });
+  const chromeBottomRect = rect({ top: 730, bottom: 820, height: 90 });
+
+  expect(resolvePlayerControlZoneTop({
+    chromeBottomRect,
+    fullscreenActive: false,
+    playerRect,
+  })).toBe(716);
+
+  expect(resolvePlayerControlZoneTop({
+    chromeBottomRect,
+    fullscreenActive: true,
+    playerRect,
+  })).toBe(712);
+});
+
+test('player UI control zone clamps chrome-derived positions inside the player', () => {
+  const playerRect = rect({ top: 100, bottom: 820, height: 720 });
+
+  expect(resolvePlayerControlZoneTop({
+    chromeBottomRect: rect({ top: 840, bottom: 920, height: 80 }),
+    fullscreenActive: false,
+    playerRect,
+  })).toBe(702);
+
+  expect(resolvePlayerControlZoneTop({
+    chromeBottomRect: rect({ top: 110, bottom: 180, height: 70 }),
+    fullscreenActive: true,
+    playerRect,
+  })).toBe(100);
+
+  expect(resolvePlayerControlZoneTop({
+    chromeBottomRect: rect({ top: 800, bottom: 850, height: 50 }),
+    fullscreenActive: false,
+    playerRect,
+  })).toBe(776);
+});
+
+test('player UI control zone falls back when chrome bottom is missing or unusable', () => {
+  const playerRect = rect({ top: 80, bottom: 800, height: 720 });
+
+  expect(resolvePlayerControlZoneTop({
+    chromeBottomRect: null,
+    fullscreenActive: false,
+    playerRect,
+  })).toBe(682);
+
+  expect(resolvePlayerControlZoneTop({
+    chromeBottomRect: rect({ top: 760, bottom: 760, height: 0 }),
+    fullscreenActive: true,
+    playerRect,
+  })).toBe(706);
+
+  expect(resolvePlayerControlZoneTop({
+    chromeBottomRect: rect({ top: 10, bottom: 60, height: 50 }),
+    fullscreenActive: false,
+    playerRect,
+  })).toBe(682);
+});
+
+test('player UI reveal requires the pointer inside the player and below the control zone', () => {
+  const playerRect = rect({ left: 40, right: 1_320, top: 100, bottom: 820, width: 1_280, height: 720 });
+  const chromeBottomRect = rect({ top: 730, bottom: 820, height: 90 });
+
+  expect(isPointerInsidePlayerRect({ playerRect, pointerX: 40, pointerY: 100 })).toBe(true);
+  expect(isPointerInsidePlayerRect({ playerRect, pointerX: 1_321, pointerY: 760 })).toBe(false);
+
+  expect(shouldRevealPlayerUiFromPointer({
+    chromeBottomRect,
+    fullscreenActive: false,
+    playerRect,
+    pointerX: 800,
+    pointerY: 716,
+  })).toBe(true);
+
+  expect(shouldRevealPlayerUiFromPointer({
+    chromeBottomRect,
+    fullscreenActive: false,
+    playerRect,
+    pointerX: 800,
+    pointerY: 715,
+  })).toBe(false);
+
+  expect(shouldRevealPlayerUiFromPointer({
+    chromeBottomRect,
+    fullscreenActive: false,
+    playerRect,
+    pointerX: 1_400,
+    pointerY: 760,
+  })).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Extract fullscreen/theater player UI hover reveal geometry into a pure helper.
- Keep DOM querying and class toggling in `src/content/fullscreen.ts`.
- Add unit coverage for control-zone offsets, clamping, fallbacks, and pointer threshold behavior.

Refs #10.

## How to test / what to tell the controller
Human review requested: no.

Commands run:
- `npm run test:unit`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm run validate:all`

Expected result:
- Full validation passes.
- Player UI reveal behavior is preserved; only the math is extracted/tested.
- No Home/Search enhanced hover grow, version, release, tag, popup, settings default, or Web Store asset changes.

Feedback format if reviewed:
- `Ready to Integrate for PR #<number>`
- `Needs Fixes for PR #<number>: <blocking findings>`
