### PR TITLE
SYT-010H-E: harden Search lockup selector fixtures

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -19,11 +19,11 @@ Use this file to track who is working, where they are working, and whether the c
 
 ## Active Agents
 
-One active serial Runner for `SYT-010H-E`.
+No active agents after `SYT-010H-E` integrated via PR #50.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Archimedes / `019eb4cc-e5d2-78c1-ba54-683c0915f08a` | `SYT-010H-E` | Senior Developer Runner | In Progress | `swarm/syt-010h-selector-fixtures` | worker-owned | draft PR expected | 2026-06-10 23:45 EDT | 2026-06-10 23:45 EDT | Open a draft PR with focused selector/fixture hardening and update `docs/swarm/handoffs/SYT-010H-E.md` | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -35,7 +35,7 @@ One active serial Runner for `SYT-010H-E`.
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `tests/unit/**`, `tests/e2e/extension.fixture.spec.ts`, `tests/e2e/youtube-fixtures.ts`, selected pure helper source if needed | `SYT-010H-E` | Archimedes | `swarm/syt-010h-selector-fixtures` / worker-owned | Selector/helper and fixture gap hardening | PR review or blocker |
+| none | none | none | none | none | none |
 
 ## Recently Completed
 
@@ -60,6 +60,7 @@ Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, t
 | `SYT-010H-B` / #46 | selector/runtime churn audit integrated |
 | `SYT-010H-C` / #47 | docs/context compaction integrated |
 | `SYT-010H-D` / #48 | runtime video binding hardening integrated |
+| `SYT-010H-E` / #50 | Search modern lockup selector fixture hardening integrated |
 
 ## Pending Launch
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -5,15 +5,16 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 ## Current Hot State
 
 - Active lane family: `SYT-010H`, final-leg polish/code-hardening under issue #10.
-- Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, and runtime video binding PR #48 are merged.
+- Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, runtime video binding PR #48, and Search lockup fixture PR #50 are merged.
 - Completed first burst:
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
   - `SYT-010H-B`: selector/runtime churn audit, PR #46, merge `ddac456`.
   - `SYT-010H-C`: docs/context compaction, PR #47, merge `b5e3f34`.
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
-- Active serial lane: `SYT-010H-E` selector helper and fixture gap hardening, assigned to Archimedes (`019eb4cc-e5d2-78c1-ba54-683c0915f08a`) on `swarm/syt-010h-selector-fixtures`.
+  - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
+- Active serial lane: none after PR #50 integration.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
-- Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding.
+- Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
 
 ## Hot Files
@@ -45,7 +46,8 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 - `SYT-010H-A` -> PR #45, merge `ce09953`, refs #10
 - `SYT-010H-B` -> PR #46, merge `ddac456`, refs #10
 - `SYT-010H-D` -> PR #48, refs #10
+- `SYT-010H-E` -> PR #50, refs #10
 
 ## Next Safe Controller Action
 
-Wait for `SYT-010H-E` to report a draft PR or blocker. Do not launch overlapping selector/runtime work and do not launch #8 hover research unless the user explicitly reopens that gate.
+If continuing #10 hardening, pick one covered `SYT-010H-F` organization target and keep it serial. Do not launch #8 hover research unless the user explicitly reopens that gate.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -9,12 +9,13 @@
 
 ## Current Focus
 
-1. Reconcile the completed first `SYT-010H` supervised burst and first serial runtime lane:
+1. Reconcile completed `SYT-010H` lanes:
    - A: settings/popup/defaults/persistence coverage, PR #45 merged at `ce09953`.
    - B: selector/runtime churn audit, PR #46 merged at `ddac456`.
    - C: swarm docs/context compaction, PR #47 merged at `b5e3f34`.
    - D: runtime video binding hardening, PR #48.
-2. Route the next serial selector/fixture hardening lane (`SYT-010H-E`) only after PR #48 is integrated and `main` is clean.
+   - E: modern Search lockup selector fixture hardening, PR #50.
+2. Keep `SYT-010H-F` proposed unless the next controller pass selects one covered module cleanup.
 3. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
 4. Keep release-candidate/version/tag/Web Store work out of the hardening lanes.
 
@@ -29,6 +30,7 @@
 - PR #46 merged the selector/runtime churn audit.
 - PR #47 merged docs compaction at `b5e3f34`.
 - PR #48 hardened runtime video binding from the existing apply loop.
