### PR TITLE
Codex: Repair SYT-010H context map

### DIFF
--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,13 +4,13 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active implementation lane: `SYT-036`
-- Last integrated lane: `SYT-010G`
-- GitHub issues: #10 open; #36 open; #38 open; #31 closed
-- PR: #37 draft for `SYT-036` / `SYT-038`
-- Branch: `swarm/syt-036-home-hover-stuck-lifecycle`
-- Current status: `SYT-036` Home autoplay route passed user QA; user then reported #38 live-stream Theater video cut-off/chat overlay collapse. #38 fix is on PR #37 with full validation and live Brave PWA geometry/screenshot verification; push/update PR and route fresh review next.
-- Next priority lane: finish #36/#38 before planning more #10 hardening
+- Active implementation lane: none
+- Last integrated lane: `SYT-036` / `SYT-038`
+- GitHub issues: #10 open; #36 closed; #38 closed; #31 closed
+- PR: none active for #10 hardening; #20 remains paused draft for #8 research
+- Branch: `main`
+- Current status: PR #37 was merged at `342854f`, closing #36/#38; PR #39 merged the post-integration state repair at `969c3b7`. User confirmed the desired behavior was working before merge.
+- Next priority lane: launch `SYT-010H` final-leg polish/code-hardening under #10.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate
 
 ## Hot Files
@@ -20,7 +20,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 - Task queue: `docs/swarm/task-board.md`
 - Agent capacity: `docs/swarm/agent-registry.md`
 - GitHub policy/state: `docs/swarm/github.md`
-- Next handoff: `docs/swarm/handoffs/SYT-036.md`
+- Next handoff: `docs/swarm/handoffs/SYT-010H.md`
 - User steering: `docs/swarm/user-feedback.md`
 
 ## Cold / Archived History
@@ -39,16 +39,17 @@ Completed lanes are intentionally compacted to stubs:
 - `SYT-010F` docs follow-up -> PR #29, merge `6580065`
 - `SYT-031` -> PR #32, merge `8e881c9`, closes #31
 - `SYT-010G` -> PR #34, merge `99156b5`, refs #10
-- `SYT-036` / `SYT-038` -> issues #36/#38, draft PR #37
+- `SYT-036` / `SYT-038` -> PR #37, merge `342854f`, closes #36/#38
+- `SYT-036` integration record -> PR #39, merge `969c3b7`
 
 Full prior handoff text is recoverable through Git history before the 2026-06-10 compaction commit. Use `docs/swarm/archive/README.md` for the reference map.
 
 ## Next Safe Controller Action
 
-Finish `SYT-036` / `SYT-038`:
+Launch `SYT-010H`:
 
 - Do not bump version, tag, or release.
-- Push and route fresh review for PR #37 after the post-review #38 live-stream Theater/chat overlay patch.
-- After review passes, wait for `Human QA passed/failed for SYT-036/#38: <notes>` unless reviewer/integrator records an explicit waiver based on the live Brave PWA evidence.
-- Integrate PR #37 only after review and human QA pass or an explicit waiver is recorded.
+- Start with a planner/audit branch such as `swarm/syt-010h-polish-plan`.
+- Produce a small list of runner-sized cleanup tasks before source refactors.
+- Focus on settings walkthrough, selector accuracy, runtime polling/churn reduction, fixture gaps, redundancy, and docs compaction.
 - Do not restart #8 enhanced hover research.


### PR DESCRIPTION
## Summary
- update the hot context map after PR #37/#39 integration
- point the next controller action at SYT-010H instead of stale SYT-036 review work

## How to test / what to tell the controller
- Human review requested: no
- Command: git diff --check origin/main...HEAD
- Expected result: passes; docs-only context map repair
- Feedback format: Controller may merge if diff check passes and PR is mergeable.
