### PR TITLE
SYT-010H-D runtime video binding hardening

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -19,11 +19,11 @@ Use this file to track who is working, where they are working, and whether the c
 
 ## Active Agents
 
-No active agents after the first `SYT-010H` A/B/C burst is reconciled.
+No active agents after `SYT-010H-D` opened PR #48 for review.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `019eb4b3-f0c3-7a41-af94-f6221752ab71` / Galileo | `SYT-010H-D` | Senior Developer Runner | Running | `swarm/syt-010h-runtime-churn` | agent workspace | TBD | 2026-06-11 03:22 UTC | Implement one narrow runtime churn hardening target, run focused checks, open draft PR | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -35,7 +35,7 @@ No active agents after the first `SYT-010H` A/B/C burst is reconciled.
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `src/content/content.ts`, `src/content/lifecycle.ts`, `src/content/state.ts`, targeted tests only | `SYT-010H-D` | Galileo | `swarm/syt-010h-runtime-churn` | Serial runtime apply-loop/polling hardening lane | PR reviewed/integrated or lane closed |
+| none | none | none | none | none | none |
 
 ## Recently Completed
 
@@ -59,6 +59,7 @@ Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, t
 | `SYT-010H-A` / #45 | settings/popup coverage integrated |
 | `SYT-010H-B` / #46 | selector/runtime churn audit integrated |
 | `SYT-010H-C` / #47 | docs/context compaction integrated |
+| `SYT-010H-D` / #48 | runtime video binding hardening draft PR opened; needs review |
 
 ## Pending Launch
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -23,7 +23,7 @@ No active agents after the first `SYT-010H` A/B/C burst is reconciled.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| `019eb4b3-f0c3-7a41-af94-f6221752ab71` / Galileo | `SYT-010H-D` | Senior Developer Runner | Running | `swarm/syt-010h-runtime-churn` | agent workspace | TBD | 2026-06-11 03:22 UTC | Implement one narrow runtime churn hardening target, run focused checks, open draft PR | none |
 
 ## Paused / Stale Agents
 
@@ -35,7 +35,7 @@ No active agents after the first `SYT-010H` A/B/C burst is reconciled.
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `src/content/content.ts`, `src/content/lifecycle.ts`, `src/content/state.ts`, targeted tests only | `SYT-010H-D` | Galileo | `swarm/syt-010h-runtime-churn` | Serial runtime apply-loop/polling hardening lane | PR reviewed/integrated or lane closed |
 
 ## Recently Completed
 
@@ -64,7 +64,7 @@ Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, t
 
 | Task ID | Role | Branch / Worktree | Launch Condition | Prompt Location |
 | --- | --- | --- | --- | --- |
-| `SYT-010H-D` | Senior Developer | `swarm/syt-010h-runtime-churn` | Only after B reports and controller selects one serial implementation target | `docs/swarm/handoffs/SYT-010H.md` |
+| none | none | none | none | none |
 
 ## Side Chats
 

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -19,7 +19,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 ## Active Agents
 
-No active agents after `SYT-010H-D` opened PR #48 for review.
+No active agents after `SYT-010H-D` integrated via PR #48.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -59,7 +59,7 @@ Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, t
 | `SYT-010H-A` / #45 | settings/popup coverage integrated |
 | `SYT-010H-B` / #46 | selector/runtime churn audit integrated |
 | `SYT-010H-C` / #47 | docs/context compaction integrated |
-| `SYT-010H-D` / #48 | runtime video binding hardening draft PR opened; needs review |
+| `SYT-010H-D` / #48 | runtime video binding hardening integrated |
 
 ## Pending Launch
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -5,14 +5,15 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 ## Current Hot State
 
 - Active lane family: `SYT-010H`, final-leg polish/code-hardening under issue #10.
-- Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, and selector/runtime audit PR #46 are merged; docs compaction PR #47 is this state repair.
+- Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, and runtime video binding PR #48 are merged.
 - Completed first burst:
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
   - `SYT-010H-B`: selector/runtime churn audit, PR #46, merge `ddac456`.
-  - `SYT-010H-C`: docs/context compaction, PR #47.
-- Active serial lane: `SYT-010H-D` runtime apply-loop/polling hardening draft PR #48 on `swarm/syt-010h-runtime-churn`; review next.
+  - `SYT-010H-C`: docs/context compaction, PR #47, merge `b5e3f34`.
+  - `SYT-010H-D`: runtime video binding hardening, PR #48.
+- Active serial lane: none after PR #48 integration. Next candidate is `SYT-010H-E` selector helper and fixture gap hardening.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
-- Recent merged swarm docs PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit.
+- Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
 
 ## Hot Files
@@ -40,10 +41,11 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 - `SYT-031` -> PR #32, merge `8e881c9`, closes #31
 - `SYT-010G` -> PR #34, merge `99156b5`, refs #10
 - `SYT-036` / `SYT-038` -> PR #37, merge `342854f`, closes #36/#38
-- `SYT-036`/`SYT-010H` docs repairs -> PRs #39/#40/#41/#42/#43/#44/#47, through this compaction lane
+- `SYT-036`/`SYT-010H` docs repairs -> PRs #39/#40/#41/#42/#43/#44/#47, through docs compaction
 - `SYT-010H-A` -> PR #45, merge `ce09953`, refs #10
 - `SYT-010H-B` -> PR #46, merge `ddac456`, refs #10
+- `SYT-010H-D` -> PR #48, refs #10
 
 ## Next Safe Controller Action
 
-Review `SYT-010H-D` draft PR #48. Do not launch additional runtime lanes in parallel until review/integration is resolved.
+After PR #48 integration is visible on clean `main`, route `SYT-010H-E` as a serial selector/fixture gap hardening lane. Do not launch #8 hover research unless the user explicitly reopens that gate.

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -10,7 +10,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
   - `SYT-010H-B`: selector/runtime churn audit, PR #46, merge `ddac456`.
   - `SYT-010H-C`: docs/context compaction, PR #47.
-- Active serial lane: `SYT-010H-D` runtime apply-loop/polling hardening on `swarm/syt-010h-runtime-churn`. Keep implementation serial.
+- Active serial lane: `SYT-010H-D` runtime apply-loop/polling hardening draft PR #48 on `swarm/syt-010h-runtime-churn`; review next.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
 - Recent merged swarm docs PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
@@ -46,4 +46,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Wait for the active `SYT-010H-D` runtime apply-loop/polling hardening runner. Do not launch additional runtime lanes in parallel.
+Review `SYT-010H-D` draft PR #48. Do not launch additional runtime lanes in parallel until review/integration is resolved.

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -10,7 +10,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
   - `SYT-010H-B`: selector/runtime churn audit, PR #46, merge `ddac456`.
   - `SYT-010H-C`: docs/context compaction, PR #47.
-- Next serial lane: choose one `SYT-010H-D` runtime apply-loop/polling hardening target from the B audit. Keep implementation serial.
+- Active serial lane: `SYT-010H-D` runtime apply-loop/polling hardening on `swarm/syt-010h-runtime-churn`. Keep implementation serial.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
 - Recent merged swarm docs PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
@@ -46,4 +46,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Launch one serial `SYT-010H-D` runtime apply-loop/polling hardening lane, scoped from the B audit. Do not launch multiple runtime lanes in parallel.
+Wait for the active `SYT-010H-D` runtime apply-loop/polling hardening runner. Do not launch additional runtime lanes in parallel.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -9,11 +9,12 @@
 
 ## Current Focus
 
-1. Reconcile the completed first `SYT-010H` supervised burst:
+1. Reconcile the completed first `SYT-010H` supervised burst and first serial runtime lane:
    - A: settings/popup/defaults/persistence coverage, PR #45 merged at `ce09953`.
    - B: selector/runtime churn audit, PR #46 merged at `ddac456`.
