### PR TITLE
Codex: Configure SYT-010H burst capacity

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -5,11 +5,11 @@ Use this file to track who is working, where they are working, and whether the c
 ## Capacity
 
 - Max active planners: 1
-- Max active runners: 1
+- Max active runners: 3 during planner-approved `SYT-010H` disjoint lanes; otherwise 1
 - Max active reviewers: 1
 - Max active integrators: 1
-- Max total active agents: 1
-- Capacity note: paced autonomous default. Raise capacity only for a named pass when the user explicitly wants a supervised burst.
+- Max total active agents: 3 during planner-approved `SYT-010H` disjoint lanes; otherwise 1
+- Capacity note: user approved a supervised `SYT-010H` final-leg burst up to 3 subagents. Use it only for non-overlapping audit/test/docs/helper lanes with separate branches/worktrees and explicit path locks. Keep fragile runtime implementation, review, and integration serial.
 
 ## Controller Lease
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -50,6 +50,6 @@ Launch `SYT-010H`:
 
 - Do not bump version, tag, or release.
 - Start with a planner/audit branch such as `swarm/syt-010h-polish-plan`.
-- Produce a small list of runner-sized cleanup tasks before source refactors.
+- Produce a small list of runner-sized cleanup tasks before source refactors, including which tasks are safe for up to 3-way parallel dispatch.
 - Focus on settings walkthrough, selector accuracy, runtime polling/churn reduction, fixture gaps, redundancy, and docs compaction.
 - Do not restart #8 enhanced hover research.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,7 +8,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-06-11 00:00 EDT
+- Last reviewed by controller: 2026-06-11 00:35 EDT
 
 ## Current Source Of Truth
 
@@ -27,10 +27,10 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Lease expected action: none
 - Lease stop condition: none
 - Lease stale after: 90 minutes
-- Controller pass budget: max 6 safe orchestration actions or 60 minutes
-- Heartbeat pass budget: max 2 safe recovery/routing actions, then stop
-- Active capacity: max 1 active subagent total
-- Heartbeat cadence target: slow back toward 90 minutes after the `SYT-010F` hot-state repair lands
+- Controller pass budget: max 10 safe orchestration actions or 90 minutes during the `SYT-010H` final-leg push
+- Heartbeat pass budget: max 4 safe recovery/routing actions, then stop
+- Active capacity: max 3 active subagents total only for `SYT-010H` lanes that the planner marks disjoint and low/medium conflict; keep max 1 for runtime implementation touching the same content modules, review, integration, merge conflicts, live YouTube behavior, or release-candidate work
+- Heartbeat cadence target: 30 minutes while `SYT-010H` is actively being planned/routed; slow back toward 90 minutes or pause after the hardening lane is integrated or blocked on human QA
 - Next human QA gate: release-candidate lane or #8 visual/product-direction gate later
 
 ## Context Hygiene
@@ -72,7 +72,10 @@ Heartbeat overlap rule:
 ## Spawn Strategy
 
 - Read `docs/swarm/agent-registry.md` before spawning.
-- Default to 1 active subagent at a time.
+- Default to 1 active subagent at a time outside the supervised `SYT-010H` hardening burst.
+- For `SYT-010H`, capacity may rise to 3 total active subagents only after the planner produces non-overlapping lanes with explicit path scopes, branch/worktree names, verification commands, and conflict-risk labels.
+- Good parallel candidates: read-only audit/planning, fixture coverage audit, popup/settings audit, docs compaction, and isolated unit-test/helper work.
+- Serial-only candidates: changes to `src/content/theater.ts`, `src/content/grid-hover.ts`, `src/content/sticky-player.ts`, shared settings contracts, live YouTube behavior, PR review, and integration.
 - Use low/medium effort for routine routing, docs, review, and fixture-test work.
 - Use high/xhigh only for hard browser-extension architecture, repeated test failures, merge conflicts, or #8 preview lifecycle work.
 - Spawn only when lane labels are present: `parallel-safe`, `serial-required`, `depends-on`, and `conflict-risk`.
