### PR TITLE
SYT-010H-F grid hover selector organization

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -19,11 +19,11 @@ Use this file to track who is working, where they are working, and whether the c
 
 ## Active Agents
 
-One active serial Runner for `SYT-010H-F`.
+No active agents after `SYT-010H-F` integrated via PR #54.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Dirac / `019eb4e0-ebda-7913-9651-dc03c9c18991` | `SYT-010H-F` | Senior Developer Runner | In Progress | `swarm/syt-010h-content-organization` | `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks-syt010h-f` | draft PR expected | 2026-06-11 00:07 EDT | 2026-06-11 00:07 EDT | Open a draft PR with one-module `grid-hover.ts` organization cleanup and update `docs/swarm/handoffs/SYT-010H-F.md` | none |
+| none | none | none | none | none | none | none | none | none | none | none |
 
 ## Paused / Stale Agents
 
@@ -35,7 +35,7 @@ One active serial Runner for `SYT-010H-F`.
 
 | Path / Area | Task ID | Owner | Branch / Worktree | Reason | Release Condition |
 | --- | --- | --- | --- | --- | --- |
-| `src/content/grid-hover.ts`, `tests/unit/grid-hover.unit.spec.ts`, `docs/swarm/handoffs/SYT-010H-F.md` | `SYT-010H-F` | Dirac | `swarm/syt-010h-content-organization` / `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks-syt010h-f` | One-module watch recommendation selector organization cleanup | PR review or blocker |
+| none | none | none | none | none | none |
 
 ## Recently Completed
 
@@ -61,6 +61,7 @@ Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, t
 | `SYT-010H-C` / #47 | docs/context compaction integrated |
 | `SYT-010H-D` / #48 | runtime video binding hardening integrated |
 | `SYT-010H-E` / #50 | Search modern lockup selector fixture hardening integrated |
+| `SYT-010H-F` / #54 | grid-hover watch recommendation selector organization integrated |
 
 ## Pending Launch
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -5,16 +5,17 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 ## Current Hot State
 
 - Active lane family: `SYT-010H`, final-leg polish/code-hardening under issue #10.
-- Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, runtime video binding PR #48, and Search lockup fixture PR #50 are merged.
+- Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, runtime video binding PR #48, Search lockup fixture PR #50, and grid-hover organization PR #54 are merged.
 - Completed first burst:
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
   - `SYT-010H-B`: selector/runtime churn audit, PR #46, merge `ddac456`.
   - `SYT-010H-C`: docs/context compaction, PR #47, merge `b5e3f34`.
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
   - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
-- Active serial lane: `SYT-010H-F`, assigned to Dirac (`019eb4e0-ebda-7913-9651-dc03c9c18991`) on `swarm/syt-010h-content-organization` in `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks-syt010h-f`.
+  - `SYT-010H-F`: grid-hover watch recommendation selector organization, PR #54.
+- Active serial lane: none after PR #54 integration.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
-- Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures.
+- Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures, #54 grid-hover organization.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
 
 ## Hot Files
@@ -47,7 +48,8 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 - `SYT-010H-B` -> PR #46, merge `ddac456`, refs #10
 - `SYT-010H-D` -> PR #48, refs #10
 - `SYT-010H-E` -> PR #50, refs #10
+- `SYT-010H-F` -> PR #54, refs #10
 
 ## Next Safe Controller Action
 
-Wait for `SYT-010H-F` to report a draft PR or blocker. Do not launch overlapping runtime/organization work and do not launch #8 hover research unless the user explicitly reopens that gate.
+Prepare `SYT-RC-001` release-candidate checklist / #10 completion decision. Do not release, bump version, tag, or launch #8 hover research without explicit user approval.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,17 +8,17 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-06-11 00:07 EDT
+- Last reviewed by controller: 2026-06-11 00:19 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `main`
 - Expected Git state: clean `main` synced with `origin/main`