-   - C: swarm docs/context compaction, PR #47.
-2. Launch at most one serial `SYT-010H-D` runtime apply-loop/polling hardening target from the B audit.
+   - C: swarm docs/context compaction, PR #47 merged at `b5e3f34`.
+   - D: runtime video binding hardening, PR #48.
+2. Route the next serial selector/fixture hardening lane (`SYT-010H-E`) only after PR #48 is integrated and `main` is clean.
 3. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
 4. Keep release-candidate/version/tag/Web Store work out of the hardening lanes.
 
@@ -26,7 +27,8 @@
 - PR #44 registered the A/B/C batch at `2f991ef`.
 - PR #45 merged settings/popup coverage.
 - PR #46 merged the selector/runtime churn audit.
-- PR #47 is this docs compaction branch.
+- PR #47 merged docs compaction at `b5e3f34`.
+- PR #48 hardened runtime video binding from the existing apply loop.
 - Issue #10 remains open for final-leg hardening; #8 remains a future gated research lane.
 
 ## Constraints And Risks
@@ -54,4 +56,4 @@
 ## Last Updated
 
 - Date: 2026-06-11
-- By: Controller/Docs Runner for `SYT-010H-C`
+- By: Controller review/integration for `SYT-010H-D`

--- a/docs/swarm/handoffs/SYT-010H-D.md
+++ b/docs/swarm/handoffs/SYT-010H-D.md
@@ -5,7 +5,7 @@
 - Task ID: `SYT-010H-D`
 - Title: Runtime Apply-Loop And Polling Hardening
 - Assigned role: Senior Developer Runner
-- Current state: Needs Review
+- Current state: Integrated
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Branch: `swarm/syt-010h-runtime-churn`
 - PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/48
@@ -67,6 +67,17 @@ Live YouTube / Brave PWA QA was not run and is not requested for this PR because
 - No known blockers.
 - Residual risk: real YouTube can still replace player/video nodes in unusual sequences; the 10 second watch-page fallback remains as a safety net while the normal path is now event/apply-driven.
 
+## Review And Integration
+
+- Review result: Ready to Integrate.
+- Controller reran and passed:
+  - `npm run test:e2e -- --grep "watch fixture validates|binds replacement video|player click fallback|docks and restores sticky"`
+  - `npm run test:unit`
+  - `npm run typecheck`
+  - `npm run lint`
+  - `git diff --check origin/main...HEAD`
+- Integration result: PR #48 merged after this branch review.
+
 ## Next Recommended Role And Action
 
-Reviewer: inspect the narrow runtime diff, confirm the PR body has the required controller section, and run targeted checks or mark `Ready to Integrate` if clean.
+Controller: keep runtime lanes serial. Route `SYT-010H-E` only if the repo is clean and `SYT-010H-D` integration is visible on `main`.