@@ -103,7 +106,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010H` | Launch final-leg #10 polish/hardening planner: settings walk-through, visual audit matrix, selector/code cleanup, polling/churn reduction, fixture gaps, and docs compaction | Controller / Planner | TBD | Handoff created and first bounded runner lane selected |
+| 1 | `SYT-010H` | Launch final-leg #10 polish/hardening planner: settings walk-through, visual audit matrix, selector/code cleanup, polling/churn reduction, fixture gaps, docs compaction, and a parallel-safe lane map for up to 3 disjoint agents | Controller / Planner | TBD | Handoff created, lane map produced, and first safe runner/reviewer batch selected |
 | 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
@@ -137,3 +140,4 @@ Heartbeat overlap rule:
 - 2026-06-10: User reported Home hover stale-card backgrounds and missing autoplay after refresh -> watch page -> SPA Home. Controller opened issue #36 and draft PR #37 for `SYT-036`; human QA failed twice. Final follow-up diagnosed Brave PWA watch -> hover hidden header -> YouTube logo/Home -> Home hover path, removed Home/Search synthetic hover/playback recovery, preserved YouTube's zero-height preview loader, added a guarded real watch-to-Home URL watcher/reload, and verified with fixtures, `npm run test:e2e:live`, `npm run validate:all`, and exact Brave PWA playback advancement. Commit `f669141` pushed and PR/issue updated; route review next.
 - 2026-06-11: User confirmed the desired #36/#38 behavior appears to be working and asked to proceed into final-leg polish/hardening. PR #37 still requires fresh review before integration; `SYT-010H` should follow only after PR #37 lands.
 - 2026-06-11: PR #37 was marked ready and squash-merged at `342854f` after `npm run validate:all` passed. Issues #36 and #38 are closed; route `SYT-010H` next.
+- 2026-06-11: User approved a supervised final-leg push with up to 3 subagents if useful. Apply that only to planner-approved disjoint `SYT-010H` lanes; do not parallelize overlapping runtime implementation.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -20,9 +20,10 @@ Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHu
 ## Current Focus
 
 1. Launch `SYT-010H` as the final-leg polish/code-hardening lane under #10: settings walkthrough, selector cleanup, fixture gaps, runtime polling audit, and small refactors only where they reduce risk.
-2. Keep #8 as a future high-risk research lane until tests and product direction justify it.
-3. Keep release-candidate work separate from routine fixture/source hardening.
-4. Keep hot swarm context compact; use `docs/swarm/context-map.md` and archive references instead of loading old completed handoffs.
+2. Use a supervised burst of up to 3 subagents only after the `SYT-010H` planner defines disjoint path scopes and verification commands; keep fragile runtime changes serial.
+3. Keep #8 as a future high-risk research lane until tests and product direction justify it.
+4. Keep release-candidate work separate from routine fixture/source hardening.
+5. Keep hot swarm context compact; use `docs/swarm/context-map.md` and archive references instead of loading old completed handoffs.
 
 ## Success Criteria
 

--- a/docs/swarm/handoffs/SYT-010H.md
+++ b/docs/swarm/handoffs/SYT-010H.md
@@ -34,6 +34,7 @@ Polish the post-v0.3.0 codebase without broad churn: reduce redundant logic, rem
   - shared settings helpers as needed
 - Add or adjust fixture/unit tests for behavior that is currently protected only by live/manual QA.
 - Compact hot handoffs/docs after PR #37 integration so future controller passes start fast.
+- Produce a parallel-safe lane map before implementation dispatch. Up to 3 subagents are allowed only when their path scopes are disjoint and at least one lane is audit/docs/test-only.
 
 ## Non-Scope
 
@@ -45,10 +46,23 @@ Polish the post-v0.3.0 codebase without broad churn: reduce redundant logic, rem
 
 ## Parallelization
 
-- `parallel-safe`: no for the initial planner/audit pass
-- `serial-required`: yes
+- `parallel-safe`: no for the initial planner/audit pass; yes only for planner-approved disjoint follow-up lanes
+- `serial-required`: yes for planning, shared runtime implementation, review, and integration
 - `depends-on`: PR #37 integrated
 - `conflict-risk`: medium/high, because this touches shared content-script behavior and settings flow
+
+## Burst Capacity Rules
+
+- Maximum active subagents: 3, only after this lane has a concrete sublane map.
+- Good parallel lanes:
+  - Settings/popup audit and fixture coverage.
+  - DOM selector/polling audit with no source edits.
+  - Docs/context compaction.
+  - Isolated helper/unit-test cleanup.
+- Keep serial:
+  - Any edit touching `src/content/theater.ts`, `grid-hover.ts`, `sticky-player.ts`, `fullscreen.ts`, `sidebar.ts`, or shared settings contracts.
+  - Any live YouTube/Brave PWA behavior fix.
+  - Review and integration.
 
 ## Verification Plan
 
@@ -60,4 +74,4 @@ Polish the post-v0.3.0 codebase without broad churn: reduce redundant logic, rem
 
 ## First Recommended Action
 
-After PR #37 is merged, create a planner branch `swarm/syt-010h-polish-plan` that audits code paths and produces a small list of runner-sized cleanup tasks. Prefer one high-value implementation lane at a time over a broad refactor.
+Create a planner branch `swarm/syt-010h-polish-plan` that audits code paths and produces a small list of runner-sized cleanup tasks. Prefer one high-value implementation lane at a time unless the lane map proves 2-3 agents can work without overlapping files or behavior.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -28,7 +28,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-031` | Home native hover autoplay after watch-to-Home SPA | Integrator | Integrated | `swarm/syt-031-home-hover-stationary-spa` | #31 stale/missing Home native preview recovery, fixture/live coverage | serial-required | `SYT-021` | high, live YouTube SPA preview lifecycle | `docs/swarm/handoffs/SYT-031.md` | #32 merged |
 | `SYT-010G` | Fullscreen player UI geometry hardening | Integrator | Integrated | `swarm/syt-010g-fullscreen-ui-geometry` | Extract/test player UI hover reveal geometry | serial-required | `SYT-031` | medium, watch-page player UI behavior | `docs/swarm/handoffs/SYT-010G.md` | #34 merged |
 | `SYT-036` | Home hover stale card lifecycle regression + live Theater chat fix | Integrator | Integrated | `swarm/syt-036-home-hover-stuck-lifecycle` | #36 native Home hover lifecycle cleanup plus #38 live-stream Theater/chat overlay layout, minimize/restore, comments scroll, and non-overlay hide-live-chat fix | serial-required | `SYT-031`, `SYT-010G` | high, live YouTube SPA/player layout behavior | `docs/swarm/handoffs/SYT-036.md` | #37 merged |
