### PR TITLE
Codex: Compact SYT-010H swarm docs

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -19,13 +19,11 @@ Use this file to track who is working, where they are working, and whether the c
 
 ## Active Agents
 
-Active rows preserve the registered A/B/C batch from PR #44. If a row is stale, the controller should reconcile it against branch/PR state before removing it.
+No active agents after the first `SYT-010H` A/B/C burst is reconciled.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019eb49a-c484-7b40-9f6f-662172dd8c22` / Nietzsche | `SYT-010H-A` | Runner | Needs Review | `swarm/syt-010h-settings-popup` | agent workspace | #45 | 2026-06-11 02:55 UTC | 2026-06-11 | Controller should route review for PR #45 after active batch reconciliation | none |
-| `019eb49b-58af-79f1-aca5-38fba53c14da` / Wegener | `SYT-010H-B` | Runner/Auditor | Needs Review | `swarm/syt-010h-selector-runtime-audit` | agent workspace | #46 | 2026-06-11 02:55 UTC | 2026-06-11 | Controller should route review for PR #46 after active batch reconciliation | none |
-| `019eb49b-ef01-7923-8c57-f4faedee2108` / Leibniz | `SYT-010H-C` | Docs Runner | Running | `swarm/syt-010h-docs-compaction` | agent workspace | TBD | 2026-06-11 02:55 UTC | 2026-06-11 | Compact hot swarm docs without source/test edits, run `git diff --check`, open draft PR | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -37,9 +35,7 @@ Active rows preserve the registered A/B/C batch from PR #44. If a row is stale, 
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `tests/e2e/extension.fixture.spec.ts`, `tests/unit/settings.unit.spec.ts`, optional `src/shared/settings.ts`, `src/content/settings.ts`, `src/popup/popup.ts` | `SYT-010H-A` | Nietzsche | `swarm/syt-010h-settings-popup` | Settings/popup coverage lane | PR reviewed/integrated or lane closed |
-| `docs/swarm/handoffs/SYT-010H-B.md`, optional isolated unit helper tests only | `SYT-010H-B` | Wegener | `swarm/syt-010h-selector-runtime-audit` | Selector/runtime churn audit lane; no production source edits | PR reviewed/integrated or lane closed |
-| `docs/swarm/context-map.md`, `docs/swarm/current-state.md`, `docs/swarm/task-board.md`, `docs/swarm/agent-registry.md`, selected completed handoff stubs/archive docs | `SYT-010H-C` | Leibniz | `swarm/syt-010h-docs-compaction` | Hot docs/context compaction lane | PR reviewed/integrated or lane closed |
+| none | none | none | none | none | none |
 
 ## Recently Completed
 
@@ -60,6 +56,9 @@ Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, t
 | `SYT-036` / #37 | Home hover lifecycle and #38 live Theater/chat fixes integrated |
 | `SYT-010H` setup / #39/#40/#41/#42/#43 | integration record, context repair, burst capacity, planner registration, and lane plan integrated |
 | `SYT-010H` batch registration / #44 | active A/B/C batch registered; preserve active rows until controller reconciliation |
+| `SYT-010H-A` / #45 | settings/popup coverage integrated |
+| `SYT-010H-B` / #46 | selector/runtime churn audit integrated |
+| `SYT-010H-C` / #47 | docs/context compaction integrated |
 
 ## Pending Launch
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -15,15 +15,17 @@ Use this file to track who is working, where they are working, and whether the c
 
 | Owner | Started | Expected Action | Stop Condition | Stale After | Notes |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | 90 minutes | No active controller lease after `SYT-021` integration. |
+| none | none | none | none | 90 minutes | No active controller lease between bounded passes. |
 
 ## Active Agents
 
+Active rows preserve the registered A/B/C batch from PR #44. If a row is stale, the controller should reconcile it against branch/PR state before removing it.
+
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019eb49a-c484-7b40-9f6f-662172dd8c22` / Nietzsche | `SYT-010H-A` | Runner | Running | `swarm/syt-010h-settings-popup` | agent workspace | TBD | 2026-06-11 02:55 UTC | Add settings/popup/defaults/persistence coverage, run focused checks, open draft PR | none |
-| `019eb49b-58af-79f1-aca5-38fba53c14da` / Wegener | `SYT-010H-B` | Runner/Auditor | Running | `swarm/syt-010h-selector-runtime-audit` | agent workspace | TBD | 2026-06-11 02:55 UTC | Produce selector/runtime churn audit with no production source edits, run checks, open draft PR if changed | none |
-| `019eb49b-ef01-7923-8c57-f4faedee2108` / Leibniz | `SYT-010H-C` | Docs Runner | Running | `swarm/syt-010h-docs-compaction` | agent workspace | TBD | 2026-06-11 02:55 UTC | Compact hot swarm docs without source/test edits, run `git diff --check`, open draft PR | none |
+| `019eb49a-c484-7b40-9f6f-662172dd8c22` / Nietzsche | `SYT-010H-A` | Runner | Needs Review | `swarm/syt-010h-settings-popup` | agent workspace | #45 | 2026-06-11 02:55 UTC | 2026-06-11 | Controller should route review for PR #45 after active batch reconciliation | none |
+| `019eb49b-58af-79f1-aca5-38fba53c14da` / Wegener | `SYT-010H-B` | Runner/Auditor | Needs Review | `swarm/syt-010h-selector-runtime-audit` | agent workspace | #46 | 2026-06-11 02:55 UTC | 2026-06-11 | Controller should route review for PR #46 after active batch reconciliation | none |
+| `019eb49b-ef01-7923-8c57-f4faedee2108` / Leibniz | `SYT-010H-C` | Docs Runner | Running | `swarm/syt-010h-docs-compaction` | agent workspace | TBD | 2026-06-11 02:55 UTC | 2026-06-11 | Compact hot swarm docs without source/test edits, run `git diff --check`, open draft PR | none |
 
 ## Paused / Stale Agents
 
@@ -37,51 +39,33 @@ Use this file to track who is working, where they are working, and whether the c
 | --- | --- | --- | --- | --- | --- |
 | `tests/e2e/extension.fixture.spec.ts`, `tests/unit/settings.unit.spec.ts`, optional `src/shared/settings.ts`, `src/content/settings.ts`, `src/popup/popup.ts` | `SYT-010H-A` | Nietzsche | `swarm/syt-010h-settings-popup` | Settings/popup coverage lane | PR reviewed/integrated or lane closed |
 | `docs/swarm/handoffs/SYT-010H-B.md`, optional isolated unit helper tests only | `SYT-010H-B` | Wegener | `swarm/syt-010h-selector-runtime-audit` | Selector/runtime churn audit lane; no production source edits | PR reviewed/integrated or lane closed |
-| `docs/swarm/context-map.md`, `docs/swarm/current-state.md`, `docs/swarm/task-board.md`, selected completed handoff stubs/archive docs | `SYT-010H-C` | Leibniz | `swarm/syt-010h-docs-compaction` | Hot docs/context compaction lane | PR reviewed/integrated or lane closed |
+| `docs/swarm/context-map.md`, `docs/swarm/current-state.md`, `docs/swarm/task-board.md`, `docs/swarm/agent-registry.md`, selected completed handoff stubs/archive docs | `SYT-010H-C` | Leibniz | `swarm/syt-010h-docs-compaction` | Hot docs/context compaction lane | PR reviewed/integrated or lane closed |
 
 ## Recently Completed
 