--- a/docs/swarm/handoffs/SYT-010H-D.md
+++ b/docs/swarm/handoffs/SYT-010H-D.md
@@ -1,0 +1,72 @@
+# SYT-010H-D: Runtime Apply-Loop And Polling Hardening
+
+## Status
+
+- Task ID: `SYT-010H-D`
+- Title: Runtime Apply-Loop And Polling Hardening
+- Assigned role: Senior Developer Runner
+- Current state: Needs Review
+- Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+- Branch: `swarm/syt-010h-runtime-churn`
+- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/48
+- GitHub issue: #10
+- Verification tier: focused fixture plus static checks
+
+## Scope
+
+Implement one audit-backed, behavior-preserving runtime churn reduction from `SYT-010H-B`.
+
+Chosen target: video event binding. The previous implementation attached once at startup and kept a permanent 2 second interval alive for the whole page lifetime. This lane makes normal DOM/navigation apply passes attach replacement video nodes immediately and keeps only a slower watch-page fallback.
+
+## Non-Scope
+
+- No watch-to-Home reload guard changes.
+- No native Home/Search preview behavior changes.
+- No enhanced Home/Search hover grow, synthetic hover, or forced preview playback.
+- No settings contract, release/version, Web Store, or broad module refactor changes.
+
+## Parallelization Metadata
+
+- `parallel-safe`: no
+- `serial-required`: yes
+- `depends-on`: integrated `SYT-010H-B` audit
+- `conflict-risk`: high for shared content runtime behavior, kept narrow in `src/content/lifecycle.ts` and `src/content/content.ts`
+
+## Files Touched
+
+- `src/content/lifecycle.ts`
+- `src/content/content.ts`
+- `tests/e2e/extension.fixture.spec.ts`
+- `docs/swarm/handoffs/SYT-010H-D.md`
+
+## Runtime Change
+
+- Extracted video listener attachment into `syncVideoEventBinding()`.
+- Calls `syncVideoEventBinding()` from the existing apply/stabilization path, so DOM observer bursts and navigation reruns bind replacement watch video nodes without waiting on interval polling.
+- Slowed the fallback interval from 2 seconds to 10 seconds and gated it to watch pages.
+- Preserved the existing `data-simple-yt-tweaks-bound` duplicate-listener guard and existing PiP/play/pause listeners.
+
+## Verification
+
+- Passed: `npm run test:e2e -- --grep "binds replacement video"`
+- Passed: `npm run test:e2e -- --grep "watch fixture validates|binds replacement video|player click fallback|docks and restores sticky"`
+- Passed: `npm run test:unit`
+- Passed: `npm run typecheck`
+- Passed: `npm run lint`
+- Passed: `git diff --check`
+
+Live YouTube / Brave PWA QA was not run and is not requested for this PR because the lane did not change watch-to-Home reload, native Home/Search preview, or live YouTube behavior.
+
+## Decisions Made
+
+- Did not change `WATCH_TO_HOME_URL_POLL_MS`; that remains a future high-risk lane because it protects the recently user-confirmed Brave PWA watch -> Home regression.
+- Used fixture coverage instead of live smoke because the behavior under change is local video-node listener binding.
+
+## Blockers Or Risks
+
+- No known blockers.
+- Residual risk: real YouTube can still replace player/video nodes in unusual sequences; the 10 second watch-page fallback remains as a safety net while the normal path is now event/apply-driven.
+
+## Next Recommended Role And Action
+
+Reviewer: inspect the narrow runtime diff, confirm the PR body has the required controller section, and run targeted checks or mark `Ready to Integrate` if clean.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -26,7 +26,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Title | Status | Release Condition |
 | --- | --- | --- | --- |
-| `SYT-010H-D` | Runtime apply-loop and polling hardening | In Progress | Galileo on `swarm/syt-010h-runtime-churn`; serial source lane from B audit. |
+| `SYT-010H-D` | Runtime apply-loop and polling hardening | Needs Review | Draft PR #48; serial source lane from B audit. |
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Hold | Start only after B identifies targets and A is not touching overlapping tests. |
 | `SYT-010H-F` | Theater/grid/sidebar organization cleanup | Proposed | Serial-only after coverage/audit lanes, one module per PR. |
 | `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
@@ -57,7 +57,7 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 | Queue | Task ID | Branch | Next Action |
 | --- | --- | --- | --- |
-| Ready For Review | none | none | none |
+| Ready For Review | `SYT-010H-D` | `swarm/syt-010h-runtime-churn` | Review draft PR #48 and handoff `docs/swarm/handoffs/SYT-010H-D.md` |
 | Ready To Integrate | none | none | none |
 | Blocked | none | none | none |
 
@@ -72,5 +72,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: wait for `SYT-010H-D` runner result; keep runtime implementation serial.
+- Current controller phase: review `SYT-010H-D` PR #48; keep runtime implementation serial.
 - Do not route #8 unless the user explicitly reopens that gate.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -26,7 +26,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Title | Status | Release Condition |
 | --- | --- | --- | --- |
-| `SYT-010H-D` | Runtime apply-loop and polling hardening | Ready | Start one serial source lane from B audit; include focused fixtures and Brave PWA QA if watch-to-Home behavior changes. |
+| `SYT-010H-D` | Runtime apply-loop and polling hardening | In Progress | Galileo on `swarm/syt-010h-runtime-churn`; serial source lane from B audit. |
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Hold | Start only after B identifies targets and A is not touching overlapping tests. |
 | `SYT-010H-F` | Theater/grid/sidebar organization cleanup | Proposed | Serial-only after coverage/audit lanes, one module per PR. |
 | `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