+- PR #50 hardened modern Search lockup fixture coverage.
 - Issue #10 remains open for final-leg hardening; #8 remains a future gated research lane.
 
 ## Constraints And Risks
@@ -56,4 +58,4 @@
 ## Last Updated
 
 - Date: 2026-06-11
-- By: Controller review/integration for `SYT-010H-D`
+- By: Controller review/integration for `SYT-010H-E`

--- a/docs/swarm/handoffs/SYT-010H-E.md
+++ b/docs/swarm/handoffs/SYT-010H-E.md
@@ -60,12 +60,13 @@ Chosen target: Search modern `yt-lockup-view-model` non-video filtering. The pro
 - Passed: `npm run typecheck`
 - Passed: `npm run lint`
 - Passed: `git diff --check`
+- Passed after PR-scope cleanup: `git diff --check main...HEAD`
 
 ## Decisions Made
 
 - Kept the lane fixture-only because the existing selectors already handled the modern lockup variants.
 - Chose Search lockup filtering over live chat/fullscreen source extraction to avoid unnecessary runtime changes in this final-leg lane.
-- Left controller-owned `docs/swarm/agent-registry.md`, `docs/swarm/context-map.md`, and `docs/swarm/task-board.md` changes unstaged because they appeared to be controller registration state for this runner, not runner-owned handoff work.
+- Preserved the earlier controller registration state on local backup branch `swarm/syt-010h-selector-fixtures-with-registration`, then narrowed the pushed PR branch so this runner PR contains only the fixture and handoff files.
 
 ## Blockers Or Risks
 

--- a/docs/swarm/handoffs/SYT-010H-E.md
+++ b/docs/swarm/handoffs/SYT-010H-E.md
@@ -5,7 +5,7 @@
 - Task ID: `SYT-010H-E`
 - Title: Selector Helper And Fixture Gap Hardening
 - Assigned role: Senior Developer Runner
-- Current state: Needs Review
+- Current state: Integrated
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Branch: `swarm/syt-010h-selector-fixtures`
 - PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/50
@@ -61,6 +61,8 @@ Chosen target: Search modern `yt-lockup-view-model` non-video filtering. The pro
 - Passed: `npm run lint`
 - Passed: `git diff --check`
 - Passed after PR-scope cleanup: `git diff --check main...HEAD`
+- Controller review passed: no findings.
+- Controller integration gate passed: `npm run validate:all`
 
 ## Decisions Made
 
@@ -75,4 +77,4 @@ Chosen target: Search modern `yt-lockup-view-model` non-video filtering. The pro
 
 ## Next Recommended Role And Action
 
-Reviewer: review the fixture additions and PR body, then mark Ready to Integrate if the Search selector coverage is acceptable. Controller/Integrator can run the standard integration gate after review.
+Controller: keep `SYT-010H-F` proposed until the next clean pass. Do not start broad organization cleanup unless it is one module per PR with coverage already in place.

--- a/docs/swarm/handoffs/SYT-010H-E.md
+++ b/docs/swarm/handoffs/SYT-010H-E.md
@@ -8,7 +8,7 @@
 - Current state: Needs Review
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Branch: `swarm/syt-010h-selector-fixtures`
-- PR: pending
+- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/50
 - GitHub issue: #10
 - Verification tier: focused fixture plus static checks
 