-| Agent / Thread | Task ID | Role | Result | Completed | Notes |
-| --- | --- | --- | --- | --- | --- |
-| `019dd83b-c95c-7ab3-a871-ed8aa6fb941c` / Gauss | `SYT-CTL-001` | Reviewer | Ready to Integrate, no findings | 2026-04-29 03:54 EDT | Read-only PR #11 review passed. |
-| `019dd83e-75af-73d2-81c1-a30a12305198` / Meitner | `SYT-CTL-001` | Integrator | Merged PR #11 | 2026-04-29 03:58 EDT | PR #11 squash-merged into `main` at `676efc8`; branch cleaned. |
-| `019dd841-965d-7cf2-be3b-d79b0f2e0595` / Beauvoir | `SYT-010A` | Runner | Opened draft PR #12 | 2026-04-29 05:37 EDT | `npm run test:e2e`, `npm run validate:all`, and `git diff --check` passed. |
-| `019dd89b-89b0-79f3-bf62-b64b3cb0ae6f` / Mendel | `SYT-010A` | Reviewer | Ready to Integrate, no findings | 2026-04-29 07:12 EDT | Targeted PR #12 review passed; `npm run test:e2e` and `git diff --check origin/main...HEAD` passed. |
-| `019dd8f8-d696-7f82-a403-c1f7b70e2716` / McClintock | `SYT-010A` | Integrator | Merged PR #12 | 2026-04-29 07:25 EDT | PR #12 squash-merged into `main` at `59ec975`; local task branch deleted and remote branch already removed. |
-| `019dd952-fc1f-7692-878b-cc0cbaa13d42` / Linnaeus | `SYT-010B` | Senior Runner | Opened draft PR #14 | 2026-04-29 10:38 EDT | Conservative validation hardening; `npm run validate:all`, `npm run test:e2e`, `npm run lint`, and `npm run typecheck` passed. |
-| `019dd9b0-7e98-7983-88de-9463e804000e` / Hypatia | `SYT-010B` | Reviewer | Ready to Integrate, no findings | 2026-04-29 12:15 EDT | Targeted PR #14 review passed; `npm run validate`, `npm run build`, `npm run test:e2e`, and content-script module checks passed. |
-| `019dda09-c04a-7040-ab08-a641d093f545` / Helmholtz | `SYT-010B` | Integrator | Merged PR #14 | 2026-04-29 12:25 EDT | PR #14 squash-merged into `main` at `5675059`; local `main` synced; remote and local task branch cleanup completed. |
-| `019dda63-8fdc-7531-b649-2a91669070c4` / Ampere | `SYT-010C` | Planner/Runner | Opened draft PR #16 | 2026-04-29 15:30 EDT | Docs-only RC gate; `git diff --check` passed; human QA requested no. |
-| `019ddabc-9d77-7692-81b6-80ff60498621` / Boole | `SYT-010C` | Reviewer | Ready to Integrate, no findings | 2026-04-29 17:06 EDT | Docs/process review passed; `git diff --check origin/main...HEAD` passed; human QA requested no. |
-| `019ddb16-4dcd-7c83-9fce-e664dfdf53a1` / Carson | `SYT-010C` | Integrator | Merged PR #16 | 2026-04-29 17:14 EDT | PR #16 squash-merged into `main` at `0fca6c3`; remote and local task branch cleanup completed; integration-record docs landed through follow-up PR policy. |
-| `019ddb72-af51-7372-8146-43d5ead7148a` / Dirac | `SYT-010D` | Planner/Runner | Opened draft PR #18 | 2026-04-29 20:28 EDT | Added Playwright unit project and helper tests; `npm run test:unit`, `typecheck`, `lint`, and `validate:all` passed. |
-| `019ddbcb-2d65-76c1-982c-54abedb730cc` / Ptolemy | `SYT-010D` | Reviewer | Ready to Integrate, no findings | 2026-04-29 22:03 EDT | PR #18 review passed; `npm run test:unit`, `git diff --check origin/main...HEAD`, `npm run validate:all`, and `git diff --check` passed. |
-| `019ddc21-c7bb-75a2-94f6-e8d84b8f4489` / Planck | `SYT-010D` | Integrator | Merged PR #18 | 2026-04-29 22:07 EDT | PR #18 squash-merged into `main` at `88f0a91`; local branch cleanup completed and stale remote-tracking ref pruned. |
-| `019eb0bd-d604-78a3-a94f-949659401efb` / Godel | `SYT-021` | Reviewer | Needs Fixes | 2026-06-10 04:52 EDT | Review found `git diff --check origin/main...HEAD` failed on EOF blank lines in compact docs; `npm run test:e2e` passed. Controller fixed whitespace on the PR branch; re-review next. |
-| `019eb0c7-e8dc-7352-9531-8f7be5692bdb` / Gibbs | `SYT-021` | Reviewer | Ready to Integrate | 2026-06-10 05:13 EDT | Re-review passed with no findings; `git diff --check origin/main...HEAD` and `npm run test:e2e` passed; human QA optional, not required. |
-| `019eb0d4-9f71-7c52-a08f-2186cff049d5` / Lorentz | `SYT-021` | Integrator | Merged PR #22 | 2026-06-10 05:23 EDT | `npm run validate:all` passed; PR #22 squash-merged into `main` at `8f90ef1`; issue #21 closed; remote/local task branch cleanup completed. |
-| `019eb0f1-9608-74f3-af18-2f13569896b5` / Euler | `SYT-010E` | Senior Runner | Opened draft PR #24 | 2026-06-10 05:52 EDT | Narrow grid-hover selector normalization; `npm run test:unit`, `npm run test:e2e`, and `npm run validate:all` passed; issue #10 commented. |
-| `019eb0fc-5137-71b1-ad83-a22a768775ed` / Hilbert | `SYT-010E` | Reviewer | Ready to Integrate | 2026-06-10 05:55 EDT | No findings; `git diff --check origin/main...HEAD` and `npm run test:unit` passed; human QA not required; PR #24 still draft. |
-| `019eb100-fe46-7bc3-b8a5-9c5f563a73b1` / Ramanujan | `SYT-010E` | Integrator | Merged PR #24 | 2026-06-10 06:13 EDT | `npm run validate:all` passed; PR #24 marked ready and squash-merged into `main` at `fae4e5d`; issue #10 remains open; remote/local task branch cleanup completed. |
-| `019eb10d-7fef-7c52-916f-0245bf25d828` / Dalton | `SYT-010F` | Planner | Needs Review | 2026-06-10 06:40 EDT | Chose Sticky Player hardening, created Runner-ready handoff, and opened draft PR #26 for review; #8 remains paused. |
-| `019eb128-3fca-7111-bbb2-152f11a8747c` / McClintock | `SYT-010F` | Reviewer | Ready to Integrate | 2026-06-10 06:49 EDT | No findings; `git diff --check origin/main...HEAD` passed; human QA not required; PR #26 still draft. |
-| `019eb12d-5860-7852-8447-17dfb4db7cc3` / Faraday | `SYT-010F` | Integrator | Merged PR #26 | 2026-06-10 07:00 EDT | PR #26 marked ready and squash-merged into `main` at `66d756f`; issue #10 remains open; remote/local planning branch cleanup completed. |
-| `019eb145-89d5-7e93-ae8e-46819bfb6ac0` / Harvey | `SYT-010F` | Senior Runner | Needs Review | 2026-06-10 07:47 EDT | Opened draft PR #28; full validation passed; issue #10 commented. |
-| `019eb18b-2df6-74b3-baba-68adfc94427a` / Newton | `SYT-010F` | Reviewer | Ready to Integrate | 2026-06-10 08:56 EDT | Final PR #28 review passed with no findings; unit/e2e/typecheck/lint and diff checks passed. |
-| `019eb1a5-f3e6-7520-86aa-956ea3bd2de6` / Hume | `SYT-010F` | Integrator | Merged PR #28 | 2026-06-10 09:02 EDT | `npm run validate:all` passed; PR #28 squash-merged at `fa07c18`; docs follow-up PR #29 merged at `6580065`; issue #10 remains open. |
-| `019eb293-9f5e-7ca2-ada8-6bad5f84c002` / Russell | `SYT-010G` | Reviewer | Ready to Integrate | 2026-06-10 13:30 EDT | No findings; `git diff --check origin/main...origin/swarm/syt-010g-fullscreen-ui-geometry` and `npm run test:unit` passed; human QA not required. |
-| Codex / main controller | `SYT-010G` | Integrator | Merged PR #34 | 2026-06-10 13:33 EDT | `npm run validate:all` passed; PR #34 squash-merged at `99156b5`; issue #10 remains open. |
-| `019eb2b0-254b-7230-9b53-3f98d55020f6` / Bacon | `SYT-036` | Reviewer | Ready for Human QA | 2026-06-10 14:04 EDT | No findings; `git diff --check`, targeted Home hover regression, and full fixture suite passed. Keep human QA gate before merge due live YouTube hover behavior. |
-| `019eb3ac-ad99-7b90-8a44-09fd13f141bc` / Anscombe | `SYT-036` | Reviewer | Ready for Human QA | 2026-06-10 18:44 EDT | No findings; `git diff --check origin/main...origin/swarm/syt-036-home-hover-stuck-lifecycle`, `npm run test:e2e`, and `npm run test:e2e:live` passed. Superseded by post-review #38 live-stream Theater/chat overlay patch. |
-| `019eb401-965a-7551-84e5-e5212c4eb10d` / Bernoulli | `SYT-036` / `SYT-038` | Reviewer | Ready for Human QA, superseded | 2026-06-10 20:13 EDT | No findings; targeted live-chat/native-hover checks and full fixture suite passed. Superseded by screenshot QA patch that removed the extension-created duplicate close button. |
-| `019eb455-9972-7030-9acc-b0f041d55f9b` / Sagan | `SYT-036` / `SYT-038` | Reviewer | Shutdown before result | 2026-06-10 21:43 EDT | Closed by controller because user reported a new non-overlay live-chat black-panel regression before review completed; route fresh review after the follow-up patch. |
-| `019eb492-7de4-7e50-8df0-fc9e66b1f2c8` / Avicenna | `SYT-010H` | Planner | Opened draft PR #43, merged | 2026-06-11 02:52 UTC | Produced SYT-010H lane map; PR #43 squash-merged at `7ce7872`; closed by controller. |
+Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, task handoff stubs, PRs, and Git history for details.
+
+| Task / PR | Result |
+| --- | --- |
+| `SYT-CTL-001` / #11 | swarm packet integrated |
+| `SYT-010A` / #12 | fixture coverage hardening integrated |
+| `SYT-010B` / #14 | settings parity validation hardening integrated |
+| `SYT-010C` / #16 | release-candidate process docs integrated |
+| `SYT-010D` / #18 | helper unit-test project integrated |
+| `SYT-021` / #22 | native hover SPA regression integrated; issue #21 closed |
+| `SYT-010E` / #24 | grid-hover selector normalization integrated |
+| `SYT-010F` / #26/#28/#29 | Sticky Player planning, implementation, and docs follow-up integrated |
+| `SYT-031` / #32 | Home native hover autoplay regression integrated; issue #31 closed |
+| `SYT-010G` / #34 | fullscreen/player UI geometry hardening integrated |
+| `SYT-036` / #37 | Home hover lifecycle and #38 live Theater/chat fixes integrated |
+| `SYT-010H` setup / #39/#40/#41/#42/#43 | integration record, context repair, burst capacity, planner registration, and lane plan integrated |
+| `SYT-010H` batch registration / #44 | active A/B/C batch registered; preserve active rows until controller reconciliation |
 
 ## Pending Launch
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| `SYT-010H-D` | Senior Developer | `swarm/syt-010h-runtime-churn` | Only after B reports and controller selects one serial implementation target | `docs/swarm/handoffs/SYT-010H.md` |
 
 ## Side Chats
 

--- a/docs/swarm/archive/README.md
+++ b/docs/swarm/archive/README.md
@@ -30,14 +30,15 @@ GitHub PR bodies, reviews, and issue comments remain the preferred public histor
 | `SYT-036` / `SYT-038` | PR #37 / issues #36/#38 | `342854f`, Home hover lifecycle and live Theater/chat fixes integrated | `docs/swarm/handoffs/SYT-036.md` |
 | `SYT-036` integration record | PR #39 | `969c3b7`, post-integration state recorded | `docs/swarm/context-map.md`, `docs/swarm/task-board.md` |
 | `SYT-010H` setup | PRs #40/#41/#42/#43/#44 / issue #10 | context repair, burst capacity, planner registration, lane map, and batch registration integrated through `2f991ef` | `docs/swarm/handoffs/SYT-010H.md` |
+| `SYT-010H-A` | PR #45 / issue #10 | `ce09953`, settings/popup coverage integrated | `docs/swarm/handoffs/SYT-010H.md` |
+| `SYT-010H-B` | PR #46 / issue #10 | `ddac456`, selector/runtime churn audit integrated | `docs/swarm/handoffs/SYT-010H-B.md` |
+| `SYT-010H-C` | PR #47 / issue #10 | docs/context compaction integrated | `docs/swarm/context-map.md` |
 
 ## Active / Deferred Work
 
 | Task | Status | Reference |
 | --- | --- | --- |
-| `SYT-010H-A` | Active settings/popup lane | `docs/swarm/handoffs/SYT-010H.md` |
-| `SYT-010H-B` | Active selector/runtime audit lane | `docs/swarm/handoffs/SYT-010H.md` |
-| `SYT-010H-C` | Active docs compaction lane | `docs/swarm/handoffs/SYT-010H.md` |
-| `SYT-010H-D/E/F` | Hold until A/B/C reconciliation | `docs/swarm/handoffs/SYT-010H.md` |
+| `SYT-010H-D` | Ready serial runtime apply-loop/polling lane | `docs/swarm/handoffs/SYT-010H.md`, `docs/swarm/handoffs/SYT-010H-B.md` |
+| `SYT-010H-E/F` | Hold until D or selector-fixture decision | `docs/swarm/handoffs/SYT-010H.md` |
 | `SYT-008A` | Paused future research | `docs/swarm/handoffs/SYT-008A.md` |
 | `SYT-RC-001` | Backlog release candidate checklist | `docs/swarm/task-board.md` |

--- a/docs/swarm/archive/README.md
+++ b/docs/swarm/archive/README.md
@@ -4,30 +4,40 @@ This archive keeps completed-lane history out of hot controller context while pr
 
 ## How To Recover Full History
 
-Use Git history for the file before the 2026-06-10 compaction commit:
+Use Git history for the handoff before the relevant compaction commit:
 
 ```bash
 git log -- docs/swarm/handoffs/<TASK-ID>.md
 git show <commit-before-compaction>:docs/swarm/handoffs/<TASK-ID>.md
 ```
 
-GitHub PR bodies and reviews remain the preferred public history for completed work.
+GitHub PR bodies, reviews, and issue comments remain the preferred public history for completed work.
 
 ## Completed Lane Map
 
 | Task | Public Reference | Merge / Result | Hot Stub |
 | --- | --- | --- | --- |
-| `SYT-CTL-001` | PR #11 | `676efc8`, repo-local swarm packet integrated | `docs/swarm/handoffs/SYT-CTL-001.md` |
+| `SYT-CTL-001` | PR #11 | `676efc8`, swarm packet integrated | `docs/swarm/handoffs/SYT-CTL-001.md` |
 | `SYT-010A` | PR #12 | `59ec975`, fixture coverage hardening integrated | `docs/swarm/handoffs/SYT-010A.md` |
 | `SYT-010B` | PR #14 | `5675059`, settings parity validation hardening integrated | `docs/swarm/handoffs/SYT-010B.md` |
 | `SYT-010C` | PR #16 | `0fca6c3`, release-candidate process docs integrated | `docs/swarm/handoffs/SYT-010C.md` |
 | `SYT-010D` | PR #18 | `88f0a91`, helper unit tests integrated | `docs/swarm/handoffs/SYT-010D.md` |
 | `SYT-021` | PR #22 / issue #21 | `8f90ef1`, native hover SPA regression integrated | `docs/swarm/handoffs/SYT-021.md` |
+| `SYT-010E` | PR #24 / issue #10 | `fae4e5d`, grid-hover selector hardening integrated | `docs/swarm/handoffs/SYT-010E.md` |
+| `SYT-010F` | PRs #26/#28/#29 / issue #10 | `66d756f` planning, `fa07c18` implementation, `6580065` docs follow-up | `docs/swarm/handoffs/SYT-010F.md` |
+| `SYT-031` | PR #32 / issue #31 | `8e881c9`, Home native hover autoplay regression integrated | `docs/swarm/handoffs/SYT-031.md` |
+| `SYT-010G` | PR #34 / issue #10 | `99156b5`, fullscreen player UI geometry hardening integrated | `docs/swarm/handoffs/SYT-010G.md` |
+| `SYT-036` / `SYT-038` | PR #37 / issues #36/#38 | `342854f`, Home hover lifecycle and live Theater/chat fixes integrated | `docs/swarm/handoffs/SYT-036.md` |
+| `SYT-036` integration record | PR #39 | `969c3b7`, post-integration state recorded | `docs/swarm/context-map.md`, `docs/swarm/task-board.md` |
+| `SYT-010H` setup | PRs #40/#41/#42/#43/#44 / issue #10 | context repair, burst capacity, planner registration, lane map, and batch registration integrated through `2f991ef` | `docs/swarm/handoffs/SYT-010H.md` |
 
 ## Active / Deferred Work
 
 | Task | Status | Reference |
 | --- | --- | --- |
+| `SYT-010H-A` | Active settings/popup lane | `docs/swarm/handoffs/SYT-010H.md` |
+| `SYT-010H-B` | Active selector/runtime audit lane | `docs/swarm/handoffs/SYT-010H.md` |
+| `SYT-010H-C` | Active docs compaction lane | `docs/swarm/handoffs/SYT-010H.md` |
+| `SYT-010H-D/E/F` | Hold until A/B/C reconciliation | `docs/swarm/handoffs/SYT-010H.md` |
 | `SYT-008A` | Paused future research | `docs/swarm/handoffs/SYT-008A.md` |