@@ -72,5 +72,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: integrate C if clean, then launch one serial `SYT-010H-D` implementation lane from B's audit.
+- Current controller phase: wait for `SYT-010H-D` runner result; keep runtime implementation serial.
 - Do not route #8 unless the user explicitly reopens that gate.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -10,8 +10,8 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 - Project brief: Ready
 - Material questions: Deferred, not blocking
-- Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C batch registered in PR #44.
-- Implementation dispatch: first burst A/B/C is integrated or being finalized by this docs PR; next source lane is serial `SYT-010H-D`.
+- Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C/D are integrated through PR #48.
+- Implementation dispatch: next source lane is serial `SYT-010H-E` selector helper and fixture gap hardening, after controller reconciliation.
 
 ## Active Tasks
 
@@ -19,15 +19,15 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `SYT-010H-A` | Settings, popup defaults, and persistence | Integrator | Integrated | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 merged |
 | `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
-| `SYT-010H-C` | Swarm docs and context compaction | Docs Runner | Ready to Integrate | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 |
+| `SYT-010H-C` | Swarm docs and context compaction | Integrator | Integrated | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 merged |
 | `SYT-008A` | Enhanced Home/Search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | user/product gate | high | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Hold / Future Tasks
 
 | Task ID | Title | Status | Release Condition |
 | --- | --- | --- | --- |
-| `SYT-010H-D` | Runtime apply-loop and polling hardening | Needs Review | Draft PR #48; serial source lane from B audit. |
-| `SYT-010H-E` | Selector helper and fixture gap hardening | Hold | Start only after B identifies targets and A is not touching overlapping tests. |
+| `SYT-010H-D` | Runtime apply-loop and polling hardening | Integrated | PR #48; event/apply-loop video binding hardening. |
+| `SYT-010H-E` | Selector helper and fixture gap hardening | Ready | Start after D is integrated and repo is clean; keep serial if touching runtime selectors. |
 | `SYT-010H-F` | Theater/grid/sidebar organization cleanup | Proposed | Serial-only after coverage/audit lanes, one module per PR. |
 | `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
@@ -52,12 +52,14 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | `SYT-010H` planning/docs setup | PRs #39/#40/#41/#42/#43/#44 merged through `2f991ef` |
 | `SYT-010H-A` | PR #45 merged at `ce09953` |
 | `SYT-010H-B` | PR #46 merged at `ddac456` |
+| `SYT-010H-C` | PR #47 merged at `b5e3f34` |
+| `SYT-010H-D` | PR #48 merged; runtime video binding hardening |
 
 ## Review / Integration Queues
 
 | Queue | Task ID | Branch | Next Action |
 | --- | --- | --- | --- |
-| Ready For Review | `SYT-010H-D` | `swarm/syt-010h-runtime-churn` | Review draft PR #48 and handoff `docs/swarm/handoffs/SYT-010H-D.md` |
+| Ready For Review | none | none | none |
 | Ready To Integrate | none | none | none |
 | Blocked | none | none | none |
 