-- Open PR expectation: PR #20 remains paused draft for #8 research; no active #10 PR after #50 merge
+- Open PR expectation: PR #20 remains paused draft for #8 research; no active #10 PR after #54 merge
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-010H-F`, one-module organization cleanup under #10
+- Current priority lane: `SYT-RC-001`, release-candidate checklist / #10 completion decision
 
 ## Controller Lease And Pacing
 
@@ -106,7 +106,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-010H-F` | Select one covered module organization target, then launch a serial Runner. Keep the PR to one module plus tests/handoff, and reject broad cleanup. | Controller / Runner | `swarm/syt-010h-content-organization` | Draft PR opened with focused checks, or handoff records a blocker |
+| 1 | `SYT-RC-001` | Prepare the release-candidate checklist and decide whether #10 hardening is complete. Do not bump version, tag, release, or update Web Store assets. | Controller / Planner | TBD | Checklist PR opened or human QA gate recorded |
 | 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
@@ -142,3 +142,4 @@ Heartbeat overlap rule:
 - 2026-06-11: PR #37 was marked ready and squash-merged at `342854f` after `npm run validate:all` passed. Issues #36 and #38 are closed; route `SYT-010H` next.
 - 2026-06-11: User approved a supervised final-leg push with up to 3 subagents if useful. Apply that only to planner-approved disjoint `SYT-010H` lanes; do not parallelize overlapping runtime implementation.
 - 2026-06-11: `SYT-010H` A/B/C/D/E are integrated through PR #50. `npm run validate:all` passed before #48 and #50 merges. Next safe source lane is serial `SYT-010H-F`; keep #8 paused.
+- 2026-06-11: `SYT-010H-F` integrated through PR #54 after focused checks and `npm run validate:all`. Next safe action is `SYT-RC-001` checklist / #10 completion decision; no release action is approved yet.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -15,9 +15,10 @@
    - C: swarm docs/context compaction, PR #47 merged at `b5e3f34`.
    - D: runtime video binding hardening, PR #48.
    - E: modern Search lockup selector fixture hardening, PR #50.
-2. `SYT-010H-F` is active as a one-module `grid-hover.ts` watch-recommendation selector organization cleanup.
-3. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
-4. Keep release-candidate/version/tag/Web Store work out of the hardening lanes.
+2. `SYT-010H-F` integrated one-module `grid-hover.ts` watch-recommendation selector organization cleanup.
+3. Next controller step is `SYT-RC-001` checklist / #10 completion decision.
+4. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
+5. Keep version/tag/Web Store release actions out unless explicitly approved.
 
 ## Recent State
 
@@ -31,7 +32,7 @@
 - PR #47 merged docs compaction at `b5e3f34`.
 - PR #48 hardened runtime video binding from the existing apply loop.
 - PR #50 hardened modern Search lockup fixture coverage.
-- `SYT-010H-F` runner Dirac is active in a separate worktree for one-module grid-hover organization cleanup.
+- PR #54 organized grid-hover watch recommendation selector construction and added unit assertions.
 - Issue #10 remains open for final-leg hardening; #8 remains a future gated research lane.
 
 ## Constraints And Risks
@@ -59,4 +60,4 @@
 ## Last Updated
 
 - Date: 2026-06-11
-- By: Controller review/integration for `SYT-010H-E`
+- By: Controller review/integration for `SYT-010H-F`

--- a/docs/swarm/handoffs/SYT-010H-F.md
+++ b/docs/swarm/handoffs/SYT-010H-F.md
@@ -5,10 +5,11 @@
 - Task ID: `SYT-010H-F`
 - Title: One-module grid-hover organization cleanup
 - Assigned role: Senior Developer Runner
