### PR TITLE
Codex: Add SYT-RC-001 checklist

### DIFF
--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,7 +4,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active lane family: `SYT-010H`, final-leg polish/code-hardening under issue #10.
+- Active lane family: `SYT-RC-001`, release-candidate checklist and #10 completion decision.
 - Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, runtime video binding PR #48, Search lockup fixture PR #50, and grid-hover organization PR #54 are merged.
 - Completed first burst:
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
@@ -13,7 +13,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
   - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
   - `SYT-010H-F`: grid-hover watch recommendation selector organization, PR #54.
-- Active serial lane: none after PR #54 integration.
+- Active serial lane: none after PR #54 integration; next state is human RC QA after checklist integration.
 - GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures, #54 grid-hover organization.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
@@ -25,7 +25,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 - Task queue: `docs/swarm/task-board.md`
 - Agent capacity: `docs/swarm/agent-registry.md`
 - GitHub policy/state: `docs/swarm/github.md`
-- Active lane handoff: `docs/swarm/handoffs/SYT-010H.md`
+- Active lane handoff: `docs/swarm/handoffs/SYT-RC-001.md`
 - User steering: `docs/swarm/user-feedback.md`
 
 ## Completed Lane References
@@ -52,4 +52,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Prepare `SYT-RC-001` release-candidate checklist / #10 completion decision. Do not release, bump version, tag, or launch #8 hover research without explicit user approval.
+Integrate `SYT-RC-001` checklist, then request human RC QA. Do not release, bump version, tag, close #10, or launch #8 hover research without explicit user approval or the checklist's stated gate.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,7 +8,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-06-11 00:19 EDT
+- Last reviewed by controller: 2026-06-11 00:32 EDT
 
 ## Current Source Of Truth
 