--- a/docs/swarm/handoffs/SYT-010H-E.md
+++ b/docs/swarm/handoffs/SYT-010H-E.md
@@ -1,0 +1,77 @@
+# SYT-010H-E: Selector Helper And Fixture Gap Hardening
+
+## Status
+
+- Task ID: `SYT-010H-E`
+- Title: Selector Helper And Fixture Gap Hardening
+- Assigned role: Senior Developer Runner
+- Current state: Needs Review
+- Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+- Branch: `swarm/syt-010h-selector-fixtures`
+- PR: pending
+- GitHub issue: #10
+- Verification tier: focused fixture plus static checks
+
+## Scope
+
+Add a narrow selector-fixture hardening target from the `SYT-010H-B` audit recommendations.
+
+Chosen target: Search modern `yt-lockup-view-model` non-video filtering. The production CSS already included selectors for modern lockup Shorts, radio, and playlist variants, but the fixture only asserted legacy renderer variants.
+
+## Non-Scope
+
+- No production runtime source changes.
+- No Home/Search hover grow behavior.
+- No synthetic hover or forced preview playback.
+- No version, release, tag, Web Store, or #8 work.
+- No broad selector refactor.
+
+## Parallelization Metadata
+
+- `parallel-safe`: yes for this test-only change after `SYT-010H-D` integration
+- `serial-required`: no production selector/runtime edits were needed
+- `depends-on`: integrated `SYT-010H-B` audit and `SYT-010H-D`
+- `conflict-risk`: low for fixture-only Search selector coverage
+
+## Files Touched
+
+- `tests/e2e/youtube-fixtures.ts`
+- `tests/e2e/extension.fixture.spec.ts`
+- `docs/swarm/handoffs/SYT-010H-E.md`
+
+## Changes
+
+- Added a reusable Search fixture lockup helper.
+- Added modern Search lockup examples for:
+  - a valid watch video result
+  - a Shorts result
+  - a radio result
+  - a playlist result
+- Extended the Search fixture assertions so compact Search cleanup:
+  - keeps the valid modern watch lockup visible
+  - hides modern Shorts, radio, and playlist lockups
+  - leaves a modern playlist lockup visible when compact Search cleanup is disabled
+
+## Commands Run
+
+- Passed: `npm run test:e2e -- --grep "search fixture"`
+- Passed: `npm run test:e2e`
+- Passed: `npm run test:unit`
+- Passed: `npm run typecheck`
+- Passed: `npm run lint`
+- Passed: `git diff --check`
+
+## Decisions Made
+
+- Kept the lane fixture-only because the existing selectors already handled the modern lockup variants.
+- Chose Search lockup filtering over live chat/fullscreen source extraction to avoid unnecessary runtime changes in this final-leg lane.
+- Left controller-owned `docs/swarm/agent-registry.md`, `docs/swarm/context-map.md`, and `docs/swarm/task-board.md` changes unstaged because they appeared to be controller registration state for this runner, not runner-owned handoff work.
+
+## Blockers Or Risks
+
+- No known blockers.
+- Live YouTube / Brave QA is not requested because this is deterministic fixture coverage only and does not alter runtime behavior.
+
+## Next Recommended Role And Action
+
+Reviewer: review the fixture additions and PR body, then mark Ready to Integrate if the Search selector coverage is acceptable. Controller/Integrator can run the standard integration gate after review.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -10,8 +10,8 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 - Project brief: Ready
 - Material questions: Deferred, not blocking
-- Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C/D are integrated through PR #48.
-- Implementation dispatch: next source lane is serial `SYT-010H-E` selector helper and fixture gap hardening, after controller reconciliation.
+- Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C/D/E are integrated through PR #50.
+- Implementation dispatch: `SYT-010H-F` remains proposed; only start if the next pass selects one covered module.
 
 ## Active Tasks
 
@@ -27,7 +27,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | Task ID | Title | Status | Release Condition |
 | --- | --- | --- | --- |
 | `SYT-010H-D` | Runtime apply-loop and polling hardening | Integrated | PR #48; event/apply-loop video binding hardening. |