-- Current state: Needs Review
+- Current state: Integrated
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Worktree: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks-syt010h-f`
 - Branch: `swarm/syt-010h-content-organization`
+- PR: https://github.com/cryptoteatime/simple-yt-tweaks/pull/54
 - GitHub issue: #10
 - Verification tier: focused unit/static checks
 
@@ -52,6 +53,13 @@ Organization-only cleanup in `src/content/grid-hover.ts` for the watch recommend
 - Passed: `npm run typecheck`
 - Passed: `npm run lint`
 - Passed: `git diff --check`
+- Controller review passed: no findings.
+- Controller focused checks passed:
+  - `npm run test:unit -- --grep "grid hover"`
+  - `npm run typecheck`
+  - `npm run lint`
+  - `git diff --check origin/main...HEAD`
+- Controller integration gate passed: `npm run validate:all`
 
 ## Decisions Made
 
@@ -67,4 +75,4 @@ Organization-only cleanup in `src/content/grid-hover.ts` for the watch recommend
 
 ## Next Recommended Role And Action
 
-Reviewer: review the narrow selector-helper diff and PR body, then mark `Ready to Integrate` if no selector regression or scope issue is found.
+Controller: keep #10 open until the release-candidate checklist records whether final hardening is complete. Do not start another broad cleanup lane without a new narrow target.

--- a/docs/swarm/handoffs/SYT-010H-F.md
+++ b/docs/swarm/handoffs/SYT-010H-F.md
@@ -1,0 +1,70 @@
+# SYT-010H-F: One-Module Grid-Hover Organization Cleanup
+
+## Status
+
+- Task ID: `SYT-010H-F`
+- Title: One-module grid-hover organization cleanup
+- Assigned role: Senior Developer Runner
+- Current state: Needs Review
+- Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+- Worktree: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks-syt010h-f`
+- Branch: `swarm/syt-010h-content-organization`
+- GitHub issue: #10
+- Verification tier: focused unit/static checks
+
+## Scope
+
+Organization-only cleanup in `src/content/grid-hover.ts` for the watch recommendation / sidebar-recommended hover grow path.
+
+## Non-Scope
+
+- No enhanced Home/Search hover grow.
+- No synthetic hover or forced preview playback.
+- No Search grid cleanup, Home native hover cleanup, watch-to-Home reload behavior, live chat, Sticky Player, settings contracts, version, tag, release, Web Store assets, or #8 changes.
+- No broad module splitting or multi-runtime cleanup.
+- No selector broadening.
+
+## Parallelization Metadata
+
+- `parallel-safe`: no
+- `serial-required`: yes
+- `depends-on`: integrated `SYT-010H-B` audit and `SYT-010H-E` selector fixture lane
+- `conflict-risk`: medium/high for runtime source, kept narrow to one module plus unit tests
+
+## Files Touched
+
+- `src/content/grid-hover.ts`
+- `tests/unit/grid-hover.unit.spec.ts`
+- `docs/swarm/handoffs/SYT-010H-F.md`
+
+## Changes
+
+- Extracted the watch recommendation container list used by related/sidebar recommendation selectors.
+- Added small local helpers for scoping watch recommendation selectors, appending descendants, and deriving the ready-state selector form.
+- Reused those helpers for legacy compact-card and modern lockup selector construction without changing the generated selector strings.
+- Added a focused unit assertion that locks the current legacy compact-card behavior and all three modern watch lockup scopes.
+
+## Commands Run
+
+- Initial blocked check: `npm run test:unit -- --grep "grid hover"` failed before dependency install because `playwright` was missing.
+- Setup: `npm ci` passed; reported one existing moderate `npm audit` finding.
+- Passed: `npm run test:unit -- --grep "grid hover"` (3 tests)
+- Passed: `npm run typecheck`
+- Passed: `npm run lint`
+- Passed: `git diff --check`
+
+## Decisions Made
+
+- Kept the legacy `ytd-compact-video-renderer` CSS behavior unscoped because that was the existing generated CSS behavior.
+- Kept modern `yt-lockup-view-model` watch selectors scoped to `#related`, `ytd-watch-next-secondary-results-renderer`, and `#secondary`.
+- Did not add e2e coverage because no fixture behavior or runtime behavior changed.
+
+## Blockers Or Risks
+
+- No known blockers.
+- Live YouTube / Brave QA is not requested for this PR because the change is selector-construction organization only and is covered by unit CSS assertions.
+- `npm ci` reported one moderate audit finding; not addressed because dependency remediation is outside this task.
+
+## Next Recommended Role And Action
+
+Reviewer: review the narrow selector-helper diff and PR body, then mark `Ready to Integrate` if no selector regression or scope issue is found.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -10,8 +10,8 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 - Project brief: Ready
 - Material questions: Deferred, not blocking
-- Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C/D/E are integrated through PR #50.
-- Implementation dispatch: `SYT-010H-F` remains proposed; only start if the next pass selects one covered module.
+- Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C/D/E/F are integrated through PR #54.
+- Implementation dispatch: no active hardening runner; next controller step is `SYT-RC-001` checklist / #10 completion decision.
 
 ## Active Tasks
 
@@ -28,7 +28,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | --- | --- | --- | --- |
 | `SYT-010H-D` | Runtime apply-loop and polling hardening | Integrated | PR #48; event/apply-loop video binding hardening. |
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Integrated | PR #50; modern Search lockup fixture coverage. |
-| `SYT-010H-F` | Grid-hover watch recommendation selector organization cleanup | In Progress | Dirac is running on `swarm/syt-010h-content-organization`; one module only. |
+| `SYT-010H-F` | Grid-hover watch recommendation selector organization cleanup | Integrated | PR #54; one-module selector organization and unit coverage. |
 | `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
 
@@ -55,6 +55,7 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | `SYT-010H-C` | PR #47 merged at `b5e3f34` |
 | `SYT-010H-D` | PR #48 merged; runtime video binding hardening |
 | `SYT-010H-E` | PR #50 merged; Search modern lockup selector fixture hardening |
+| `SYT-010H-F` | PR #54 merged; grid-hover watch recommendation selector organization |
 
 ## Review / Integration Queues
 
@@ -75,5 +76,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: wait for `SYT-010H-F` draft PR or blocker; do not spawn overlapping runtime/organization work.
+- Current controller phase: post-`SYT-010H-F` clean state; prepare `SYT-RC-001` checklist or decide whether #10 can close.
 - Do not route #8 unless the user explicitly reopens that gate.

--- a/src/content/grid-hover.ts
+++ b/src/content/grid-hover.ts
@@ -20,62 +20,70 @@ const PREVIEW_CONTAINER_SELECTOR = [
   '.ytp-inline-preview-ui',
   'video',
 ].join(',');
-const SIDEBAR_CARD_SELECTOR = [
-  '#related ytd-compact-video-renderer',
-  'ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer',
-  '#secondary ytd-compact-video-renderer',
-  '#related yt-lockup-view-model',
-  'ytd-watch-next-secondary-results-renderer yt-lockup-view-model',
-  '#secondary yt-lockup-view-model',
-].join(',');
 const SEARCH_GRID_CONTENTS_SELECTOR =
   'ytd-search ytd-two-column-search-results-renderer #primary ytd-section-list-renderer > #contents.ytd-section-list-renderer';
-const HOVER_CARD_SELECTOR = SIDEBAR_CARD_SELECTOR;
-const LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR = 'ytd-compact-video-renderer';
-const MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS = [
-  '#related yt-lockup-view-model:has(a[href*="/watch"])',
-  'ytd-watch-next-secondary-results-renderer yt-lockup-view-model:has(a[href*="/watch"])',
-  '#secondary yt-lockup-view-model:has(a[href*="/watch"])',
+const WATCH_RECOMMENDATION_SCOPES = [
+  '#related',
+  'ytd-watch-next-secondary-results-renderer',
+  '#secondary',
 ];
+const LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR = 'ytd-compact-video-renderer';
+const MODERN_WATCH_RECOMMENDATION_CARD_SELECTOR = 'yt-lockup-view-model:has(a[href*="/watch"])';
+const MODERN_WATCH_RECOMMENDATION_BASE_SELECTOR = 'yt-lockup-view-model';
+
+function scopeWatchRecommendationSelector(selector: string): string[] {
+  return WATCH_RECOMMENDATION_SCOPES.map((scope) => `${scope} ${selector}`);
+}
+
+function appendDescendant(selectors: string[], descendant: string): string[] {
+  return selectors.map((selector) => `${selector} ${descendant}`);
+}
+
+const SIDEBAR_CARD_SELECTOR = [
+  ...scopeWatchRecommendationSelector(LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR),
+  ...scopeWatchRecommendationSelector(MODERN_WATCH_RECOMMENDATION_BASE_SELECTOR),
+].join(',');
+const HOVER_CARD_SELECTOR = SIDEBAR_CARD_SELECTOR;
+const MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS = scopeWatchRecommendationSelector(
+  MODERN_WATCH_RECOMMENDATION_CARD_SELECTOR,
+);
 const WATCH_RECOMMENDATION_CARD_SELECTORS = [
   LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR,
   ...MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS,
 ];
-function addGridHoverReadyClass(selector: string): string {
+function readyWatchRecommendationSelector(selector: string): string {
   if (selector === LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR) {
     return `${LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR}.${GRID_HOVER_READY_CLASS}`;
   }
 
-  return selector.replace('yt-lockup-view-model', `yt-lockup-view-model.${GRID_HOVER_READY_CLASS}`);
+  return selector.replace(
+    MODERN_WATCH_RECOMMENDATION_BASE_SELECTOR,
+    `${MODERN_WATCH_RECOMMENDATION_BASE_SELECTOR}.${GRID_HOVER_READY_CLASS}`,
+  );
 }
 const READY_WATCH_RECOMMENDATION_CARD_SELECTORS =
-  WATCH_RECOMMENDATION_CARD_SELECTORS.map(addGridHoverReadyClass);
+  WATCH_RECOMMENDATION_CARD_SELECTORS.map(readyWatchRecommendationSelector);
 const WATCH_RECOMMENDATION_MEDIA_SELECTORS = [
   `${LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR} ytd-thumbnail`,
-  ...MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS.map((selector) => `${selector} yt-thumbnail-view-model`),
+  ...appendDescendant(MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS, 'yt-thumbnail-view-model'),
 ];
 const READY_WATCH_RECOMMENDATION_MEDIA_SELECTORS = [
-  `${addGridHoverReadyClass(LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR)} ytd-thumbnail`,
-  ...MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS.map(
-    (selector) => `${addGridHoverReadyClass(selector)} yt-thumbnail-view-model`,
+  `${readyWatchRecommendationSelector(LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR)} ytd-thumbnail`,
+  ...appendDescendant(
+    MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS.map(readyWatchRecommendationSelector),
+    'yt-thumbnail-view-model',
   ),
 ];
 const WATCH_RECOMMENDATION_OVERLAY_BUTTON_SELECTORS = [
-  ...MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS.map(
-    (selector) => `${addGridHoverReadyClass(selector)} thumbnail-overlay-button-view-model`,
+  ...appendDescendant(
+    MODERN_WATCH_RECOMMENDATION_CARD_SELECTORS.map(readyWatchRecommendationSelector),
+    'thumbnail-overlay-button-view-model',
   ),
-  `${addGridHoverReadyClass(LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR)} ytd-thumbnail-overlay-toggle-button-renderer`,
+  `${readyWatchRecommendationSelector(LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR)} ytd-thumbnail-overlay-toggle-button-renderer`,
 ];
-function appendDescendant(selectors: string[], descendant: string): string[] {
-  return selectors.map((selector) => `${selector} ${descendant}`);
-}
 const HOVER_MEDIA_SELECTOR = [
-  '#related ytd-compact-video-renderer ytd-thumbnail',
-  'ytd-watch-next-secondary-results-renderer ytd-compact-video-renderer ytd-thumbnail',
-  '#secondary ytd-compact-video-renderer ytd-thumbnail',
-  '#related yt-lockup-view-model yt-thumbnail-view-model',
-  'ytd-watch-next-secondary-results-renderer yt-lockup-view-model yt-thumbnail-view-model',
-  '#secondary yt-lockup-view-model yt-thumbnail-view-model',
+  ...scopeWatchRecommendationSelector(`${LEGACY_WATCH_RECOMMENDATION_CARD_SELECTOR} ytd-thumbnail`),
+  ...scopeWatchRecommendationSelector(`${MODERN_WATCH_RECOMMENDATION_BASE_SELECTOR} yt-thumbnail-view-model`),
 ].join(',');
 const NATIVE_FEED_CARD_SELECTORS = [
   'ytd-browse[page-subtype="home"] ytd-rich-item-renderer',

--- a/tests/unit/grid-hover.unit.spec.ts
+++ b/tests/unit/grid-hover.unit.spec.ts
@@ -28,6 +28,31 @@ test('grid hover CSS scopes watch recommendation selectors to enabled modes', ()
   );
 });
 
+test('grid hover CSS keeps legacy and modern watch recommendation scopes aligned', () => {
+  const css = buildGridHoverCss(settings({
+    generalApplyFeedColumnsToSearch: false,
+    defaultRecommendedHoverGrow: true,
+    theaterRecommendedHoverGrow: false,
+  }));
+  const scope = 'body.simple-yt-tweaks-active.simple-yt-tweaks-default-view';
+
+  expect(css).toContain(`${scope} ytd-compact-video-renderer`);
+  expect(css).toContain(`${scope} ytd-compact-video-renderer ytd-thumbnail`);
+  expect(css).toContain(`${scope} ytd-compact-video-renderer.simple-yt-tweaks-grid-hover-ready ytd-thumbnail`);
+
+  for (const container of ['#related', 'ytd-watch-next-secondary-results-renderer', '#secondary']) {
+    expect(css).toContain(
+      `${scope} ${container} yt-lockup-view-model:has(a[href*="/watch"]) yt-thumbnail-view-model`,
+    );
+    expect(css).toContain(
+      `${scope} ${container} yt-lockup-view-model.simple-yt-tweaks-grid-hover-ready:has(a[href*="/watch"]) yt-thumbnail-view-model`,
+    );
+    expect(css).toContain(
+      `${scope} ${container} yt-lockup-view-model.simple-yt-tweaks-grid-hover-ready:has(a[href*="/watch"]) thumbnail-overlay-button-view-model`,
+    );
+  }
+});
+
 test('grid hover CSS omits disabled watch recommendation hover scopes', () => {
   const theaterOnlyCss = buildGridHoverCss(settings({
     generalApplyFeedColumnsToSearch: false,


### PR DESCRIPTION
## Summary

Refs #10.

- Centralizes watch recommendation container scoping in `src/content/grid-hover.ts`.
- Reuses local helpers for legacy compact-card and modern lockup selector derivation.
- Adds unit assertions that lock the current legacy compact-card CSS behavior and modern watch lockup scopes.

## Scope

This is an organization-only cleanup for the watch recommendation / sidebar-recommended hover grow path. It does not reintroduce enhanced Home/Search hover grow, synthesize hover, force preview playback, or change watch-to-Home, live chat, Sticky Player, settings, release, or Web Store behavior.

## How to test / what to tell the controller

Human review requested: no.

Commands run:

```sh
npm run test:unit -- --grep "grid hover"
npm run typecheck
npm run lint
git diff --check
```

Expected result: all commands pass. The focused unit suite should report 3 passing grid-hover tests.

Live QA needed: no. This is selector construction organization plus unit CSS assertions only; no fixture or live YouTube behavior changed.

Controller feedback format: `SYT-010H-F PR #<number> review passed` or `SYT-010H-F PR #<number> needs fixes: <file/line findings>`.

Notes: the first unit attempt failed before dependency install because `playwright` was missing in the worktree; `npm ci` was run and reported one existing moderate npm audit finding outside this task.