-| `SYT-010H` | Final-leg polish and code hardening | Planner | Ready | TBD after PR #37 | Audit settings/UI flows, selector accuracy, runtime polling/churn, fixture gaps, redundant code, and compact docs before release-candidate work | serial-required | `SYT-036` integrated | medium/high, shared content modules and popup/settings behavior | `docs/swarm/handoffs/SYT-010H.md` | none |
+| `SYT-010H` | Final-leg polish and code hardening | Planner | Ready | TBD | Audit settings/UI flows, selector accuracy, runtime polling/churn, fixture gaps, redundant code, and compact docs before release-candidate work; define parallel-safe sublanes before dispatch | serial-required for planning, then planner may split disjoint lanes | `SYT-036` integrated | medium/high, shared content modules and popup/settings behavior | `docs/swarm/handoffs/SYT-010H.md` | none |
 
 ## Backlog
 
@@ -74,7 +74,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Agent registry: `docs/swarm/agent-registry.md`.
 - Bootstrap log: `docs/swarm/bootstrap-log.md`.
 - GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; launch `SYT-010H` final-leg polish/hardening under #10.
+- Current controller phase: Phase 4 active; launch `SYT-010H` final-leg polish/hardening under #10 with planner-approved capacity up to 3 only for disjoint lanes.
 - 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and draft PR #22 for `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`.
 - 2026-06-10: User requested compact context/docs and more frequent automation. Completed historical handoffs were compacted to stubs with `docs/swarm/archive/README.md` reference mapping; `docs/swarm/context-map.md` is now the hot context entrypoint.
 - 2026-06-10: PR #22 squash-merged at `8f90ef1`, closing #21. Remote/local task branch cleanup completed. Route `SYT-010E` next.
@@ -91,3 +91,4 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - 2026-06-10: User confirmed Home hover autoplay works, then reported live-stream Theater video cut-off/chat overlay collapse and a broken live chat close state. Controller opened #38 and patched PR #37 so live chat overlay no longer reserves full-bleed layout width, `iframe#chatframe` fills the overlay, and the overlay `X` minimizes to a right-edge restore tab. `npm run validate:all` passed; live Brave PWA geometry and minimize/restore verification passed. Follow-up placement refinement moved the close button outside the chat panel and made the minimized tab visibly exposed; focused fixture and full validation passed.
 - 2026-06-11: User confirmed everything currently desired appears to be working and asked for final-leg polish/hardening. Treat PR #37 human QA as passed; route fresh review, integrate if clean, then launch `SYT-010H`.
 - 2026-06-11: PR #37 was marked ready and squash-merged at `342854f` after `npm run validate:all` passed. Issues #36 and #38 are closed. Next lane is `SYT-010H`.
+- 2026-06-11: User approved up to 3 subagents for the final-leg push. `SYT-010H` planner must split explicit non-overlapping lanes before any parallel dispatch.


### PR DESCRIPTION
## Summary
- allow a supervised SYT-010H burst of up to 3 subagents only for planner-approved disjoint lanes
- keep fragile runtime implementation, review, and integration serial
- update the SYT-010H handoff, controller directives, registry, and context map
- heartbeat prompt was updated separately to read repo-documented capacity and run every 30 minutes during this push

## How to test / what to tell the controller
- Human review requested: no
- Command: git diff --check origin/main...HEAD
- Expected result: passes; docs-only controller capacity setup
- Feedback format: Controller may merge if diff check passes and PR is mergeable.