@@ -106,7 +106,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-RC-001` | Prepare the release-candidate checklist and decide whether #10 hardening is complete. Do not bump version, tag, release, or update Web Store assets. | Controller / Planner | TBD | Checklist PR opened or human QA gate recorded |
+| 1 | `SYT-RC-001` | Integrate the release-candidate checklist and record the #10 completion decision. Do not bump version, tag, release, close #10, or update Web Store assets. | Controller / Planner | `swarm/syt-rc-001-checklist` | Checklist PR merged or human QA gate recorded |
 | 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
@@ -143,3 +143,4 @@ Heartbeat overlap rule:
 - 2026-06-11: User approved a supervised final-leg push with up to 3 subagents if useful. Apply that only to planner-approved disjoint `SYT-010H` lanes; do not parallelize overlapping runtime implementation.
 - 2026-06-11: `SYT-010H` A/B/C/D/E are integrated through PR #50. `npm run validate:all` passed before #48 and #50 merges. Next safe source lane is serial `SYT-010H-F`; keep #8 paused.
 - 2026-06-11: `SYT-010H-F` integrated through PR #54 after focused checks and `npm run validate:all`. Next safe action is `SYT-RC-001` checklist / #10 completion decision; no release action is approved yet.
+- 2026-06-11: Controller prepared `SYT-RC-001` checklist branch. #10 remains open until checklist integration and RC pass/fail decision.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,19 +4,19 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening; `SYT-010H` final-leg polish/code-hardening is active under issue #10.
+- Status: existing repo, post-v0.3.0 hardening; `SYT-010H` implementation lanes are integrated and the repo is moving into `SYT-RC-001` release-candidate validation.
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
 
 ## Current Focus
 
-1. Reconcile completed `SYT-010H` lanes:
+1. Completed `SYT-010H` lanes:
    - A: settings/popup/defaults/persistence coverage, PR #45 merged at `ce09953`.
    - B: selector/runtime churn audit, PR #46 merged at `ddac456`.
    - C: swarm docs/context compaction, PR #47 merged at `b5e3f34`.
    - D: runtime video binding hardening, PR #48.
    - E: modern Search lockup selector fixture hardening, PR #50.
 2. `SYT-010H-F` integrated one-module `grid-hover.ts` watch-recommendation selector organization cleanup.
-3. Next controller step is `SYT-RC-001` checklist / #10 completion decision.
+3. Current controller step is `SYT-RC-001`: publish the RC checklist and make #10 completion criteria explicit.
 4. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
 5. Keep version/tag/Web Store release actions out unless explicitly approved.
 
@@ -42,13 +42,14 @@
 - Live YouTube smoke can be noisy; fixture-first checks remain the normal gate.
 - Do not reintroduce Home/Search enhanced hover grow, synthetic hover, or forced preview playback.
 - Do not bump version, tag releases, edit Web Store assets, or close #10 from docs/test lanes.
+- #10 should remain open until the RC checklist is integrated and the next controller/user RC pass confirms no new hardening defects.
 
 ## Verification Defaults
 
 - Runner focused checks: task-specific `npm run test:e2e`, `npm run test:unit`, `npm run lint`, `npm run typecheck`, or `git diff --check` as assigned.
 - Reviewer targeted checks: changed-risk checks plus PR body/handoff validation.
 - Integrator full gate for source/test PRs: `npm run validate:all`.
-- Human QA: release candidate, #8 visual hover implementation, or explicit high-risk live browser behavior.
+- Human QA: required for `SYT-RC-001`, #8 visual hover implementation, or explicit high-risk live browser behavior.
 
 ## Automation Notes
 
@@ -60,4 +61,4 @@
 ## Last Updated
 
 - Date: 2026-06-11
-- By: Controller review/integration for `SYT-010H-F`
+- By: Controller heartbeat preparing `SYT-RC-001`

--- a/docs/swarm/handoffs/SYT-RC-001.md
+++ b/docs/swarm/handoffs/SYT-RC-001.md
@@ -1,0 +1,128 @@
+# SYT-RC-001: Release-Candidate Checklist And #10 Completion Decision
+
+## Status
+
+- Task ID: `SYT-RC-001`
+- GitHub issue: #10 remains open
+- Branch: `swarm/syt-rc-001-checklist`
+- PR: #55
+- State: Ready for Human QA after checklist PR integration
+- Role: Controller / release-candidate planner
+- Last updated: 2026-06-11 00:32 EDT
+
+## Goal
+
+Move the repo from post-v0.3.0 hardening into a release-candidate validation gate without changing runtime behavior, bumping the extension version, tagging a release, or updating Web Store assets.
+
+## Scope
+
+- Capture the final automated and human QA checklist for the next release-candidate pass.
+- Record the controller decision for #10: implementation hardening lanes A-F are complete enough to stop routing new #10 work unless RC QA finds a concrete regression.
+- Keep #8 enhanced Home/Search hover grow research paused.
+- Keep release actions blocked until explicit user approval after RC QA.
+
+## Non-Scope
+
+- No production source edits.
+- No test fixture edits unless a later RC failure requires them.
+- No enhanced Home/Search hover grow, forced preview playback, or synthetic hover behavior.
+- No version bump, tag, GitHub release, package upload, or Web Store asset update.
+- Do not close #10 from this docs-only checklist PR.
+
+## #10 Completion Decision
+
+`SYT-010H` completed the planned hardening lanes:
+
+- A: settings, popup defaults, and persistence coverage.
+- B: selector/runtime churn audit.
+- C: hot docs/context compaction.
+- D: runtime video binding hardening.
+- E: modern Search lockup fixture coverage.
+- F: grid-hover watch recommendation selector organization.
+
+Decision: stop opening additional speculative #10 hardening lanes. Keep #10 open until the checklist PR is integrated and the next controller/user RC pass confirms no new hardening defects. If RC QA passes, #10 can be closed with a summary linking the merged hardening PRs and the RC checklist. If RC QA fails, file or route a new narrow issue for the concrete failure instead of reopening broad hardening.
+
+## Automated Gate
+
+Run on clean `main` before asking for RC human QA or release approval:
+
+- `npm run validate:all`
+- `git status --short --branch`
+
+Optional supplemental checks:
+
+- `npm run test:e2e:live` only when a live YouTube path is directly relevant. Consent, captcha, network, or YouTube experiment failures are non-blocking if fixture checks pass and the limitation is recorded.
+- Chrome-for-Testing or Brave PWA visual smoke only for release-candidate behavior, not as a replacement for repo-owned tests.
+
+## Human QA Checklist
+
+Use a freshly reloaded unpacked extension or the intended packaged build. The exact pass/fail response format is:
+
+`Human QA passed for SYT-RC-001: <notes>`
+
+or:
+
+`Human QA failed for SYT-RC-001: <steps and observed problem>`
+
+### Popup And Settings
+
+- Popup opens and shows version `0.3.0` until a release bump is explicitly approved.
+- General, Sidebar, and Modes tabs are usable.
+- Sticky Player defaults to on for a fresh/default settings load.
+- Enhanced Grid Hover remains absent for Home/Search behavior.
+- General > Feed Columns > Apply to Search persists and gates Search grid styling.
+- Modes > Default > Recommended Hover Grow appears nested under the recommendations group and works.
+- Modes > Theater > Recommended Hover Grow appears nested under the recommendations group and works.
+- Theater > Hide Live Chat and Show Chat Overlay interact cleanly.
+- Reset Tab resets only the current tab/pane expectations and preserves normal persistence behavior.
+
+### Home Feed
+
+- Native YouTube hover preview works after a fresh Home load.
+- Native YouTube hover preview works after Home -> watch video -> hover hidden header -> YouTube logo/Home or sidebar Home -> Home.
+- First-column Home cards autoplay on hover just like the other visible columns.
+- No extension grow/highlight behavior appears on Home cards.
+- Home grid has no blank sponsored-card holes.
+- Home cards do not retain stuck opaque hover backgrounds after leaving hover.
+
+### Search Results
+
+- Search results show only videos/channels when cleanup is enabled.
+- Modern Shorts shelves stay hidden.
+- Channel cards fit and keep the centered channel name styling.
+- Video cards stay compact: descriptions/extra metadata hidden, badges kept on the compact channel row.
+- Infinite-scroll Search results continue filling the grid row instead of starting after a blank gap.
+- Native YouTube hover preview works with no extension grow/highlight behavior.
+
+### Watch Pages
+
+- Clicking the main video toggles play/pause in Default, Theater, and Fullscreen modes.
+- Comments remain visible and scrollable when Hide Comments is off.
+- Theater/default scroll does not snap back to the player when reading comments.
+- Sidebar/recommended hover grow waits long enough to feel intentional and is controlled by the relevant mode setting.
+- Queue/watch-later/three-dot controls remain accessible on recommendations.
+- Sticky Player dock, restore, close, and PiP behavior still work.
+
+### Live Streams
+
+- With Show Chat Overlay on, Theater live chat overlays on the right without squeezing or cutting off the video.
+- Overlay close/minimize moves to a subtle right-edge restore affordance.
+- Reopening the overlay restores the same usable chat surface with a visible close control.
+- The chat three-dot menu remains accessible and is not covered by the extension close/minimize control.
+- With Show Chat Overlay off or Hide Live Chat on, the video is not left with a black reserved chat panel.
+- Live chat behavior does not block normal comments on non-live videos.
+
+## Verification Tier
+
+- Automated: full.
+- Browser/live: supplemental for RC only.
+- Human: required before any release/version/tag/Web Store step.
+
+## Next Recommended Controller Action
+
+After this checklist PR is integrated:
+
+1. Run `npm run validate:all` on clean `main` if it was not already run during the checklist PR.
+2. Ask the user for `SYT-RC-001` human QA using the checklist above.
+3. If the user passes RC QA, comment on and close #10 with the hardening summary, then wait for explicit release approval.
+4. If the user fails RC QA, route only the concrete failing behavior as a new narrow issue or task lane.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C/D/E/F are integrated through PR #54.
-- Implementation dispatch: no active hardening runner; next controller step is `SYT-RC-001` checklist / #10 completion decision.
+- Implementation dispatch: no active hardening runner; current controller step is `SYT-RC-001` checklist / #10 completion decision.
 
 ## Active Tasks
 
@@ -20,6 +20,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-A` | Settings, popup defaults, and persistence | Integrator | Integrated | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 merged |
 | `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
 | `SYT-010H-C` | Swarm docs and context compaction | Integrator | Integrated | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 merged |
+| `SYT-RC-001` | Next release-candidate checklist | Controller | Ready for Human QA after checklist integration | `swarm/syt-rc-001-checklist` | RC checklist and #10 completion criteria; no release action | serial-required | `SYT-010H-F` integrated | low docs, high if release attempted | `docs/swarm/handoffs/SYT-RC-001.md` | #55 |
 | `SYT-008A` | Enhanced Home/Search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | user/product gate | high | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Hold / Future Tasks
@@ -29,7 +30,6 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-D` | Runtime apply-loop and polling hardening | Integrated | PR #48; event/apply-loop video binding hardening. |
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Integrated | PR #50; modern Search lockup fixture coverage. |
 | `SYT-010H-F` | Grid-hover watch recommendation selector organization cleanup | Integrated | PR #54; one-module selector organization and unit coverage. |
