### PR TITLE
Codex: Register SYT-010H-F runner

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -19,11 +19,11 @@ Use this file to track who is working, where they are working, and whether the c
 
 ## Active Agents
 
-No active agents after `SYT-010H-E` integrated via PR #50.
+One active serial Runner for `SYT-010H-F`.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none | none | none | none | none | none |
+| Dirac / `019eb4e0-ebda-7913-9651-dc03c9c18991` | `SYT-010H-F` | Senior Developer Runner | In Progress | `swarm/syt-010h-content-organization` | `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks-syt010h-f` | draft PR expected | 2026-06-11 00:07 EDT | 2026-06-11 00:07 EDT | Open a draft PR with one-module `grid-hover.ts` organization cleanup and update `docs/swarm/handoffs/SYT-010H-F.md` | none |
 
 ## Paused / Stale Agents
 
@@ -35,7 +35,7 @@ No active agents after `SYT-010H-E` integrated via PR #50.
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| none | none | none | none | none | none |
+| `src/content/grid-hover.ts`, `tests/unit/grid-hover.unit.spec.ts`, `docs/swarm/handoffs/SYT-010H-F.md` | `SYT-010H-F` | Dirac | `swarm/syt-010h-content-organization` / `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks-syt010h-f` | One-module watch recommendation selector organization cleanup | PR review or blocker |
 
 ## Recently Completed
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -12,7 +12,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-C`: docs/context compaction, PR #47, merge `b5e3f34`.
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
   - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
-- Active serial lane: none after PR #50 integration.
+- Active serial lane: `SYT-010H-F`, assigned to Dirac (`019eb4e0-ebda-7913-9651-dc03c9c18991`) on `swarm/syt-010h-content-organization` in `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks-syt010h-f`.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
@@ -50,4 +50,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-If continuing #10 hardening, pick one covered `SYT-010H-F` organization target and keep it serial. Do not launch #8 hover research unless the user explicitly reopens that gate.
+Wait for `SYT-010H-F` to report a draft PR or blocker. Do not launch overlapping runtime/organization work and do not launch #8 hover research unless the user explicitly reopens that gate.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -15,7 +15,7 @@
    - C: swarm docs/context compaction, PR #47 merged at `b5e3f34`.
    - D: runtime video binding hardening, PR #48.
    - E: modern Search lockup selector fixture hardening, PR #50.
-2. Keep `SYT-010H-F` proposed unless the next controller pass selects one covered module cleanup.
+2. `SYT-010H-F` is active as a one-module `grid-hover.ts` watch-recommendation selector organization cleanup.
 3. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
 4. Keep release-candidate/version/tag/Web Store work out of the hardening lanes.
 
@@ -31,6 +31,7 @@
 - PR #47 merged docs compaction at `b5e3f34`.
 - PR #48 hardened runtime video binding from the existing apply loop.
 - PR #50 hardened modern Search lockup fixture coverage.
+- `SYT-010H-F` runner Dirac is active in a separate worktree for one-module grid-hover organization cleanup.
 - Issue #10 remains open for final-leg hardening; #8 remains a future gated research lane.
 
 ## Constraints And Risks

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -28,7 +28,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | --- | --- | --- | --- |
 | `SYT-010H-D` | Runtime apply-loop and polling hardening | Integrated | PR #48; event/apply-loop video binding hardening. |
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Integrated | PR #50; modern Search lockup fixture coverage. |
-| `SYT-010H-F` | Theater/grid/sidebar organization cleanup | Proposed | Serial-only after coverage/audit lanes, one module per PR. |
+| `SYT-010H-F` | Grid-hover watch recommendation selector organization cleanup | In Progress | Dirac is running on `swarm/syt-010h-content-organization`; one module only. |
 | `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
 
@@ -75,5 +75,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: post-`SYT-010H-E` clean state; consider `SYT-010H-F` only as one covered module per PR.
+- Current controller phase: wait for `SYT-010H-F` draft PR or blocker; do not spawn overlapping runtime/organization work.
 - Do not route #8 unless the user explicitly reopens that gate.


### PR DESCRIPTION
## Summary

- Register the active SYT-010H-F runner in the swarm docs.
- Lock `grid-hover.ts` and focused unit-test scope while the worker prepares its draft PR.
- Keep #8 paused and prevent overlapping runtime/organization work.

Refs #10.

## How to test / what to tell the controller

Human review requested: no.

Commands run:

```sh
git diff --check
```

Expected result: command passes and the heartbeat sees Dirac as the active SYT-010H-F runner.

Controller feedback format: `Ready to Integrate` or `Needs Fixes: <reason>`.