-| `SYT-010E` | Next code-hardening lane | `docs/swarm/handoffs/SYT-010E.md` |
 | `SYT-RC-001` | Backlog release candidate checklist | `docs/swarm/task-board.md` |

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,14 +4,16 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active implementation lane: none
-- Last integrated lane: `SYT-036` / `SYT-038`
-- GitHub issues: #10 open; #36 closed; #38 closed; #31 closed
-- PR: none active for #10 hardening; #20 remains paused draft for #8 research
-- Branch: `main`
-- Current status: PR #37 was merged at `342854f`, closing #36/#38; PR #39 merged the post-integration state repair at `969c3b7`. User confirmed the desired behavior was working before merge.
-- Next priority lane: launch `SYT-010H` final-leg polish/code-hardening under #10.
-- Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate
+- Active lane family: `SYT-010H`, final-leg polish/code-hardening under issue #10.
+- Current routing: planning PR #43 merged at `7ce7872`; batch registration PR #44 merged at `2f991ef`; first supervised burst is A/B/C only.
+- Active batch:
+  - `SYT-010H-A`: settings/popup/defaults/persistence coverage on `swarm/syt-010h-settings-popup`, PR #45 open.
+  - `SYT-010H-B`: selector/runtime churn audit on `swarm/syt-010h-selector-runtime-audit`, PR #46 open.
+  - `SYT-010H-C`: docs/context compaction on `swarm/syt-010h-docs-compaction`.
+- Hold lanes: `SYT-010H-D/E/F` stay serial until A/B/C report and the controller reconciles docs.
+- GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
+- Recent merged swarm docs PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration.
+- Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
 
 ## Hot Files
 
@@ -20,12 +22,12 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 - Task queue: `docs/swarm/task-board.md`
 - Agent capacity: `docs/swarm/agent-registry.md`
 - GitHub policy/state: `docs/swarm/github.md`
-- Next handoff: `docs/swarm/handoffs/SYT-010H.md`
+- Active lane handoff: `docs/swarm/handoffs/SYT-010H.md`
 - User steering: `docs/swarm/user-feedback.md`
 
-## Cold / Archived History
+## Completed Lane References
 