@@ -72,5 +74,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: review `SYT-010H-D` PR #48; keep runtime implementation serial.
+- Current controller phase: reconcile PR #48 integration, then route `SYT-010H-E` if clean.
 - Do not route #8 unless the user explicitly reopens that gate.

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,6 +1,6 @@
 import { buildFullscreenCss, buildSharedPlayerUiCss, resetFullscreenGridPeekState, resetFullscreenNavigationState, shouldSuppressFullscreenGridPeekInteraction, updateFullscreenActionDock, updatePlayerUiFocusState, updatePlayerUiHoverState } from './fullscreen';
 import { bindGridHoverHandlers, buildGridHoverCss, syncGridHoverState } from './grid-hover';
-import { bindPlayerSurfaceClickFallback, bindPointerHandlers, bindRuntimeMessages, bindStorageObserver, bindVideoEvents, observeDom, observeNavigation, scheduleModeStabilization, syncWatchObserver, updateViewportHeightVar } from './lifecycle';
+import { bindPlayerSurfaceClickFallback, bindPointerHandlers, bindRuntimeMessages, bindStorageObserver, bindVideoEvents, observeDom, observeNavigation, scheduleModeStabilization, syncVideoEventBinding, syncWatchObserver, updateViewportHeightVar } from './lifecycle';
 import { buildPipCss, ensureMiniPlayerPipButton, syncPipButtons } from './pip';
 import { GENERAL_HIDDEN_CLASS, SELECTORS, STYLE_ID } from './selectors';
 import { loadSettings } from './settings';
@@ -274,6 +274,7 @@ function stabilizeUi(): void {
   ensureMiniPlayerPipButton();
   updateFullscreenActionDock();
   updateStickyPlayerState();
+  syncVideoEventBinding();
   syncGridHoverState(state.settings);
   refreshPlayerLayout();
 }
