### PR TITLE
Codex: Register SYT-010H-E runner

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -19,11 +19,11 @@ Use this file to track who is working, where they are working, and whether the c
 
 ## Active Agents
 
-No active agents after `SYT-010H-D` integrated via PR #48.
+One active serial Runner for `SYT-010H-E`.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| Archimedes / `019eb4cc-e5d2-78c1-ba54-683c0915f08a` | `SYT-010H-E` | Senior Developer Runner | In Progress | `swarm/syt-010h-selector-fixtures` | worker-owned | draft PR expected | 2026-06-10 23:45 EDT | 2026-06-10 23:45 EDT | Open a draft PR with focused selector/fixture hardening and update `docs/swarm/handoffs/SYT-010H-E.md` | none |
 
 ## Paused / Stale Agents
 
@@ -35,7 +35,7 @@ No active agents after `SYT-010H-D` integrated via PR #48.
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `tests/unit/**`, `tests/e2e/extension.fixture.spec.ts`, `tests/e2e/youtube-fixtures.ts`, selected pure helper source if needed | `SYT-010H-E` | Archimedes | `swarm/syt-010h-selector-fixtures` / worker-owned | Selector/helper and fixture gap hardening | PR review or blocker |
 
 ## Recently Completed
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -11,7 +11,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-B`: selector/runtime churn audit, PR #46, merge `ddac456`.
   - `SYT-010H-C`: docs/context compaction, PR #47, merge `b5e3f34`.
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
-- Active serial lane: none after PR #48 integration. Next candidate is `SYT-010H-E` selector helper and fixture gap hardening.
+- Active serial lane: `SYT-010H-E` selector helper and fixture gap hardening, assigned to Archimedes (`019eb4cc-e5d2-78c1-ba54-683c0915f08a`) on `swarm/syt-010h-selector-fixtures`.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
@@ -48,4 +48,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-After PR #48 integration is visible on clean `main`, route `SYT-010H-E` as a serial selector/fixture gap hardening lane. Do not launch #8 hover research unless the user explicitly reopens that gate.
+Wait for `SYT-010H-E` to report a draft PR or blocker. Do not launch overlapping selector/runtime work and do not launch #8 hover research unless the user explicitly reopens that gate.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -27,7 +27,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | Task ID | Title | Status | Release Condition |
 | --- | --- | --- | --- |
 | `SYT-010H-D` | Runtime apply-loop and polling hardening | Integrated | PR #48; event/apply-loop video binding hardening. |
-| `SYT-010H-E` | Selector helper and fixture gap hardening | Ready | Start after D is integrated and repo is clean; keep serial if touching runtime selectors. |
+| `SYT-010H-E` | Selector helper and fixture gap hardening | In Progress | Archimedes is running on `swarm/syt-010h-selector-fixtures`; keep serial if touching runtime selectors. |
 | `SYT-010H-F` | Theater/grid/sidebar organization cleanup | Proposed | Serial-only after coverage/audit lanes, one module per PR. |
 | `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
@@ -74,5 +74,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: reconcile PR #48 integration, then route `SYT-010H-E` if clean.
+- Current controller phase: wait for `SYT-010H-E` draft PR or blocker; do not spawn overlapping selector/runtime work.
 - Do not route #8 unless the user explicitly reopens that gate.


### PR DESCRIPTION
## Summary

- Register the active SYT-010H-E runner in the swarm docs.
- Lock selector/fixture paths while the worker prepares its draft PR.
- Keep #8 paused and prevent overlapping selector/runtime work.

Refs #10.

## How to test / what to tell the controller

Human review requested: no.

Commands run:

```sh
git diff --check origin/main...HEAD
```

Expected result: command passes and the heartbeat sees Archimedes as the active SYT-010H-E runner.

Controller feedback format: `Ready to Integrate` or `Needs Fixes: <reason>`.