-| `SYT-RC-001` | Next release-candidate checklist | Backlog | After #10 hardening. Human QA required before release. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
 
 ## Completed / Archived
@@ -70,11 +70,11 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | Task ID | PR / URL | Status | Required Before Merge | Exact Pass/Fail Message |
 | --- | --- | --- | --- | --- |
 | `SYT-008A` | none | Not started | Yes before implementing visual hover behavior | `Human QA passed/failed for SYT-008A: <notes>` |
-| `SYT-RC-001` | none | Not started | Yes before release | `Human QA passed/failed for SYT-RC-001: <notes>` |
+| `SYT-RC-001` | #55 | Checklist preparing | Yes before release | `Human QA passed/failed for SYT-RC-001: <notes>` |
 
 ## Controller Notes
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: post-`SYT-010H-F` clean state; prepare `SYT-RC-001` checklist or decide whether #10 can close.
+- Current controller phase: `SYT-RC-001` checklist; no source hardening lanes should launch unless RC QA finds a concrete failure.
 - Do not route #8 unless the user explicitly reopens that gate.


### PR DESCRIPTION
## Summary

- Add the `SYT-RC-001` release-candidate checklist and #10 completion decision handoff.
- Update hot swarm docs so the next controller pass lands on RC human QA instead of spawning more broad #10 hardening lanes.
- Keep #10 open, #8 paused, and release/version/Web Store actions blocked until explicit approval.

## How to test / what to tell the controller

Human review requested: no for this docs-only PR. Human QA is required after this checklist lands.

Commands:
- `git diff --cached --check` passed before commit.
- `git diff --check` should pass for review/integration.

Expected result:
- Diff is docs-only under `docs/swarm/**`.
- `docs/swarm/handoffs/SYT-RC-001.md` contains the RC manual QA checklist.
- Hot docs point to `SYT-RC-001` and do not authorize release, version bump, #10 closure, or #8 restart.

Controller feedback format:
- `Ready to Integrate` if the docs point to the correct RC gate.
- `Needs Fixes: <specific doc/state issue>` if any state is stale or unsafe.

Refs #10.