-Completed lanes are intentionally compacted to stubs:
+Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/archive/README.md` for full history.
 
 - `SYT-CTL-001` -> PR #11, merge `676efc8`
 - `SYT-010A` -> PR #12, merge `59ec975`
@@ -34,22 +36,12 @@ Completed lanes are intentionally compacted to stubs:
 - `SYT-010D` -> PR #18, merge `88f0a91`
 - `SYT-021` -> PR #22, merge `8f90ef1`, closes #21
 - `SYT-010E` -> PR #24, merge `fae4e5d`, refs #10
-- `SYT-010F` planning -> PR #26, merge `66d756f`, refs #10
-- `SYT-010F` implementation -> PR #28, merge `fa07c18`, refs #10
-- `SYT-010F` docs follow-up -> PR #29, merge `6580065`
+- `SYT-010F` planning/implementation/docs -> PRs #26/#28/#29, merges `66d756f`/`fa07c18`/`6580065`
 - `SYT-031` -> PR #32, merge `8e881c9`, closes #31
 - `SYT-010G` -> PR #34, merge `99156b5`, refs #10
 - `SYT-036` / `SYT-038` -> PR #37, merge `342854f`, closes #36/#38
-- `SYT-036` integration record -> PR #39, merge `969c3b7`
-
-Full prior handoff text is recoverable through Git history before the 2026-06-10 compaction commit. Use `docs/swarm/archive/README.md` for the reference map.
+- `SYT-036`/`SYT-010H` docs repairs -> PRs #39/#40/#41/#42/#43/#44, through merge `2f991ef`
 
 ## Next Safe Controller Action
 
-Launch `SYT-010H`:
-
-- Do not bump version, tag, or release.
-- Start with a planner/audit branch such as `swarm/syt-010h-polish-plan`.
-- Produce a small list of runner-sized cleanup tasks before source refactors, including which tasks are safe for up to 3-way parallel dispatch.
-- Focus on settings walkthrough, selector accuracy, runtime polling/churn reduction, fixture gaps, redundancy, and docs compaction.
-- Do not restart #8 enhanced hover research.
+Wait for or reconcile the active `SYT-010H-A/B/C` batch. After all three report, update the registry/task board, review their PRs serially, then select at most one serial runtime lane from B's audit recommendations.

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -5,14 +5,14 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 ## Current Hot State
 
 - Active lane family: `SYT-010H`, final-leg polish/code-hardening under issue #10.
-- Current routing: planning PR #43 merged at `7ce7872`; batch registration PR #44 merged at `2f991ef`; first supervised burst is A/B/C only.
-- Active batch:
-  - `SYT-010H-A`: settings/popup/defaults/persistence coverage on `swarm/syt-010h-settings-popup`, PR #45 open.
-  - `SYT-010H-B`: selector/runtime churn audit on `swarm/syt-010h-selector-runtime-audit`, PR #46 open.
-  - `SYT-010H-C`: docs/context compaction on `swarm/syt-010h-docs-compaction`.
-- Hold lanes: `SYT-010H-D/E/F` stay serial until A/B/C report and the controller reconciles docs.
+- Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, and selector/runtime audit PR #46 are merged; docs compaction PR #47 is this state repair.
+- Completed first burst:
+  - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
+  - `SYT-010H-B`: selector/runtime churn audit, PR #46, merge `ddac456`.
+  - `SYT-010H-C`: docs/context compaction, PR #47.
+- Next serial lane: choose one `SYT-010H-D` runtime apply-loop/polling hardening target from the B audit. Keep implementation serial.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
-- Recent merged swarm docs PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration.
+- Recent merged swarm docs PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
 
 ## Hot Files
@@ -40,8 +40,10 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 - `SYT-031` -> PR #32, merge `8e881c9`, closes #31
 - `SYT-010G` -> PR #34, merge `99156b5`, refs #10
 - `SYT-036` / `SYT-038` -> PR #37, merge `342854f`, closes #36/#38
-- `SYT-036`/`SYT-010H` docs repairs -> PRs #39/#40/#41/#42/#43/#44, through merge `2f991ef`
+- `SYT-036`/`SYT-010H` docs repairs -> PRs #39/#40/#41/#42/#43/#44/#47, through this compaction lane
+- `SYT-010H-A` -> PR #45, merge `ce09953`, refs #10
+- `SYT-010H-B` -> PR #46, merge `ddac456`, refs #10
 
 ## Next Safe Controller Action
 
-Wait for or reconcile the active `SYT-010H-A/B/C` batch. After all three report, update the registry/task board, review their PRs serially, then select at most one serial runtime lane from B's audit recommendations.
+Launch one serial `SYT-010H-D` runtime apply-loop/polling hardening lane, scoped from the B audit. Do not launch multiple runtime lanes in parallel.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -9,11 +9,11 @@
 
 ## Current Focus
 
-1. Finish the first `SYT-010H` supervised burst:
-   - A: settings/popup/defaults/persistence coverage.
-   - B: selector/runtime churn audit.
-   - C: swarm docs/context compaction.
-2. Keep runtime implementation serial until B reports. Do not mix `SYT-010H-D/E/F` with the active A/B/C batch.
+1. Reconcile the completed first `SYT-010H` supervised burst:
+   - A: settings/popup/defaults/persistence coverage, PR #45 merged at `ce09953`.
+   - B: selector/runtime churn audit, PR #46 merged at `ddac456`.
+   - C: swarm docs/context compaction, PR #47.
+2. Launch at most one serial `SYT-010H-D` runtime apply-loop/polling hardening target from the B audit.
 3. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
 4. Keep release-candidate/version/tag/Web Store work out of the hardening lanes.
 
@@ -24,7 +24,9 @@
 - PRs #40/#41/#42 repaired SYT-010H context, burst capacity, and planner registry state.
 - PR #43 merged the `SYT-010H` lane map at `7ce7872`.
 - PR #44 registered the A/B/C batch at `2f991ef`.
-- PRs #45 and #46 are open for A and B; C is this docs compaction branch.
+- PR #45 merged settings/popup coverage.
+- PR #46 merged the selector/runtime churn audit.
+- PR #47 is this docs compaction branch.
 - Issue #10 remains open for final-leg hardening; #8 remains a future gated research lane.
 
 ## Constraints And Risks
@@ -52,4 +54,4 @@
 ## Last Updated
 
 - Date: 2026-06-11
-- By: Docs Runner for `SYT-010H-C`
+- By: Controller/Docs Runner for `SYT-010H-C`

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,91 +4,52 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening; `SYT-036` / #38 are integrated on `main`, and `SYT-010H` is the next final-leg polish/code-hardening lane
+- Status: existing repo, post-v0.3.0 hardening; `SYT-010H` final-leg polish/code-hardening is active under issue #10.
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
-
-## Project Brief
-
-- Brief: `docs/swarm/project-brief.md`
-- Question gate: deferred, not blocking
-- Dispatch readiness: `SYT-010H` is ready for a planner/audit branch after PR #37 integration
-
-## Goal
-
-Put Simple YT Tweaks into a paced autonomous controller rhythm with scoped GitHub issue lanes, stronger fixture-first automated verification, and a smoother release-candidate process.
 
 ## Current Focus
 
-1. Launch `SYT-010H` as the final-leg polish/code-hardening lane under #10: settings walkthrough, selector cleanup, fixture gaps, runtime polling audit, and small refactors only where they reduce risk.
-2. Use a supervised burst of up to 3 subagents only after the `SYT-010H` planner defines disjoint path scopes and verification commands; keep fragile runtime changes serial.
-3. Keep #8 as a future high-risk research lane until tests and product direction justify it.
-4. Keep release-candidate work separate from routine fixture/source hardening.
-5. Keep hot swarm context compact; use `docs/swarm/context-map.md` and archive references instead of loading old completed handoffs.
+1. Finish the first `SYT-010H` supervised burst:
+   - A: settings/popup/defaults/persistence coverage.
+   - B: selector/runtime churn audit.
+   - C: swarm docs/context compaction.
+2. Keep runtime implementation serial until B reports. Do not mix `SYT-010H-D/E/F` with the active A/B/C batch.
+3. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
+4. Keep release-candidate/version/tag/Web Store work out of the hardening lanes.
 
-## Success Criteria
+## Recent State
 
-- `SWARM.md` and `docs/swarm/**` exist and are repo-local.
-- Task board maps #8 and #10 into scoped lanes with dependencies, verification commands, PR strategy, and human QA gates.
-- Repo-owned Playwright fixture tests remain the primary verification path.
-- Controller heartbeat is active at about 90 minutes while work remains active.
-- No product code is changed during fixture-hardening setup unless a scoped task explicitly owns it.
+- PR #37 merged at `342854f`, closing #36/#38 after user-confirmed Home hover and live Theater/chat behavior.
+- PR #39 recorded #36/#38 integration.
+- PRs #40/#41/#42 repaired SYT-010H context, burst capacity, and planner registry state.
+- PR #43 merged the `SYT-010H` lane map at `7ce7872`.
+- PR #44 registered the A/B/C batch at `2f991ef`.
+- PRs #45 and #46 are open for A and B; C is this docs compaction branch.
+- Issue #10 remains open for final-leg hardening; #8 remains a future gated research lane.
 
-## Constraints
+## Constraints And Risks
 
-- Existing repo, not blank.
-- Use existing remote and GitHub issues.
-- Use task branches and draft PRs when useful.
-- Default to 1 active subagent at a time.
-- Do not request human QA for every small PR.
-- Do not rely on live YouTube tests as the default gate.
-- Keep private `.private/` notes off GitHub.
-- Do not bump versions, tag releases, or edit Web Store assets during hardening setup.
-
-## Known Risks
-
-- `src/content/grid-hover.ts`, `sticky-player.ts`, `sidebar.ts`, `fullscreen.ts`, and `theater.ts` are large and touch fragile YouTube DOM behavior.
-- Settings are duplicated between `src/shared/settings.ts` and `src/content/settings.ts`; validation checks parity, but refactoring could affect bundling.
-- Fixture tests do not fully simulate live YouTube hover preview overlay behavior, so #8 needs a research gate and likely human/visual QA.
-- Live YouTube smoke can be flaky due to consent, experiments, bot checks, ads, or network issues.
-- Current live YouTube recommendations may render as modern `#secondary yt-lockup-view-model` cards instead of legacy compact renderers.
-
-## Recommended First Milestone
-
-`SYT-036` passed user QA for the Home hover autoplay route on PR #37. During that QA, the user found #38: live streams in enhanced Theater mode could appear cut off while live chat overlay collapsed, and non-overlay hidden live chat could leave a black panel. PR #37 was squash-merged into `main` at `342854f` after `npm run validate:all` passed; issues #36 and #38 are closed. Issue #10 remains open for `SYT-010H`, the next polish/code-hardening lane.
+- Source modules such as `grid-hover.ts`, `sticky-player.ts`, `sidebar.ts`, `fullscreen.ts`, and `theater.ts` touch fragile YouTube DOM behavior.
+- Settings are duplicated between `src/shared/settings.ts` and `src/content/settings.ts`; parity tests are the guardrail.
+- Live YouTube smoke can be noisy; fixture-first checks remain the normal gate.
+- Do not reintroduce Home/Search enhanced hover grow, synthetic hover, or forced preview playback.
+- Do not bump version, tag releases, edit Web Store assets, or close #10 from docs/test lanes.
 
 ## Verification Defaults
 
-- Runner focused checks: task-specific `npm run test:e2e`, `npm run lint`, or `npm run typecheck`.
-- Reviewer targeted checks: targeted Playwright tests plus source diff review.
-- Integrator full verify: `npm run validate:all`.
-- Browser QA: repo-owned Playwright first; `agent-browser`/Browser Use only as supplemental inspection.
-- Human milestone QA: release candidate, #8 live hover preview, or explicit high-risk browser behavior.
-
-## Tooling Preflight
-
-- Git: clean `main...origin/main` at discovery.
-- Remote: `origin` points to `https://github.com/cryptoteatime/simple-yt-tweaks.git`.
-- GitHub auth: `gh auth status` passed as `cryptoteatime`.
-- GitHub repo: `cryptoteatime/simple-yt-tweaks`, public, default branch `main`.
-- Runtime: Node `v25.9.0`, npm `11.12.1`.
-- Dependencies: `node_modules/` present.
-- Full verification: `npm run validate:all` passed on 2026-04-29 after the swarm docs were added.
-- Agent browser: `/opt/homebrew/bin/agent-browser`; wrapper `.codex-swarm/bin/agent-browser-cft` opened and closed `about:blank`.
+- Runner focused checks: task-specific `npm run test:e2e`, `npm run test:unit`, `npm run lint`, `npm run typecheck`, or `git diff --check` as assigned.
+- Reviewer targeted checks: changed-risk checks plus PR body/handoff validation.
+- Integrator full gate for source/test PRs: `npm run validate:all`.
+- Human QA: release candidate, #8 visual hover implementation, or explicit high-risk live browser behavior.
 
 ## Automation Notes
 
-- Controller heartbeat: active.
-- Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`.
-- Heartbeat cadence: slow back toward about 90 minutes after the `SYT-010F` hot-state repair lands.
-- Execution strategy: paced controller with direct subagents only after lane readiness.
-- Batch dispatch policy: disabled by default via max 1 active subagent; require disjoint parallel-safe labels if capacity is raised.
-- Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work unless assigned.
-- Active subagents: none.
-- Agent registry: `docs/swarm/agent-registry.md`.
-- Bootstrap log: `docs/swarm/bootstrap-log.md`.
-- GitHub workflow: `docs/swarm/github.md`.
+- Controller heartbeat: active, id `simple-yt-tweaks-controller-heartbeat`.
+- Capacity: up to 3 only for planner-approved disjoint `SYT-010H` A/B/C work; review, integration, and runtime implementation stay serial.
+- Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry unless a handoff explicitly assigns them.
+- Registry: `docs/swarm/agent-registry.md`.
 
 ## Last Updated
 
 - Date: 2026-06-11
-- By: Controller/Integrator after PR #37
+- By: Docs Runner for `SYT-010H-C`

--- a/docs/swarm/handoffs/SYT-010E.md
+++ b/docs/swarm/handoffs/SYT-010E.md
@@ -4,59 +4,14 @@
 
 - State: Integrated
 - GitHub issue: #10
-- Branch: `swarm/syt-010e-code-hardening` (cleaned locally and remotely)
-- PR: #24, https://github.com/cryptoteatime/simple-yt-tweaks/pull/24 (merged)
+- Branch: `swarm/syt-010e-code-hardening` (cleaned)
+- PR: #24, https://github.com/cryptoteatime/simple-yt-tweaks/pull/24
 - Merge: `fae4e5d99466b60c1149a277100f68db85c10b55`
-- Role: Integrator
-- Updated: 2026-06-10 by Integrator
+- Updated: 2026-06-11 by docs compaction
 
-## Goal
+## Result
 
-Continue post-v0.3.0 hardening without broad rewrites. Use fixture and unit coverage as the gate, and only refactor where it reduces real regression risk.
-
-## Chosen Target
-
-Narrow behavior-preserving selector normalization in `src/content/grid-hover.ts`:
-
-- Centralized the watch recommendation hover-grow card/media/overlay selector variants used by `buildSidebarHoverCss`.
-- Kept the legacy `ytd-compact-video-renderer` and modern `yt-lockup-view-model` selectors emitted for default and theater watch modes.
-- Added unit coverage that asserts enabled-mode scoping and disabled-mode omission for the generated grid hover CSS.
-
-## Scope
-
-- Audit the largest/highest-risk content modules after #21 settles:
-  - `src/content/grid-hover.ts`
-  - `src/content/sidebar.ts`
-  - `src/content/sticky-player.ts`
-  - `src/content/fullscreen.ts`
-  - `src/content/theater.ts`
-- Pick one narrow implementation target per PR.
-- Prefer behavior-preserving extraction, selector normalization, or helper tests over aesthetic file splitting.
-- Add or extend tests before changing fragile YouTube DOM behavior.
-
-## Non-Scope
-
-- Do not revive #8 enhanced Home/Search hover grow.
-- Do not change settings defaults.
-- Do not version bump, tag, release, or edit Web Store assets.
-- Do not combine broad code hardening with release-candidate work.
-
-## Lane Metadata
-
-- Parallel-safe: no while #21 is under review or integration.
-- Serial-required: yes for runtime source hardening.
-- Depends-on: PR #22 review/integration state clear.
-- Conflict-risk: medium/high because these files touch live YouTube DOM behavior.
-
-## Suggested First Pass
-
-Completed:
-
-1. Reviewed hot swarm state after PR #22 integration.
-2. Audited the requested high-risk modules by function outline and sampled relevant source/test sections.
-3. Chose one bounded target: grid hover watch recommendation selector normalization.
-4. Added unit coverage before/alongside the cleanup.
-5. Ran focused checks and the full validation gate.
+Behavior-preserving grid-hover selector normalization landed. The lane centralized watch recommendation hover-grow selector variants for legacy `ytd-compact-video-renderer` and modern `yt-lockup-view-model` recommendations, then added unit coverage for enabled-mode scoping and disabled-mode omission.
 
 ## Files Touched
 
@@ -66,26 +21,13 @@ Completed:
 
 ## Verification
 
-- Focused: `npm run test:unit` - passed, 10 tests.
-- Focused: `npm run test:e2e` - passed, 10 fixture tests.
-- Full gate: `npm run validate:all` - passed, including typecheck, lint, `git diff --check`, package validation, unit tests, and fixture tests.
-- Live Chrome/YouTube smoke not used; this target is selector/CSS generation cleanup with fixture coverage.
+- `npm run test:unit`: passed
+- `npm run test:e2e`: passed
+- `npm run validate:all`: passed
 
-## Integration
+## Notes
 
-- Reviewer Hilbert reported no findings and marked the lane `Ready to Integrate`.
-- Integrator Ramanujan verified PR #24 was mergeable and clean, marked it ready for review, and squash-merged it into `main`.
-- Final integration gate: `npm run validate:all` passed on 2026-06-10.
-- Branch cleanup completed: local and remote `swarm/syt-010e-code-hardening` refs are gone.
-- Issue #10 remains open for future hardening lanes.
-
-## Risks
-
-- Low/medium residual risk: the selector normalization still touches watch recommendation hover CSS assembly, but the emitted legacy and modern selector families are covered by unit assertions and fixture watch hover tests.
-- No settings defaults changed.
 - #8 enhanced Home/Search hover grow was not reintroduced.
-- No version, release, tag, or Web Store asset changes.
-
-## Next Recommended Role
-
-Controller: after the integration-record docs follow-up lands and the worktree is clean, plan or route `SYT-010F` as another small #10 hardening lane if issue #10 remains open. Do not reopen #8 unless the user explicitly requests that gate.
+- No settings defaults, version, release, tag, or Web Store assets changed.
+- Issue #10 remained open after merge for later hardening lanes.
+- Full historical detail is recoverable from PR #24 and Git history; see `docs/swarm/archive/README.md`.

--- a/docs/swarm/handoffs/SYT-010F.md
+++ b/docs/swarm/handoffs/SYT-010F.md
@@ -1,208 +1,41 @@
-# SYT-010F: Sticky Player Hardening Plan
+# SYT-010F: Sticky Player Hardening
 
 ## Status
 
 - State: Integrated
 - GitHub issue: #10
-- Planning PR: #26 merged at `66d756f`, https://github.com/cryptoteatime/simple-yt-tweaks/pull/26
-- Implementation PR: #28, https://github.com/cryptoteatime/simple-yt-tweaks/pull/28
-- Planning branch: `swarm/syt-010f-planning` cleaned locally/remotely
-- Recommended implementation branch: `swarm/syt-010f-sticky-player-hardening`
-- Role: Integrator
-- Updated: 2026-06-10 by Integrator
+- Planning PR: #26, merged at `66d756f`
+- Implementation PR: #28, merged at `fa07c1891d8711839fad41aaec34681b09fd69ea`
+- Docs follow-up: PR #29, merged at `6580065`
+- Branches: planning and implementation branches cleaned
+- Updated: 2026-06-11 by docs compaction
 
-## Planning Integration
+## Result
 
-- Reviewer McClintock reported no findings and `Ready to Integrate`.
-- Integrator Faraday marked PR #26 ready and squash-merged it into `main` at `66d756f`.
-- Verification: `git diff --check origin/main...HEAD` passed for the docs-only planning branch.
-- Human QA: not required.
-- Issue #10 remains open.
-- Next action: create/use `swarm/syt-010f-sticky-player-hardening` from current `main` and implement the lane below.
+Sticky Player geometry hardening landed. The implementation extracted visibility threshold and resize-rectangle math into `src/content/sticky-player-geometry.ts`, kept DOM mutation and docking behavior in `src/content/sticky-player.ts`, added pure unit coverage, and added deterministic fixture coverage for dock/restore.
 
-## Goal
-
-Continue the post-harness #10 hardening pass with one small, behavior-preserving Sticky Player lane. Reduce regression risk in `src/content/sticky-player.ts` by making its scroll/visibility/resize decisions testable and adding deterministic fixture coverage for dock/restore behavior.
-
-## Chosen Target
-
-`src/content/sticky-player.ts`
-
-Why this target:
-
-- It is one of the largest remaining content modules, at roughly 726 lines.
-- Current tests cover the Sticky Player setting in the popup, but not Sticky Player dock/restore behavior.
-- The integration log already records Sticky Player dock/undock as a deterministic fixture gap from earlier #10 work.
-- The module contains pure decision/geometry logic inside private functions (`isPlayerScrolledAway`, `isPlayerMostlyVisible`, `resolveResizedRect`) that can be extracted and unit-tested without live YouTube.
-- The existing watch fixture already has the needed player shape (`#movie_player`, video, controls, `#player-container-outer`), so fixture coverage should be possible with a small scrollable-height adjustment.
-
-## Scope
-
-- Add a narrow source hardening change for Sticky Player decision/geometry logic.
-- Prefer extracting pure helpers into a small adjacent module such as `src/content/sticky-player-geometry.ts` if importing `src/content/sticky-player.ts` directly would pull in browser globals or state too early for unit tests.
-- Keep `src/content/sticky-player.ts` as the owner of DOM mutation, docking, timers, PiP coordination, and event binding.
-- Add unit tests for the extracted pure logic:
-  - default-view sticky threshold
-  - theater-view sticky threshold
-  - mostly-visible restore threshold
-  - resize rectangle clamping/aspect-ratio behavior for representative directions
-- Add one fixture test for the watch page Sticky Player dock/restore path if it stays deterministic:
-  - make the watch fixture scrollable
-  - scroll until the player is eligible to dock
-  - assert `#simple-yt-tweaks-sticky-player-shell #movie_player`, placeholder, and body class are present
-  - scroll back to the visible player position and assert the player restores and the shell is removed
-- Update only handoff/docs needed to report the implementation result.
-
-## Non-Scope
-
-- Do not reintroduce enhanced Home/Search hover grow or highlight.
-- Do not change settings defaults, labels, storage keys, popup behavior, or version metadata.
-- Do not broaden into a Sticky Player redesign.
-- Do not change browser Picture-in-Picture behavior except where an existing call path needs to keep compiling after helper extraction.
-- Do not add live YouTube smoke as a required gate.
-- Do not bump version, tag, release, or edit Web Store assets.
-- Do not merge.
-
-## Dependencies
-
-- Depends on `SYT-010E` / PR #24 integration, already complete.
-- Depends on issue #10 remaining open, confirmed open after PR #26 merge on 2026-06-10.
-- No dependency on #8; keep #8 paused.
-
-## Parallelization Metadata
-
-- Parallel-safe: no by default under current capacity.
-- Serial-required: yes for runtime source hardening in large content modules.
-- Depends-on: `SYT-010F` planning PR #26 integrated; clean `main`.
-- Conflict-risk: medium/high because Sticky Player moves live YouTube player DOM nodes and interacts with PiP/fullscreen/theater state.
-
-## Write Scope
-
-Expected implementation files:
+## Files Touched
 
 - `src/content/sticky-player.ts`
-- Optional: `src/content/sticky-player-geometry.ts`
+- `src/content/sticky-player-geometry.ts`
 - `tests/unit/sticky-player.unit.spec.ts`
 - `tests/e2e/extension.fixture.spec.ts`
 - `tests/e2e/youtube-fixtures.ts`
 - `docs/swarm/handoffs/SYT-010F.md`
 
-Do not edit unrelated content modules unless a compile/test failure directly requires a small import/type follow-up.
-
 ## Verification
 
-Runner focused checks:
+- `npm run test:unit`: passed
+- `npm run test:e2e`: passed
+- `npm run typecheck`: passed
+- `npm run lint`: passed
+- `git diff --check`: passed
+- `npm run validate:all`: passed
 
-- `npm run test:unit`
-- `npm run test:e2e`
-- `npm run typecheck`
-- `npm run lint`
-- `git diff --check`
+## Notes
 
-Integrator full gate:
-
-- `npm run validate:all`
-
-Do not run live YouTube for this lane unless the Runner uncovers behavior that cannot be represented in fixtures and records why.
-
-## Risks
-
-- Sticky Player fixture behavior depends on reliable player geometry after scrolling. If Chromium fixture geometry is flaky, keep the helper extraction/unit tests and record the exact fixture blocker rather than forcing a fragile test.
-- Helper extraction should preserve the existing thresholds exactly unless a failing test proves an existing threshold is wrong.
-- `src/content/sticky-player.ts` imports `state`, which initializes browser-dependent state. Unit tests should avoid importing that module directly if it makes tests depend on global `location` or `document` setup.
-- Dock/restore moves the real player node; assertions must verify the node is restored to the watch fixture, not recreated or duplicated.
-
-## Integration Result
-
-- Result: Integrated.
-- Implementation PR: #28, https://github.com/cryptoteatime/simple-yt-tweaks/pull/28.
-- Merge: squash-merged into `main` at `fa07c1891d8711839fad41aaec34681b09fd69ea`.
-- Final gate: `npm run validate:all` passed, including typecheck, lint, package validation, 18 unit tests, and 11 fixture tests.
-- Branch cleanup: remote and local `swarm/syt-010f-sticky-player-hardening` refs were removed after merge.
-- Issue #10: remains open for future hardening lanes.
-- Human QA: not required for this fixture-backed hardening lane.
-- Next recommended role: Controller.
-- Exact next action: decide whether #10 needs another bounded hardening lane or can be left open for later; keep #8 enhanced hover research paused unless the user explicitly reopens it.
-
-## Senior Runner Result
-
-- Result: Needs Review.
-- Branch: `swarm/syt-010f-sticky-player-hardening`.
-- Implementation PR: #28, https://github.com/cryptoteatime/simple-yt-tweaks/pull/28.
-- Files touched:
-  - `src/content/sticky-player.ts`
-  - `src/content/sticky-player-geometry.ts`
-  - `tests/unit/sticky-player.unit.spec.ts`
-  - `tests/e2e/extension.fixture.spec.ts`
-  - `tests/e2e/youtube-fixtures.ts`
-  - `docs/swarm/handoffs/SYT-010F.md`
-- Changes:
-  - Extracted Sticky Player visibility threshold and resize-rectangle math into `src/content/sticky-player-geometry.ts`.
-  - Kept `src/content/sticky-player.ts` responsible for DOM queries, docking/restoring, timers, PiP coordination, shell controls, and event binding.
-  - Added unit coverage for default/theater dock thresholds, mostly-visible restore thresholds, unusable rectangles, and representative resize clamp/aspect-ratio paths.
-  - Added deterministic watch fixture dock/restore coverage by making the fixture scrollable, scrolling the player away, asserting shell/placeholder/body-class state, then scrolling back and asserting the real player returns to `#player`.
-- Fixture feasibility decision: feasible. The existing watch fixture player geometry was deterministic after adding a simple scroll spacer.
-- Commands run:
-  - `npm run test:unit` passed.
-  - `npm run test:e2e` passed.
-  - `npm run typecheck` passed.
-  - `npm run lint` passed after removing an unused extraction wrapper.
-  - `git diff --check` passed.
-  - `npm run validate:all` passed.
-- Decisions:
-  - No live YouTube smoke was run; fixture coverage represented the dock/restore path deterministically.
-  - No #8 enhanced Home/Search hover grow or highlight behavior was routed or implemented.
-  - No settings defaults, labels, storage keys, popup behavior, version metadata, release assets, or Web Store assets were changed.
-- Blockers: none.
-- Next recommended role: Reviewer.
-- Exact next action: review the branch/PR diff for behavior-preserving Sticky Player extraction, run targeted checks as needed, and report `Ready to Integrate` or `Needs Fixes`.
-
-## Exact Runner Prompt
-
-You are Senior Runner for Simple YT Tweaks task `SYT-010F`.
-
-Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-Issue: #10, Post-harness code hardening pass
-Branch to create/use: `swarm/syt-010f-sticky-player-hardening` from current `main`
-
-Required reading, in order:
-
-1. `/Users/d4ngl/Git Repos/Codex/AGENTS.md`
-2. `SWARM.md`
-3. `docs/swarm/controller-directives.md`
-4. `docs/swarm/context-map.md`
-5. `docs/swarm/github.md`
-6. `docs/swarm/task-board.md`
-7. `docs/swarm/user-feedback.md`
-8. `docs/swarm/handoffs/SYT-010F.md`
-9. Relevant source/tests you inspect
-
-Scope:
-
-- Implement the Sticky Player hardening lane described in `docs/swarm/handoffs/SYT-010F.md`.
-- Keep changes behavior-preserving.
-- Prefer extracting pure Sticky Player visibility/resize helpers into a small adjacent module so unit tests can cover thresholds without importing DOM state.
-- Add deterministic unit coverage and one fixture dock/restore test if feasible.
-- Update this handoff with files touched, commands run, decisions, blockers, and next role.
-
-Non-scope:
-
-- Do not reintroduce #8 enhanced Home/Search hover grow/highlight.
-- Do not change settings defaults, version, release assets, or Web Store assets.
-- Do not merge.
-- Do not run live YouTube unless a fixture gap forces a documented optional smoke.
-
-Verification:
-
-- Run `npm run test:unit`.
-- Run `npm run test:e2e`.
-- Run `npm run typecheck`.
-- Run `npm run lint`.
-- Run `git diff --check`.
-- If all focused checks pass and time permits, run `npm run validate:all`; otherwise leave it as the Integrator gate.
-
-Expected final state:
-
-- If implementation and focused checks pass, push the branch and open/update a draft PR with title starting `Codex: `.
-- PR body must include `How to test / what to tell the controller`, human review requested: `no`, exact commands, expected results, and feedback format if any.
-- Report `Needs Review` to the controller.
+- No live YouTube smoke was required; fixture coverage represented the dock/restore path deterministically.
+- #8 enhanced Home/Search hover behavior was not routed or implemented.
+- No settings defaults, version, release, tag, or Web Store assets changed.
+- Issue #10 remained open after merge.
+- Full historical detail is recoverable from PRs #26/#28/#29 and Git history; see `docs/swarm/archive/README.md`.

--- a/docs/swarm/handoffs/SYT-010H-B.md
+++ b/docs/swarm/handoffs/SYT-010H-B.md
@@ -5,10 +5,10 @@
 - Task ID: `SYT-010H-B`
 - Title: Selector Accuracy And Runtime Churn Audit
 - Assigned role: Runner/Auditor
-- Current state: Needs Review
+- Current state: Integrated
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Branch: `swarm/syt-010h-selector-runtime-audit`
-- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/46
+- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/46, merged at `ddac456`
 - GitHub issue: #10
 - Verification tier: focused docs-only
 
@@ -133,4 +133,4 @@ No helper tests were added, so `npm run test:unit`, `npm run typecheck`, and `np
 
 ## Next Recommended Role And Action
 
-Reviewer: validate that this audit is source-backed and complete enough to route `SYT-010H-D` and `SYT-010H-E`. If accepted, ask the controller to launch one serial runtime lane focused on event-first polling/downstream gate reductions, plus a separate selector-fixture lane before any selector rewrites.
+Controller: use this integrated audit to launch one serial runtime lane focused on event-first polling/downstream gate reductions, plus a separate selector-fixture lane before any selector rewrites if needed.

--- a/docs/swarm/handoffs/SYT-021.md
+++ b/docs/swarm/handoffs/SYT-021.md
@@ -1,49 +1,17 @@
 # SYT-021: Native Hover SPA Regression And Live Recommendation Drift
 
-## State
+## Status
 
-- Status: Integrated
-- Role: Integrator
-- Repo: Simple YT Tweaks
-- Branch: `swarm/syt-008b-native-hover-spa-regression` merged and cleaned
+- State: Integrated
 - GitHub issue: #21 closed
-- PR: #22 merged
-- Created: 2026-06-10
-- Updated: 2026-06-10
+- Branch: `swarm/syt-008b-native-hover-spa-regression` (cleaned)
+- PR: #22, https://github.com/cryptoteatime/simple-yt-tweaks/pull/22
+- Merge: `8f90ef1072f0e2ac3e611417ef85919f6131a02f`
+- Updated: 2026-06-11 by docs compaction
 
-## Goal
+## Result
 
-Fix the live YouTube regression where native Home hover previews can stall after navigating from a watch page back to Home without a full refresh, while preserving the v0.3.0 decision not to reintroduce enhanced Home/Search hover grow.
-
-## Scope
-
-- Preserve native Home/Search hover preview behavior with no extension grow/highlight classes.
-- Defer destructive Home sponsored cleanup briefly after SPA navigation so YouTube can finish mounting native preview/feed nodes.
-- Add a narrow fallback that only calls `play()` on an existing native feed preview video under the pointer when YouTube has already mounted it and left it paused.
-- Ensure watch-page video helpers prefer the real `#movie_player` video instead of stale preview videos.
-- Harden player-surface click fallback against transient native no-op timing.
-- Support current live recommendation cards rendered as `#secondary yt-lockup-view-model`.
-- Add fixture coverage for these regression paths.
-
-## Non-Scope
-
-- Do not revive #8 enhanced Home/Search hover grow.
-- Do not bump version, tag, release, or update Web Store assets.
-- Do not merge directly to `main`.
-
-## Dependencies
-
-- Branch started from post-v0.3.0 hardening baseline.
-- Existing #8 enhanced hover research remains deferred.
-- Existing #10 hardening remains open.
-
-## Lane Metadata
-
-- Parallel-safe: no with #8 hover research or sidebar/player runtime work.
-- Serial-required: yes; live YouTube preview lifecycle and recommendation markup are fragile.
-- Depends-on: v0.3.0 baseline and fixture harness.
-- Conflict-risk: high; touches `src/content/grid-hover.ts`, `src/content/sidebar.ts`, watch click fallback, and YouTube DOM selectors.
-- Shared coordination docs allowed: this handoff plus controller-owned task board/current state/GitHub notes.
+The lane repaired native Home/Search hover preview stalls after watch-to-Home SPA navigation and added support for modern live recommendation cards rendered as `#secondary yt-lockup-view-model`. It preserved the v0.3.0 decision not to reintroduce enhanced Home/Search hover grow.
 
 ## Files Touched
 
@@ -59,44 +27,15 @@ Fix the live YouTube regression where native Home hover previews can stall after
 
 ## Verification
 
-| Check | Result | Notes |
-| --- | --- | --- |
-| `npm run test:e2e` | Passed | 10 fixture tests, including new SPA cleanup, modern recommendation card, and transient click fallback coverage. |
-| `npm run typecheck` | Passed | TypeScript clean. |
-| `npm run lint` | Passed | ESLint clean. |
-| `git diff --check` | Passed | Included in `validate:all`. |
-| `npm run validate:all` | Passed | Typecheck, lint, whitespace, package, packaged validation, unit, and fixture tests passed. |
-| Live signed-in Chrome smoke | Passed | Home watch-to-back hover previews played/advanced on three cards; Search grid/Shorts cleanup passed; Search preview played; comments visible; real CoreGraphics player click toggled pause/play; modern `#secondary yt-lockup-view-model` recommendation hover delay passed. |
+- `npm run test:e2e`: passed
+- `npm run typecheck`: passed
+- `npm run lint`: passed
+- `npm run validate:all`: passed
+- Live signed-in Chrome smoke: passed for Home/Search previews, comments, player click fallback, and modern recommendation hover delay.
 
-## Decisions
+## Notes
 
-- Keep Home/Search previews visually native. The fallback only resumes an already-mounted native preview video under the pointer; it does not create preview UI or apply grow/highlight behavior.
-- Stop removing arbitrary empty Home grid items. Only explicit hidden/sponsored home containers/items are removed, preventing accidental interference with YouTube SPA/preview placeholders.
-- Keep #8 separate as future research for enhanced hover preview; #21 only repairs native behavior and live selector drift.
-- Treat accessibility/connector clicks as unreliable for YouTube player click testing. The real user-facing click path was verified with a lower-level CoreGraphics click.
-
-## Risks
-
-- YouTube live DOM experiments may continue to drift. Fixture now covers the observed modern `#secondary yt-lockup-view-model` recommendation shape.
-- Live YouTube ad/consent/experiment behavior can make smoke checks noisy. The stable gate remains `npm run validate:all`.
-
-## Review Result
-
-- Godel review: Needs Fixes for EOF whitespace only; `npm run test:e2e` passed.
-- Gibbs re-review: Ready to Integrate with no findings; `git diff --check origin/main...HEAD` and `npm run test:e2e` passed.
-- Human QA: optional supplemental QA, not a required merge gate, because signed-in live Chrome smoke already passed.
-
-## Integration Result
-
-- Decision: Integrated.
-- Merge: PR #22 squash-merged into `main` at `8f90ef1072f0e2ac3e611417ef85919f6131a02f`.
-- Issue: #21 auto-closed on merge at 2026-06-10T09:22:57Z.
-- Final gate: `npm run validate:all` passed on 2026-06-10, including typecheck, lint, whitespace, package validation, 8 unit tests, and 10 fixture tests.
-- Branch cleanup: remote and local `swarm/syt-008b-native-hover-spa-regression` branches cleaned.
-- Release actions: none; no version bump, tag, release, or Web Store asset update.
-
-## Next Handoff
-
-- Next role: Planner / Senior Runner for `SYT-010E`.
-- Next action: Start the next #10 code-hardening lane from `docs/swarm/handoffs/SYT-010E.md`; do not route #8 enhanced hover research next.
-- Expected result: scoped hardening PR with `npm run validate:all` as the final gate.
+- Home/Search previews remained visually native.
+- #8 enhanced Home/Search hover grow stayed deferred.
+- No version, release, tag, or Web Store assets changed.
+- Full historical detail is recoverable from PR #22 and Git history; see `docs/swarm/archive/README.md`.

--- a/docs/swarm/handoffs/SYT-036.md
+++ b/docs/swarm/handoffs/SYT-036.md
@@ -2,37 +2,19 @@
 
 ## Status
 
-- Task ID: `SYT-036`
-- GitHub issue: #36
-- Branch: `swarm/syt-036-home-hover-stuck-lifecycle`
-- PR: #37
-- State: Needs Review
-- Role: Controller/Runner
+- State: Integrated
+- GitHub issues: #36 and #38 closed
+- Branch: `swarm/syt-036-home-hover-stuck-lifecycle` (cleaned)
+- PR: #37, https://github.com/cryptoteatime/simple-yt-tweaks/pull/37
+- Merge: `342854f`
+- Integration record: PR #39, merge `969c3b7`
+- Updated: 2026-06-11 by docs compaction
 
-## Scope
+## Result
 
-Fix the live Brave YouTube PWA regression where native Home thumbnail hover autoplay stops after this route:
+The lane fixed the live Brave YouTube PWA route where native Home thumbnail hover autoplay stopped after Home -> watch -> hidden-header Home navigation. It removed synthetic Home/Search hover/playback recovery, preserved YouTube's zero-height native preview loader, and added a guarded real watch-to-Home reload watcher.
 
-1. Start on Home.
-2. Open a watch page.
-3. Hover the hidden top header to expose YouTube navigation.
-4. Click the YouTube logo or sidebar Home.
-5. Hover Home feed cards.
-
-The extension must not reintroduce enhanced Home/Search hover grow, highlight, or forced preview behavior.
-
-## Non-Scope
-
-- Do not reintroduce enhanced Home/Search hover grow, highlight, or #8 behavior.
-- Do not touch version, release, tag, Web Store assets, popup settings, or unrelated watch-page behavior.
-- Do not close #10; this is a separate bug lane.
-
-## Parallelization
-
-- `parallel-safe`: no
-- `serial-required`: yes
-- `depends-on`: `SYT-031` and `SYT-010G` integrated
-- `conflict-risk`: high, live YouTube SPA/native preview lifecycle
+The same PR also fixed #38 live-stream Theater/chat behavior: overlay chat no longer squeezes the player, comments remain scrollable, live-chat minimize/restore preserves the existing chat frame, and non-overlay `Hide Live Chat` no longer leaves a black right-side panel.
 
 ## Files Touched
 
@@ -43,104 +25,24 @@ The extension must not reintroduce enhanced Home/Search hover grow, highlight, o
 - `tests/e2e/extension.fixture.spec.ts`
 - `docs/swarm/handoffs/SYT-036.md`
 
-## Root Cause
-
-The earlier recovery path tried to help YouTube by synthetically dispatching Home/Search hover events and forcing native preview video playback. That made the fixture tests pass but remained fragile on live YouTube. After a real watch page and SPA return to Home, YouTube can leave preview-controller state in a different shape than a fresh Home load. Interfering with that state caused stale card hover backgrounds and could block YouTube's own preview startup.
-
-The live Brave PWA also showed a zero-height `#video-preview > ytd-video-preview-loader` placeholder on Home. Removing that placeholder killed native autoplay. Only visible detached overlays should be cleaned up.
-
-## Changes
-
-- Removed Home/Search synthetic native hover nudges and playback forcing.
-- Kept Home/Search feed hover native-only: no extension grow, highlight, synthetic pointer/mouse lifecycle, or direct `video.play()` calls.
-- Preserved YouTube's zero-height native preview loader placeholder.
-- Limited detached native preview cleanup to visible off-card overlays only.
-- Kept Home feed metadata repair so visible grid cards get correct first/last-column attributes after sponsored cleanup.
-- Kept hidden watch/miniplayer cache cleanup on Home to avoid stale watch-page blockers.
-- Added a narrow one-shot reload when a real watch page transitions to Home through YouTube navigation. The reload is guarded by a real `ytd-watch-flexy` watch-page observation, the recorded watch video id, and session storage, so fixture-only `pushState` routes do not reload.
-- Added a small URL watcher for the watch-to-Home path because live YouTube does not reliably deliver the SPA events before the native preview controller gets stuck. The watcher only records real watch pages and does not synthesize hover or playback.
-- Updated fixture coverage to assert the extension does not synthesize Home feed hover after watch-to-Home navigation and does not force preview playback.
-- Added issue #38 coverage/fix on this branch after human QA confirmed the Home autoplay route: live streams in enhanced Theater mode no longer let YouTube's `#panels-full-bleed-container` squeeze the player when live chat overlay is enabled.
-- Let the fixed-position live chat overlay override the zero-size `#chat` cleanup rule and force `iframe#chatframe` to fill the overlay.
-- Added a live Theater scroll correction for standalone/minimal-ui PWA display mode when a live player is visibly shifted above the viewport.
-- Added live-chat overlay minimize/restore controls for #38 follow-up: the floating overlay `X` minimizes the overlay to a right-edge `Live chat` tab instead of leaving YouTube's collapsed opaque overlay in place.
-- Restoring live chat removes YouTube's `collapsed` / `hide-chat-frame` attributes from the overlay frame and restores `iframe#chatframe` from the current watch video id when YouTube clears the iframe src.
-- Refined the live-chat overlay controls after user QA: the close button now sits outside the chat panel instead of covering YouTube's top-right chat controls, and the minimized `Live chat` tab remains visibly exposed on the right edge while still becoming more obvious on hover/focus.
-- Final close-control refinement after user QA: moved the `X` down beside the chat body so it stays away from YouTube's chat header/three-dot menu after restore, increased idle visibility, and added a slide-out transition so minimizing visually moves the panel toward the right-edge restore tab.
-- Superseding close-control fix after screenshot QA: removed the extension-created `X` completely because YouTube's native live-chat header already provides a close button. The extension now only reacts to YouTube's `collapsed` / `hide-chat-frame` state and provides the right-edge `Live chat` restore tab.
-- Fixed Theater comments scroll regression: the live-stream scroll correction no longer runs from the general scroll listener, and it now requires active live-chat overlay state plus a marked live-chat frame before it can reset scroll.
-- Fixed live-chat restore identity regression: the extension now captures YouTube's original `iframe#chatframe` src and restores that exact URL after minimize, instead of rebuilding a simplified `/live_chat?v=...` URL that can look like a different/larger chat.
-- Corrected live-chat minimize model after user QA: the extension now intercepts YouTube's native live-chat close click before YouTube collapses/removes the iframe, prevents the native teardown, and hides the existing overlay offscreen. Restoring shows the same live-chat frame instead of reopening/rebuilding a different chat.
-- Follow-up live QA found YouTube can omit its native live-chat close button after reload/restore. The extension no longer uses a top-page fixed close hit target because it covered the three-dot menu. Instead, when the iframe lacks a native close button, it injects a fallback `X` inside the live-chat iframe header as a sibling after YouTube's More options control.
-- Removed the frequent live Theater scroll reset from the general `applyFeatureState()` DOM churn path so normal Theater comments scrolling is not snapped back while reading comments. The one-shot stabilization path remains for live/PWA layout entry.
-- Follow-up user QA confirmed overlay mode works and comments scroll, but disabling `Show Chat Overlay` while `Hide Live Chat` is on left YouTube's full-bleed live-chat panel as a black right-side area. The non-overlay hide-live-chat CSS now also expands `#player-full-bleed-container` to 100% and collapses `#panels-full-bleed-container` / `#secondary` to 0px.
-
 ## Verification
 
-- `npm run typecheck`: PASS.
-- `npm run lint`: PASS.
-- `npm run test:e2e`: PASS, 16 fixture tests.
-- `npm run test:e2e:live`: PASS, 2 live tests.
-- `git diff --check`: PASS.
-- `npm run validate:all`: PASS, including typecheck, lint, diff check, package validation, 22 unit tests, and 16 fixture tests.
-- Brave PWA supplemental inspection: PASS after rebuilding `dist/`, relaunching Brave with `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks/dist` explicitly loaded, and opening the YouTube PWA. Verified the exact user route: Home -> click a video -> hover hidden top header -> trusted mouse click on YouTube logo -> Home one-shot reload -> hover Home thumbnail. The matching native preview for `https://www.youtube.com/watch?v=KXPpU_8Pyms` was visible, unpaused, muted, `readyState: 4`, and advanced from `0.181187` to `1.787207`.
-- Brave PWA live-stream supplemental inspection for #38: PASS after rebuilding/restarting Brave with repo `dist/`, navigating the YouTube PWA to `https://www.youtube.com/watch?v=KqJmIFmczNw`, and measuring the live DOM through CDP. Verified the injected style contains the new live overlay rules; `#player-full-bleed-container` is 1080px wide, `#panels-full-bleed-container` is 0px wide, `ytd-live-chat-frame#chat` is 380px wide, and `iframe#chatframe` fills the overlay. Screenshot: `test-results/live-stream-theater-overlay-fixed.png`.
-- Focused fixture check after minimize/restore follow-up: `npm run test:e2e -- --grep "live chat overlay"` PASS.
-- Full validation after minimize/restore follow-up: `npm run validate:all` PASS.
-- Brave PWA live-stream minimize/restore supplemental inspection for #38: PASS. Verified clicking the injected `X` moves the live chat overlay offscreen with opacity 0 and shows the right-edge `Live chat` tab; after simulating YouTube's broken collapsed state by setting `collapsed`, `hide-chat-frame`, and clearing `iframe#chatframe.src`, clicking the tab restored the overlay, removed both attributes, and restored `/live_chat?v=KqJmIFmczNw`.
-- Focused fixture check after close/restore placement refinement: `npm run test:e2e -- --grep "live chat overlay"` PASS, including assertions that the close button is outside the chat panel and the restore tab is visibly exposed on the right edge.
-- Full validation after close/restore placement refinement: `npm run validate:all` PASS.
-- Focused fixture check after final close-control refinement: `npm run test:e2e -- --grep "live chat overlay"` PASS, including restored-state assertions that the `X` remains outside the panel and below the chat header.
-- Full validation after final close-control refinement: `npm run validate:all` PASS.
-- Focused fixture check after removing extension-created close button: `npm run test:e2e -- --grep "live chat overlay"` PASS, including assertions that `#simple-yt-tweaks-live-chat-close` is absent and native collapsed state still opens the restore tab.
-- Full validation after removing extension-created close button: `npm run validate:all` PASS.
-- Targeted fixture check after Theater comments/live-chat identity fixes: `npm run test:e2e -- --grep "mode classes|live chat overlay"` PASS, including assertions that Theater comments remain scrollable and live-chat restore preserves the original iframe src with extra parameters.
-- Full validation after Theater comments/live-chat identity fixes: `npm run validate:all` PASS.
-- Targeted fixture check after native-close interception: `npm run test:e2e -- --grep "mode classes|live chat overlay"` PASS, including assertions that a native close click minimizes without setting `collapsed` or removing the iframe src.
-- Full validation after native-close interception: `npm run validate:all` PASS.
-- Targeted fixture check after iframe-header fallback close and comments scroll fix: `npm run test:e2e -- --grep "mode classes|live chat overlay"` PASS.
-- Focused fixture check after moving fallback close after the iframe More options control: `npm run test:e2e -- --grep "live chat overlay"` PASS.
-- Full validation after iframe-header fallback close and comments scroll fix: `npm run validate:all` PASS.
-- Live Brave PWA supplemental inspection after reloading the unpacked extension and live PWA: PASS. Verified no top-page `#simple-yt-tweaks-live-chat-close-hit-target` exists; when YouTube omits its native close button, fallback `#simple-yt-tweaks-live-chat-frame-close` is inside `iframe#chatframe` at x=330/y=6, while YouTube's More options button remains accessible at x=290/y=4. Clicking the fallback minimizes the same chat frame to the right-edge restore tab, and restoring brings the same iframe back without setting `collapsed`.
-- Live normal-video comments smoke after the scroll fix: PASS. In a separate YouTube watch tab, Theater comments scrolled to `window.scrollY` 778 and remained scrollable after waiting, advancing to 1739 instead of snapping back to the player.
-- Focused fixture check after non-overlay black-panel fix: `npm run test:e2e -- --grep "live chat"` PASS, including the new non-overlay live-chat regression fixture.
-- Full validation after non-overlay black-panel fix: `npm run validate:all` PASS, including 22 unit tests and 17 fixture tests.
-- Live Brave PWA supplemental inspection after reloading the unpacked extension and current watch page: PASS for current live/PWA layout. The page rendered `#player-full-bleed-container` at viewport width 1920px, `#panels-full-bleed-container` at 0px, `#secondary` at 0px, no restore tab, and no black panel. YouTube did not stamp a live-chat frame on that reload, so the new fixture covers the exact live-chat-present non-overlay path.
+- `npm run typecheck`: passed
+- `npm run lint`: passed
+- `npm run test:e2e`: passed
+- `npm run test:e2e:live`: passed where used for live YouTube checks
+- `git diff --check`: passed
+- `npm run validate:all`: passed
+- Supplemental Brave PWA inspection: passed for the exact Home hover route and live Theater/chat overlay/non-overlay paths.
 
 ## Human QA
 
-- Prior human QA failed twice while the branch still contained synthetic hover recovery.
-- 2026-06-10 user confirmed the Home hover autoplay route now works correctly.
-- User then reported a new live-stream Theater/chat overlay regression; controller opened #38, fixed it on this branch, verified it in the live Brave YouTube PWA, and added a follow-up minimize/restore control for the YouTube live chat close button behavior.
-- User then reported the fallback close control covered YouTube's three-dot menu. The latest patch moves the fallback into the iframe header after More options and keeps the three-dot menu unobstructed.
-- User confirmed overlay mode now behaves correctly and comments can be scrolled, then reported the non-overlay hide-live-chat black panel. Latest patch fixes that non-overlay path.
-- 2026-06-11 user confirmation: everything currently desired appears to be working. Treat human QA for PR #37 as passed. Because the #38 patch landed after the final reviewer pass, route fresh review next before integration.
+- Earlier QA failed while synthetic hover recovery was still present.
+- User later confirmed the desired #36/#38 behavior appeared to be working and asked to proceed into final-leg polish/hardening.
 
-## Review
+## Notes
 
-- Previous reviewer: Bacon (`019eb2b0-254b-7230-9b53-3f98d55020f6`)
-- Previous result: Ready for Human QA, no findings.
-- Superseded by failed-QA follow-up patch. Route a fresh review before returning to human QA or integrating.
-- 2026-06-10 final follow-up reviewer: Codex Reviewer.
-- Result: Ready for Human QA.
-- Findings: none.
-- Commands run:
-  - `git fetch origin main swarm/syt-036-home-hover-stuck-lifecycle --prune`: PASS.
-  - `git diff --check origin/main...origin/swarm/syt-036-home-hover-stuck-lifecycle`: PASS.
-  - `npm run test:e2e`: PASS, 15 fixture tests.
-  - `npm run test:e2e:live`: PASS, 2 live tests.
-- Review notes:
-  - Home/Search feed hover remains native-only in the reviewed diff: synthetic Home/Search hover nudges and direct preview playback recovery were removed from `src/content/grid-hover.ts`.
-  - The watch-to-Home reload is guarded by real watch-page observation, video id capture, session storage, and a Home-only delayed reload.
-  - Fixture coverage now asserts no synthetic native feed hover after watch-to-Home navigation and validates visible off-card preview cleanup without rewarding forced playback.
-  - PR #37 includes a visible `How to test / what to tell the controller` section with human review requested, exact commands/evidence, expected result, and pass/fail feedback format.
-- 2026-06-10 post-review controller patches: added #38 live-stream Theater squeeze/chat overlay fix after user reported the live PWA stream was cut off, then added live-chat minimize/restore controls after the YouTube close button left an opaque/collapsed overlay. These supersede the previous review state; route a fresh review of PR #37 before integration.
-- 2026-06-10 reviewer Bernoulli marked PR #37 Ready for Human QA after commit `89ef94d`, but screenshot QA then found the extension-created `X` duplicated YouTube's native close button and blocked the three-dot menu. The new patch removes the extension-created close button, so Bernoulli's review result is superseded; route fresh review before human QA/integration.
-
-## Risks
-
-- Medium/high. This patch deliberately stops fighting YouTube's native Home/Search hover controller and uses a guarded Home reload after real watch-to-Home navigation. It also touches enhanced Theater live-chat/player layout and minimize/restore controls for live streams. Both areas are live YouTube DOM behavior and can vary by experiment.
-
-## Next Action
-
-Route a fresh Reviewer for PR #37 focused on the final #38 Theater live-stream layout/minimize/non-overlay patch plus regression risk to the already-passed SYT-036 Home autoplay fix. If review and full validation are clean, integrate PR #37 and then launch `SYT-010H` final-leg polish/hardening under issue #10.
+- #8 enhanced Home/Search hover grow remained out of scope.
+- No popup settings, version, release, tag, or Web Store assets changed.
+- Issue #10 remained open for `SYT-010H`.
+- Full historical detail is recoverable from PRs #37/#39 and Git history; see `docs/swarm/archive/README.md`.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,22 +11,22 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C batch registered in PR #44.
-- Implementation dispatch: first burst A/B/C is active or being reconciled; D/E/F are hold/serial lanes.
+- Implementation dispatch: first burst A/B/C is integrated or being finalized by this docs PR; next source lane is serial `SYT-010H-D`.
 
 ## Active Tasks
 
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `SYT-010H-A` | Settings, popup defaults, and persistence | Runner | Needs Review | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests; source only for small test-proven fixes | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 open |
-| `SYT-010H-B` | Selector accuracy and runtime churn audit | Senior/Planner | Needs Review | `swarm/syt-010h-selector-runtime-audit` | docs/audit or isolated helper-test work; no production runtime edits in parallel batch | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H.md` | #46 open |
-| `SYT-010H-C` | Swarm docs and context compaction | Docs Runner | In Progress | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | TBD |
+| `SYT-010H-A` | Settings, popup defaults, and persistence | Integrator | Integrated | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 merged |
+| `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
+| `SYT-010H-C` | Swarm docs and context compaction | Docs Runner | Ready to Integrate | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 |
 | `SYT-008A` | Enhanced Home/Search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | user/product gate | high | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Hold / Future Tasks
 
 | Task ID | Title | Status | Release Condition |
 | --- | --- | --- | --- |
-| `SYT-010H-D` | Runtime apply-loop and polling hardening | Hold | Start only after B reports; serial runtime source lane. |
+| `SYT-010H-D` | Runtime apply-loop and polling hardening | Ready | Start one serial source lane from B audit; include focused fixtures and Brave PWA QA if watch-to-Home behavior changes. |
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Hold | Start only after B identifies targets and A is not touching overlapping tests. |
 | `SYT-010H-F` | Theater/grid/sidebar organization cleanup | Proposed | Serial-only after coverage/audit lanes, one module per PR. |
 | `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
@@ -50,13 +50,14 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | `SYT-010G` | PR #34 merged at `99156b5` |
 | `SYT-036` / `SYT-038` | PR #37 merged at `342854f`; issues #36/#38 closed |
 | `SYT-010H` planning/docs setup | PRs #39/#40/#41/#42/#43/#44 merged through `2f991ef` |
+| `SYT-010H-A` | PR #45 merged at `ce09953` |
+| `SYT-010H-B` | PR #46 merged at `ddac456` |
 
 ## Review / Integration Queues
 
 | Queue | Task ID | Branch | Next Action |
 | --- | --- | --- | --- |
-| Ready For Review | `SYT-010H-A` | `swarm/syt-010h-settings-popup` | Review PR #45 after C opens/finishes if controller wants serial review. |
-| Ready For Review | `SYT-010H-B` | `swarm/syt-010h-selector-runtime-audit` | Review PR #46 after C opens/finishes if controller wants serial review. |
+| Ready For Review | none | none | none |
 | Ready To Integrate | none | none | none |
 | Blocked | none | none | none |
 
@@ -69,7 +70,7 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 ## Controller Notes
 
-- Capacity is up to 3 only for the active `SYT-010H-A/B/C` burst with separate branches/worktrees and disjoint path locks.
+- Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: reconcile A/B/C outputs, then choose at most one serial implementation lane from B's audit.
+- Current controller phase: integrate C if clean, then launch one serial `SYT-010H-D` implementation lane from B's audit.
 - Do not route #8 unless the user explicitly reopens that gate.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -10,50 +10,55 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 - Project brief: Ready
 - Material questions: Deferred, not blocking
-- First milestone plan: Ready
-- Implementation dispatch: `SYT-010H` is ready; `SYT-036` / #38 are integrated and issue #10 remains open.
+- Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C batch registered in PR #44.
+- Implementation dispatch: first burst A/B/C is active or being reconciled; D/E/F are hold/serial lanes.
 
 ## Active Tasks
 
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `SYT-010A` | Audit and harden fixture coverage for #10/#8 risk | Integrator | Integrated | `swarm/syt-010a-test-harness-audit` | `tests/e2e/**`, docs as needed | parallel-safe after bootstrap | `SYT-CTL-001` | medium, fixture contracts | `docs/swarm/handoffs/SYT-010A.md` | #12 merged |
-| `SYT-010B` | Settings parity and source-of-truth hardening | Integrator | Integrated | `swarm/syt-010b-settings-hardening` | `src/shared/settings.ts`, `src/content/settings.ts`, validation/tests | serial-required | `SYT-010A` | high, settings contracts | `docs/swarm/handoffs/SYT-010B.md` | #14 merged |
-| `SYT-010C` | Release-candidate process smoothing | Integrator | Integrated | `swarm/syt-010c-rc-process` | `DEVELOPMENT.md`, `docs/swarm/**`, scripts if needed | parallel-safe with source-free work | `SYT-010A` preferred | low/medium, release docs | `docs/swarm/handoffs/SYT-010C.md` | #16 merged |
-| `SYT-010D` | Pure helper tests | Integrator | Integrated | `swarm/syt-010d-helper-tests` | `tests/unit/**`, `playwright.config.ts`, `package.json`, helper modules only if needed | parallel-safe with no other source task | `SYT-010A`, `SYT-010B`, `SYT-010C` | low/medium, test config/helper exports | `docs/swarm/handoffs/SYT-010D.md` | #18 merged |
-| `SYT-008A` | Enhanced home/search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | `SYT-010A`, user/product gate | high, live YouTube preview lifecycle | `docs/swarm/handoffs/SYT-008A.md` | none |
-| `SYT-021` | Native hover SPA regression and live recommendation drift | Integrator | Integrated | `swarm/syt-008b-native-hover-spa-regression` | #21 native Home/Search preview repair, watch click fallback hardening, modern recommendation selector drift | serial-required | v0.3.0 baseline | high, live YouTube SPA/player behavior | `docs/swarm/handoffs/SYT-021.md` | #22 merged |
-| `SYT-010E` | Code-hardening lane after #21 | Integrator | Integrated | `swarm/syt-010e-code-hardening` | Grid-hover selector normalization with unit coverage | serial-required | `SYT-021` | medium/high, runtime source hardening | `docs/swarm/handoffs/SYT-010E.md` | #24 merged |
-| `SYT-010F` | Sticky Player hardening | Integrator | Integrated | `swarm/syt-010f-sticky-player-hardening` | Sticky Player visibility/resize helpers and deterministic dock/restore fixture coverage | serial-required | `SYT-010F` planning PR #26 merged | medium/high, player DOM docking | `docs/swarm/handoffs/SYT-010F.md` | #28 merged |
-| `SYT-031` | Home native hover autoplay after watch-to-Home SPA | Integrator | Integrated | `swarm/syt-031-home-hover-stationary-spa` | #31 stale/missing Home native preview recovery, fixture/live coverage | serial-required | `SYT-021` | high, live YouTube SPA preview lifecycle | `docs/swarm/handoffs/SYT-031.md` | #32 merged |
-| `SYT-010G` | Fullscreen player UI geometry hardening | Integrator | Integrated | `swarm/syt-010g-fullscreen-ui-geometry` | Extract/test player UI hover reveal geometry | serial-required | `SYT-031` | medium, watch-page player UI behavior | `docs/swarm/handoffs/SYT-010G.md` | #34 merged |
-| `SYT-036` | Home hover stale card lifecycle regression + live Theater chat fix | Integrator | Integrated | `swarm/syt-036-home-hover-stuck-lifecycle` | #36 native Home hover lifecycle cleanup plus #38 live-stream Theater/chat overlay layout, minimize/restore, comments scroll, and non-overlay hide-live-chat fix | serial-required | `SYT-031`, `SYT-010G` | high, live YouTube SPA/player layout behavior | `docs/swarm/handoffs/SYT-036.md` | #37 merged |
-| `SYT-010H` | Final-leg polish and code hardening | Planner | Ready | TBD | Audit settings/UI flows, selector accuracy, runtime polling/churn, fixture gaps, redundant code, and compact docs before release-candidate work; define parallel-safe sublanes before dispatch | serial-required for planning, then planner may split disjoint lanes | `SYT-036` integrated | medium/high, shared content modules and popup/settings behavior | `docs/swarm/handoffs/SYT-010H.md` | none |
+| `SYT-010H-A` | Settings, popup defaults, and persistence | Runner | Needs Review | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests; source only for small test-proven fixes | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 open |
+| `SYT-010H-B` | Selector accuracy and runtime churn audit | Senior/Planner | Needs Review | `swarm/syt-010h-selector-runtime-audit` | docs/audit or isolated helper-test work; no production runtime edits in parallel batch | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H.md` | #46 open |
+| `SYT-010H-C` | Swarm docs and context compaction | Docs Runner | In Progress | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | TBD |
+| `SYT-008A` | Enhanced Home/Search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | user/product gate | high | `docs/swarm/handoffs/SYT-008A.md` | none |
 
-## Backlog
+## Hold / Future Tasks
 
-| Task ID | Title | Reason | Notes |
+| Task ID | Title | Status | Release Condition |
 | --- | --- | --- | --- |
-| `SYT-RC-001` | Next release-candidate checklist | Make future version bump/package/release flow smoother. | Human QA required before release. |
-| `SYT-RC-002` | Release-candidate polish after #10 hardening | Run only after `SYT-010H` and any follow-up fixes are integrated. | Human QA required before version bump/release. |
+| `SYT-010H-D` | Runtime apply-loop and polling hardening | Hold | Start only after B reports; serial runtime source lane. |
+| `SYT-010H-E` | Selector helper and fixture gap hardening | Hold | Start only after B identifies targets and A is not touching overlapping tests. |
+| `SYT-010H-F` | Theater/grid/sidebar organization cleanup | Proposed | Serial-only after coverage/audit lanes, one module per PR. |
+| `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
+| `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
 
-## Blocked
+## Completed / Archived
 
-| Task ID | Blocker | Needed From | Next Check |
+Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/archive/README.md`.
+
+| Task ID | Result |
+| --- | --- |
+| `SYT-CTL-001` | PR #11 merged at `676efc8` |
+| `SYT-010A` | PR #12 merged at `59ec975` |
+| `SYT-010B` | PR #14 merged at `5675059` |
+| `SYT-010C` | PR #16 merged at `0fca6c3` |
+| `SYT-010D` | PR #18 merged at `88f0a91` |
+| `SYT-021` | PR #22 merged at `8f90ef1`; issue #21 closed |
+| `SYT-010E` | PR #24 merged at `fae4e5d` |
+| `SYT-010F` | PRs #26/#28/#29 merged through `6580065` |
+| `SYT-031` | PR #32 merged at `8e881c9`; issue #31 closed |
+| `SYT-010G` | PR #34 merged at `99156b5` |
+| `SYT-036` / `SYT-038` | PR #37 merged at `342854f`; issues #36/#38 closed |
+| `SYT-010H` planning/docs setup | PRs #39/#40/#41/#42/#43/#44 merged through `2f991ef` |
+
+## Review / Integration Queues
+
+| Queue | Task ID | Branch | Next Action |
 | --- | --- | --- | --- |
-| none | none | none | none |
-
-## Ready For Review
-
-| Task ID | Branch | Reviewer Focus | Verification Tier | Handoff |
-| --- | --- | --- | --- | --- |
-| none | none | none | none | none |
-
-## Ready To Integrate
-
-| Task ID | Branch | Checks | Cleanup Plan | Handoff |
-| --- | --- | --- | --- | --- |
-| none | none | none | none | none |
+| Ready For Review | `SYT-010H-A` | `swarm/syt-010h-settings-popup` | Review PR #45 after C opens/finishes if controller wants serial review. |
+| Ready For Review | `SYT-010H-B` | `swarm/syt-010h-selector-runtime-audit` | Review PR #46 after C opens/finishes if controller wants serial review. |
+| Ready To Integrate | none | none | none |
+| Blocked | none | none | none |
 
 ## Human QA
 
@@ -61,34 +66,10 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | --- | --- | --- | --- | --- |
 | `SYT-008A` | none | Not started | Yes before implementing visual hover behavior | `Human QA passed/failed for SYT-008A: <notes>` |
 | `SYT-RC-001` | none | Not started | Yes before release | `Human QA passed/failed for SYT-RC-001: <notes>` |
-| `SYT-036` | #37 | Passed by user on 2026-06-11: Home autoplay, live overlay behavior, comments scroll, and non-overlay hidden live chat are working as desired | Satisfied; fresh review still required before merge | `Human QA passed for SYT-036/#38: behavior working; proceed to review/integration` |
 
 ## Controller Notes
 
-- Active controller-spawned subagents: none after Hume integrated `SYT-010F` implementation PR #28.
-- Active cron bursts: none; cron is a failsafe, not the normal execution path.
-- Parallel worktree root: none yet.
-- Batch dispatch policy: disabled by default because max active subagents is 1.
-- Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry during parallel work.
-- Verification tiers: focused runner checks, targeted reviewer checks, full integrator/checkpoint verify.
-- Agent registry: `docs/swarm/agent-registry.md`.
-- Bootstrap log: `docs/swarm/bootstrap-log.md`.
-- GitHub workflow: `docs/swarm/github.md`.
-- Current controller phase: Phase 4 active; launch `SYT-010H` final-leg polish/hardening under #10 with planner-approved capacity up to 3 only for disjoint lanes.
-- 2026-06-10: User reported live watch-to-Home native hover autoplay regression. Controller opened #21 and draft PR #22 for `SYT-021` on `swarm/syt-008b-native-hover-spa-regression`.
-- 2026-06-10: User requested compact context/docs and more frequent automation. Completed historical handoffs were compacted to stubs with `docs/swarm/archive/README.md` reference mapping; `docs/swarm/context-map.md` is now the hot context entrypoint.
-- 2026-06-10: PR #22 squash-merged at `8f90ef1`, closing #21. Remote/local task branch cleanup completed. Route `SYT-010E` next.
-- 2026-06-10: PR #24 squash-merged at `fae4e5d`, leaving #10 open for future hardening lanes. Remote/local task branch cleanup completed. Plan/route `SYT-010F` next if work remains safe and bounded.
-- 2026-06-10: `SYT-010F` planning selected Sticky Player hardening: pure visibility/resize helper coverage plus one deterministic dock/restore fixture if feasible. Keep #8 paused.
-- 2026-06-10: PR #26 squash-merged at `66d756f`, leaving #10 open. Next safe action is Senior Runner on `swarm/syt-010f-sticky-player-hardening`.
-- 2026-06-10: PR #28 squash-merged at `fa07c18`, adding Sticky Player geometry/unit/fixture hardening. PR #29 docs follow-up merged at `6580065`. Issue #10 remains open; #8 remains paused.
-- 2026-06-10: User reported #21 still failed after watch-to-Home SPA navigation. Controller opened #31 and implemented `SYT-031` to recover stale/missing native Home previews without reintroducing #8 hover grow.
-- 2026-06-10: PR #32 squash-merged at `8e881c9`, closing #31. Route `SYT-010G` next only if a narrow #10 hardening target is identified.
-- 2026-06-10: `SYT-010G` selected fullscreen/player UI geometry hardening. Unit/type/diff checks passed; route review next.
-- 2026-06-10: Reviewer Russell marked PR #34 Ready to Integrate with no findings; route Integrator next.
-- 2026-06-10: PR #34 squash-merged at `99156b5`, adding fullscreen/player UI geometry unit hardening. Issue #10 remains open; #8 remains paused.
-- 2026-06-10: User reported Home cards retaining opaque hover backgrounds and hover autoplay failing after refresh -> watch page -> SPA Home navigation. Controller opened #36 and draft PR #37 for `SYT-036`; human QA failed twice. User clarified the failing route is watch -> hover hidden header -> YouTube logo/sidebar Home, not browser Back/profile navigation, and that the app is Brave PWA. Final follow-up patch passed full validation, stricter live smoke, and exact Brave PWA verification.
-- 2026-06-10: User confirmed Home hover autoplay works, then reported live-stream Theater video cut-off/chat overlay collapse and a broken live chat close state. Controller opened #38 and patched PR #37 so live chat overlay no longer reserves full-bleed layout width, `iframe#chatframe` fills the overlay, and the overlay `X` minimizes to a right-edge restore tab. `npm run validate:all` passed; live Brave PWA geometry and minimize/restore verification passed. Follow-up placement refinement moved the close button outside the chat panel and made the minimized tab visibly exposed; focused fixture and full validation passed.
-- 2026-06-11: User confirmed everything currently desired appears to be working and asked for final-leg polish/hardening. Treat PR #37 human QA as passed; route fresh review, integrate if clean, then launch `SYT-010H`.
-- 2026-06-11: PR #37 was marked ready and squash-merged at `342854f` after `npm run validate:all` passed. Issues #36 and #38 are closed. Next lane is `SYT-010H`.
-- 2026-06-11: User approved up to 3 subagents for the final-leg push. `SYT-010H` planner must split explicit non-overlapping lanes before any parallel dispatch.
+- Capacity is up to 3 only for the active `SYT-010H-A/B/C` burst with separate branches/worktrees and disjoint path locks.
+- Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
+- Current controller phase: reconcile A/B/C outputs, then choose at most one serial implementation lane from B's audit.
+- Do not route #8 unless the user explicitly reopens that gate.


### PR DESCRIPTION
## Summary

- Compact hot swarm docs around the active SYT-010H A/B/C burst.
- Reduce completed-lane handoffs for SYT-021, SYT-010E, SYT-010F, and SYT-036 to recovery stubs.
- Update the archive reference map and current routing references through PRs #44, #45, and #46.

## How to test / what to tell the controller

Human review requested: no

Commands:
- `git diff --check origin/main...HEAD`
- `git diff --check`

Expected result:
- Both commands complete with no output and exit 0.
- Diff is docs-only under `docs/swarm/**`; no product source, tests, release metadata, version, tags, Web Store assets, or issue-closing changes.

Feedback format:
- `SYT-010H-C review passed: docs-only compaction is safe to integrate`
- or `SYT-010H-C needs fixes: <specific stale state, missing reference, or formatting issue>`

Controller next action after merge:
- Reconcile A/B/C outputs and route review for PR #45 and PR #46 serially; then choose at most one serial runtime lane from the B audit recommendations.