-| `SYT-010H-E` | Selector helper and fixture gap hardening | In Progress | Archimedes is running on `swarm/syt-010h-selector-fixtures`; keep serial if touching runtime selectors. |
+| `SYT-010H-E` | Selector helper and fixture gap hardening | Integrated | PR #50; modern Search lockup fixture coverage. |
 | `SYT-010H-F` | Theater/grid/sidebar organization cleanup | Proposed | Serial-only after coverage/audit lanes, one module per PR. |
 | `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
@@ -54,6 +54,7 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | `SYT-010H-B` | PR #46 merged at `ddac456` |
 | `SYT-010H-C` | PR #47 merged at `b5e3f34` |
 | `SYT-010H-D` | PR #48 merged; runtime video binding hardening |
+| `SYT-010H-E` | PR #50 merged; Search modern lockup selector fixture hardening |
 
 ## Review / Integration Queues
 
@@ -74,5 +75,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: wait for `SYT-010H-E` draft PR or blocker; do not spawn overlapping selector/runtime work.
+- Current controller phase: post-`SYT-010H-E` clean state; consider `SYT-010H-F` only as one covered module per PR.
 - Do not route #8 unless the user explicitly reopens that gate.

--- a/tests/e2e/extension.fixture.spec.ts
+++ b/tests/e2e/extension.fixture.spec.ts
@@ -380,6 +380,10 @@ test('search fixture applies compact grid cleanup and badge movement', async ({ 
   await expect(page.locator('[data-testid="search-shorts-video"]')).toBeHidden();
   await expect(page.locator('[data-testid="search-radio-video"]')).toBeHidden();
   await expect(page.locator('[data-testid="radio-result"]')).toBeHidden();
+  await expect(page.locator('[data-testid="modern-search-video"]')).toBeVisible();
+  await expect(page.locator('[data-testid="modern-search-shorts"]')).toBeHidden();
+  await expect(page.locator('[data-testid="modern-search-radio"]')).toBeHidden();
+  await expect(page.locator('[data-testid="modern-search-playlist"]')).toBeHidden();
   await expect(page.locator('[data-testid="generic-shelf"]')).toBeHidden();
   await expect(page.locator('[data-testid="channel-card"] #channel-title #text')).toHaveCSS('text-align', 'center');
   await expect(page.locator('[data-testid="search-1"] #channel-info .simple-yt-tweaks-search-badges')).toContainText('New');
@@ -402,6 +406,7 @@ test('search fixture can disable compact grid through stored settings', async ({
   );
   await expect(results).not.toHaveCSS('display', 'grid');
   await expect(page.locator('[data-testid="playlist-result"]')).toBeVisible();
+  await expect(page.locator('[data-testid="modern-search-playlist"]')).toBeVisible();
   await expect(page.locator('[data-testid="search-1"] .simple-yt-tweaks-search-badges')).toHaveCount(0);
   expect(extensionErrors(errors)).toEqual([]);
 });

--- a/tests/e2e/youtube-fixtures.ts
+++ b/tests/e2e/youtube-fixtures.ts
@@ -192,6 +192,17 @@ function videoRenderer(id: string, title: string, badges = ''): string {
   `;
 }
 
+function searchLockup(id: string, title: string, href: string): string {
+  return `
+    <yt-lockup-view-model data-testid="${id}">
+      <a class="ytLockupViewModelContentImage" href="${href}">
+        <yt-thumbnail-view-model></yt-thumbnail-view-model>
+      </a>
+      <a class="ytLockupMetadataViewModelTitle" href="${href}">${title}</a>
+    </yt-lockup-view-model>
+  `;
+}
+
 function searchFixture(): string {
   return pageShell(
     'YouTube Fixture Search',
@@ -234,6 +245,10 @@ function searchFixture(): string {
                       <ytd-radio-renderer data-testid="radio-result">
                         <a href="/watch?v=radio&start_radio=1">Radio result</a>
                       </ytd-radio-renderer>
+                      ${searchLockup('modern-search-video', 'Modern search video', '/watch?v=modern-search-video')}
+                      ${searchLockup('modern-search-shorts', 'Modern Shorts lockup', '/shorts/modern-search-short')}
+                      ${searchLockup('modern-search-radio', 'Modern radio lockup', '/watch?v=modern-radio&list=RDfixture')}
+                      ${searchLockup('modern-search-playlist', 'Modern playlist lockup', '/playlist?list=PLmodern')}
                       <ytd-shelf-renderer data-testid="generic-shelf">
                         <a href="/watch?v=shelf">Generic shelf</a>
                       </ytd-shelf-renderer>


### PR DESCRIPTION
## Summary

- Refs #10.
- Adds modern Search `yt-lockup-view-model` fixture variants for valid video, Shorts, radio, and playlist results.
- Extends fixture assertions so compact Search cleanup hides modern non-video lockups while preserving a valid modern watch result.
- Keeps this lane fixture-only; no production runtime selector changes were needed.

## How to test / what to tell the controller

Human review requested: no.

Exact commands run:

```bash
npm run test:e2e -- --grep "search fixture"
npm run test:e2e
npm run test:unit
npm run typecheck
npm run lint
git diff --check
git diff --check main...HEAD
```

Expected result: all commands pass. `npm run test:e2e` should report 21 fixture tests passing, and `npm run test:unit` should report 24 unit tests passing.

Controller feedback format: `SYT-010H-E review passed` or `SYT-010H-E needs fixes: <file/line and issue>`.

Live QA needed: no, because this is deterministic fixture coverage only and does not change runtime behavior.

## Notes

The runner handoff is updated at `docs/swarm/handoffs/SYT-010H-E.md`.
