### PR TITLE
SYT-010H-A: Harden settings popup coverage

### DIFF
--- a/tests/e2e/extension.fixture.spec.ts
+++ b/tests/e2e/extension.fixture.spec.ts
@@ -45,6 +45,23 @@ async function writeExtensionSettings(
   await page.close();
 }
 
+async function readExtensionSettings(page: Page): Promise<Record<string, unknown>> {
+  return page.evaluate(
+    () =>
+      new Promise<Record<string, unknown>>((resolve, reject) => {
+        chrome.storage.sync.get(null, (items) => {
+          const error = chrome.runtime.lastError;
+          if (error) {
+            reject(new Error(error.message));
+            return;
+          }
+
+          resolve(items);
+        });
+      }),
+  );
+}
+
 async function setupPlaybackProbe(page: Page): Promise<void> {
   await page.locator('#movie_player video.html5-main-video').evaluate(async (video) => {
     window.__simpleYtTweaksPlaybackEvents = [];
@@ -785,10 +802,18 @@ test('popup fixture renders settings, nested controls, version, and storage pers
   await expect(page.locator('#generalApplyFeedColumnsToSearch')).toBeChecked();
 
   await page.locator('#pipButton').uncheck();
+  await expect.poll(() => readExtensionSettings(page)).toMatchObject({
+    pipButton: false,
+    floatingMiniPlayer: false,
+  });
   await page.reload();
   await expect(page.locator('#pipButton')).not.toBeChecked();
   await page.locator('#resetBtn').click();
   await expect(page.locator('#pipButton')).toBeChecked();
+  await expect.poll(() => readExtensionSettings(page)).toMatchObject({
+    pipButton: true,
+    floatingMiniPlayer: true,
+  });
 
   await page.locator('#settingsTabs button', { hasText: 'Modes' }).click();
   await page.locator('#viewModes button', { hasText: 'Default' }).click();
@@ -799,6 +824,114 @@ test('popup fixture renders settings, nested controls, version, and storage pers
   await expect(page.locator('#theaterHideRecommendations')).toBeChecked();
   await expect(page.locator('#theaterRecommendedHoverGrow')).toBeChecked();
   await expect(page.locator('#theaterRecommendedHoverGrow')).toBeEnabled();
+  expect(extensionErrors(errors)).toEqual([]);
+});
+
+test('popup fixture resets only the active settings pane', async ({ context, extensionId }) => {
+  await writeExtensionSettings(context, extensionId, {
+    generalFeedColumns: 4,
+    generalApplyFeedColumnsToSearch: false,
+    generalStickyPlayer: false,
+    pipButton: false,
+    floatingMiniPlayer: false,
+    generalSidebarCleanup: false,
+    generalHideSidebar: true,
+    defaultHideComments: true,
+  });
+
+  const page = await context.newPage();
+  const errors = collectPageErrors(page);
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+
+  await expect(page.locator('#settingsTabs button', { hasText: 'General' })).toHaveAttribute('aria-selected', 'true');
+  await expect(page.locator('#generalFeedColumns')).toHaveValue('4');
+  await expect(page.locator('#generalStickyPlayer')).not.toBeChecked();
+  await page.locator('#resetBtn').click();
+
+  await expect(page.locator('#generalFeedColumns')).toHaveValue('3');
+  await expect(page.locator('#generalStickyPlayer')).toBeChecked();
+  await expect.poll(() => readExtensionSettings(page)).toMatchObject({
+    generalFeedColumns: 3,
+    generalApplyFeedColumnsToSearch: true,
+    generalStickyPlayer: true,
+    pipButton: true,
+    floatingMiniPlayer: true,
+    generalSidebarCleanup: false,
+    generalHideSidebar: true,
+    defaultHideComments: true,
+  });
+
+  await page.locator('#settingsTabs button', { hasText: 'Modes' }).click();
+  await page.locator('#viewModes button', { hasText: 'Default' }).click();
+  await expect(page.locator('#defaultHideComments')).toBeChecked();
+  await page.locator('#resetBtn').click();
+  await expect(page.locator('#defaultHideComments')).not.toBeChecked();
+  await expect.poll(() => readExtensionSettings(page)).toMatchObject({
+    generalSidebarCleanup: false,
+    generalHideSidebar: true,
+    defaultHideComments: false,
+  });
+  expect(extensionErrors(errors)).toEqual([]);
+});
+
+test('popup fixture keeps nested child disabled state aligned with parent settings', async ({ context, extensionId }) => {
+  await writeExtensionSettings(context, extensionId, {
+    enhancedTheaterMode: true,
+    theaterHideHeader: false,
+    theaterShowHeaderOnHover: true,
+    theaterHideRecommendations: false,
+    theaterRecommendedHoverGrow: true,
+    defaultHideMetadata: false,
+    defaultShowPrimaryMetadata: true,
+    defaultHideRecommendations: false,
+    defaultRecommendedHoverGrow: true,
+  });
+
+  const page = await context.newPage();
+  const errors = collectPageErrors(page);
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+
+  await page.locator('#settingsTabs button', { hasText: 'Modes' }).click();
+  await expect(page.locator('#theaterHideHeader')).not.toBeChecked();
+  await expect(page.locator('#theaterShowHeaderOnHover')).toBeChecked();
+  await expect(page.locator('#theaterShowHeaderOnHover')).toBeDisabled();
+  await expect(page.locator('#theaterHideRecommendations')).not.toBeChecked();
+  await expect(page.locator('#theaterRecommendedHoverGrow')).toBeChecked();
+  await expect(page.locator('#theaterRecommendedHoverGrow')).toBeEnabled();
+
+  await page.locator('#viewModes button', { hasText: 'Default' }).click();
+  await expect(page.locator('#defaultHideMetadata')).not.toBeChecked();
+  await expect(page.locator('#defaultShowPrimaryMetadata')).toBeChecked();
+  await expect(page.locator('#defaultShowPrimaryMetadata')).toBeDisabled();
+  await expect(page.locator('#defaultHideRecommendations')).not.toBeChecked();
+  await expect(page.locator('#defaultRecommendedHoverGrow')).toBeChecked();
+  await expect(page.locator('#defaultRecommendedHoverGrow')).toBeEnabled();
+  expect(extensionErrors(errors)).toEqual([]);
+});
+
+test('popup fixture turns on sidebar Shorts cleanup when Hide Shorts is enabled', async ({ context, extensionId }) => {
+  await writeExtensionSettings(context, extensionId, {
+    generalHideShorts: false,
+    generalSidebarCleanup: false,
+    generalHideSidebarShorts: false,
+  });
+
+  const page = await context.newPage();
+  const errors = collectPageErrors(page);
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+
+  await expect(page.locator('#generalHideShorts')).not.toBeChecked();
+  await page.locator('#generalHideShorts').check();
+  await expect.poll(() => readExtensionSettings(page)).toMatchObject({
+    generalHideShorts: true,
+    generalSidebarCleanup: true,
+    generalHideSidebarShorts: true,
+  });
+
+  await page.locator('#settingsTabs button', { hasText: 'Sidebar' }).click();
+  await expect(page.locator('#generalSidebarCleanup')).toBeChecked();
+  await expect(page.locator('#generalHideSidebarShorts')).toBeChecked();
+  await expect(page.locator('#generalHideSidebarShorts')).toBeEnabled();
   expect(extensionErrors(errors)).toEqual([]);
 });
 

--- a/tests/unit/settings.unit.spec.ts
+++ b/tests/unit/settings.unit.spec.ts
@@ -7,11 +7,16 @@ import {
   normalizeSettings,
   type Settings,
 } from '../../src/content/settings';
-import { DEFAULT_SETTINGS as SHARED_DEFAULT_SETTINGS } from '../../src/shared/settings';
+import {
+  DEFAULT_SETTINGS as SHARED_DEFAULT_SETTINGS,
+  SETTING_KEYS as SHARED_SETTING_KEYS,
+  normalizeSettings as normalizeSharedSettings,
+} from '../../src/shared/settings';
 
 test('content defaults stay aligned with shared settings defaults', () => {
   expect(CONTENT_DEFAULT_SETTINGS).toEqual(SHARED_DEFAULT_SETTINGS);
   expect(SETTING_KEYS).toEqual(Object.keys(CONTENT_DEFAULT_SETTINGS));
+  expect(SETTING_KEYS).toEqual(SHARED_SETTING_KEYS);
 });
 
 test('normalizeSettings accepts valid stored values and falls back for invalid values', () => {
@@ -44,6 +49,51 @@ test('normalizeSettings rejects unsupported feed column counts', () => {
   for (const generalFeedColumns of [2, 3, 4]) {
     expect(normalizeSettings({ generalFeedColumns }).generalFeedColumns).toBe(generalFeedColumns);
   }
+});
+
+test('content and shared normalizeSettings stay behaviorally identical', () => {
+  const cases = [
+    {},
+    {
+      generalFeedColumns: 2,
+      generalHideShorts: false,
+      generalSidebarCleanup: false,
+      generalHideSidebarShorts: false,
+      defaultHideMetadata: false,
+    },
+    {
+      generalFeedColumns: '4',
+      enhancedTheaterMode: 'true',
+      theaterShowHeaderOnHover: 1,
+      theaterHideLiveChat: false,
+      theaterShowLiveChatOverlay: true,
+    },
+    {
+      generalFeedColumns: 4,
+      pipButton: false,
+      floatingMiniPlayer: true,
+      fullscreenHideActionOverlay: false,
+    },
+  ];
+
+  for (const storedSettings of cases) {
+    expect(normalizeSettings(storedSettings)).toEqual(normalizeSharedSettings(storedSettings));
+  }
+});
+
+test('normalizeSettings persists floatingMiniPlayer as a compatibility alias of pipButton', () => {
+  expect(normalizeSettings({ pipButton: false, floatingMiniPlayer: true })).toMatchObject({
+    pipButton: false,
+    floatingMiniPlayer: false,
+  });
+  expect(normalizeSettings({ pipButton: true, floatingMiniPlayer: false })).toMatchObject({
+    pipButton: true,
+    floatingMiniPlayer: true,
+  });
+  expect(normalizeSettings({ floatingMiniPlayer: false })).toMatchObject({
+    pipButton: CONTENT_DEFAULT_SETTINGS.pipButton,
+    floatingMiniPlayer: CONTENT_DEFAULT_SETTINGS.pipButton,
+  });
 });
 
 test('isFeatureEnabled preserves the PiP-controlled floating mini player compatibility alias', () => {


### PR DESCRIPTION
Refs #10

## Summary
- Add unit coverage that content/shared settings keys, defaults, and normalization stay in parity.
- Add popup fixture coverage for pane-scoped reset, nested child enable/disable state, Hide Shorts sidebar side effects, and PiP/floatingMiniPlayer alias persistence.
- No source behavior changes.

## How to test / what to tell the controller
- Human review requested: no
- Commands:
  - `npm run test:unit`
  - `npm run test:e2e -- --grep "popup|settings"`
  - `npm run typecheck`
  - `npm run lint`
  - `git diff --check`
- Expected result: all commands pass; popup/settings fixture subset reports 7 passing tests; unit suite reports 24 passing tests.
- Feedback format: `SYT-010H-A review result: Ready to Integrate` or `SYT-010H-A review result: Needs Fixes - <file/line and issue>`.