@@ -327,6 +328,7 @@ function applyFeatureState(): void {
   syncPipButtons();
   updateFullscreenActionDock();
   updateStickyPlayerState();
+  syncVideoEventBinding();
   syncGridHoverState(state.settings);
 
   if (

--- a/src/content/lifecycle.ts
+++ b/src/content/lifecycle.ts
@@ -4,6 +4,9 @@ import { state } from './state';
 
 let videoBindIntervalId: number | null = null;
 let playerSurfaceClickFallbackBound = false;
+let videoEventHandlers: VideoEventHandlers | null = null;
+
+const VIDEO_BIND_FALLBACK_INTERVAL_MS = 10_000;
 
 const PLAYER_CLICK_CONTROL_SELECTOR = [
   'a',
@@ -284,27 +287,39 @@ export function bindPlayerSurfaceClickFallback(): void {
   );
 }
 
-export function bindVideoEvents(handlers: {
+type VideoEventHandlers = {
   onPipChange: () => void;
   onPlaybackStateChange: () => void;
-}): void {
-  const attach = () => {
-    const video = getVideo();
-    if (!video || video.dataset.simpleYtTweaksBound === '1') return;
+};
 
-    video.dataset.simpleYtTweaksBound = '1';
-    const refreshPlaybackUi = () => {
-      window.setTimeout(() => handlers.onPlaybackStateChange(), 0);
-    };
+function attachVideoEvents(handlers: VideoEventHandlers): void {
+  const video = getVideo();
+  if (!video || video.dataset.simpleYtTweaksBound === '1') return;
 
-    video.addEventListener('enterpictureinpicture', handlers.onPipChange, { passive: true });
-    video.addEventListener('leavepictureinpicture', handlers.onPipChange, { passive: true });
-    video.addEventListener('play', refreshPlaybackUi, { passive: true });
-    video.addEventListener('pause', refreshPlaybackUi, { passive: true });
+  video.dataset.simpleYtTweaksBound = '1';
+  const refreshPlaybackUi = () => {
+    window.setTimeout(() => handlers.onPlaybackStateChange(), 0);
   };
 
-  attach();
+  video.addEventListener('enterpictureinpicture', handlers.onPipChange, { passive: true });
+  video.addEventListener('leavepictureinpicture', handlers.onPipChange, { passive: true });
+  video.addEventListener('play', refreshPlaybackUi, { passive: true });
+  video.addEventListener('pause', refreshPlaybackUi, { passive: true });
+}
+
+export function syncVideoEventBinding(): void {
+  if (!videoEventHandlers) return;
+
+  attachVideoEvents(videoEventHandlers);
+}
+
+export function bindVideoEvents(handlers: VideoEventHandlers): void {
+  videoEventHandlers = handlers;
+  syncVideoEventBinding();
+
   if (videoBindIntervalId === null) {
-    videoBindIntervalId = window.setInterval(attach, 2000);
+    videoBindIntervalId = window.setInterval(() => {
+      if (isWatchPage()) syncVideoEventBinding();
+    }, VIDEO_BIND_FALLBACK_INTERVAL_MS);
   }
 }

--- a/tests/e2e/extension.fixture.spec.ts
+++ b/tests/e2e/extension.fixture.spec.ts
@@ -451,6 +451,27 @@ test('watch fixture validates mode classes, visible comments, hover grow, and vi
   expect(extensionErrors(errors)).toEqual([]);
 });
 
+test('watch fixture binds replacement video through the runtime apply loop', async ({ context }) => {
+  const page = await context.newPage();
+  const errors = await openFixture(page, 'watch', 'https://www.youtube.com/watch?v=fixture');
+  const videoSurface = page.locator('#movie_player video.html5-main-video');
+
+  await expect(videoSurface).toHaveAttribute('data-simple-yt-tweaks-bound', '1');
+  await videoSurface.evaluate((video) => {
+    const replacement = video.cloneNode(false) as HTMLVideoElement;
+    replacement.removeAttribute('data-simple-yt-tweaks-bound');
+    replacement.setAttribute('data-testid', 'replacement-video');
+    video.replaceWith(replacement);
+  });
+
+  await expect(page.locator('[data-testid="replacement-video"]')).toHaveAttribute(
+    'data-simple-yt-tweaks-bound',
+    '1',
+    { timeout: 1_000 },
+  );
+  expect(extensionErrors(errors)).toEqual([]);
+});
+
 test('watch fixture keeps live chat overlay from squeezing the theater player', async ({ context, extensionId }) => {
   await writeExtensionSettings(context, extensionId, {
     theaterHideLiveChat: true,


### PR DESCRIPTION
## Summary

- Rebind watch video event listeners from the existing runtime apply/stabilization path so YouTube video node replacements do not wait on interval polling.
- Slow the video binding fallback from a permanent 2 second scan to a 10 second watch-page-only safety net.
- Add fixture coverage proving a replaced watch video node is rebound through the apply loop.

Refs #10.

## Safety

This does not change the watch-to-Home reload guard, native Home/Search preview behavior, enhanced hover behavior, settings contracts, release assets, or Web Store assets. The existing `data-simple-yt-tweaks-bound` marker still prevents duplicate listener attachment.

## How to test / what to tell the controller

Human review requested: no.

Commands run:

```sh
npm run test:e2e -- --grep "binds replacement video"
npm run test:e2e -- --grep "watch fixture validates|binds replacement video|player click fallback|docks and restores sticky"
npm run test:unit
npm run typecheck
npm run lint
git diff --check
```

Expected result: all commands pass. The focused fixture should show replacement watch video nodes receive `data-simple-yt-tweaks-bound="1"` within the apply-loop timeout.

Live QA needed: no. This PR does not alter watch-to-Home reload, native Home/Search previews, or live YouTube behavior.

Controller feedback format: `Review result for SYT-010H-D PR #<number>: Ready to Integrate` or `Needs Fixes: <file/line and issue>`.