### PR TITLE
Codex: Record SYT-RC-001 QA pass

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -62,7 +62,7 @@ Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, t
 | `SYT-010H-D` / #48 | runtime video binding hardening integrated |
 | `SYT-010H-E` / #50 | Search modern lockup selector fixture hardening integrated |
 | `SYT-010H-F` / #54 | grid-hover watch recommendation selector organization integrated |
-| `SYT-RC-001` / #55 | release-candidate checklist integrated; human QA gate is next |
+| `SYT-RC-001` / #55/#56 | release-candidate checklist integrated; human QA passed; #10 closed |
 
 ## Pending Launch
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,7 +4,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active lane family: `SYT-RC-001`, release-candidate checklist and #10 completion decision.
+- Active lane family: none; `SYT-RC-001` passed and #10 is closed.
 - Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, runtime video binding PR #48, Search lockup fixture PR #50, grid-hover organization PR #54, and RC checklist PR #55 are merged.
 - Completed first burst:
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
@@ -13,8 +13,8 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
   - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
   - `SYT-010H-F`: grid-hover watch recommendation selector organization, PR #54.
-- Active serial lane: none after PR #55 integration; next state is human RC QA.
-- GitHub issues: #10 open; #36/#38/#31 closed; #8 paused.
+- Active serial lane: none after `SYT-RC-001` human QA pass.
+- GitHub issues: #10/#36/#38/#31 closed; #8 paused.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures, #54 grid-hover organization, #55 RC checklist.
 - Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
 
@@ -52,4 +52,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Request `SYT-RC-001` human RC QA using `docs/swarm/handoffs/SYT-RC-001.md`. `npm run validate:all` passed on clean `main` after PR #55. Do not release, bump version, tag, close #10, or launch #8 hover research without explicit user approval or the checklist's stated gate.
+Wait for explicit release/version/tag/Web Store instruction or a new scoped issue. `SYT-RC-001` human QA passed and #10 is closed. Do not release, bump version, tag, or launch #8 hover research without explicit user approval.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,17 +8,17 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-06-11 00:45 EDT
+- Last reviewed by controller: 2026-06-11 01:36 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `main`
 - Expected Git state: clean `main` synced with `origin/main`
-- Open PR expectation: PR #20 remains paused draft for #8 research; no active #10 PR after #55 merge
+- Open PR expectation: PR #20 remains paused draft for #8 research; no active #10 PR after #10 closure
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-RC-001`, human release-candidate QA gate / #10 completion decision
+- Current priority lane: idle after `SYT-RC-001` human QA pass and #10 closure
 
 ## Controller Lease And Pacing
 
@@ -30,8 +30,8 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Controller pass budget: max 10 safe orchestration actions or 90 minutes during the `SYT-010H` final-leg push
 - Heartbeat pass budget: max 4 safe recovery/routing actions, then stop
 - Active capacity: max 3 active subagents total only for `SYT-010H` lanes that the planner marks disjoint and low/medium conflict; keep max 1 for runtime implementation touching the same content modules, review, integration, merge conflicts, live YouTube behavior, or release-candidate work
-- Heartbeat cadence target: 30 minutes while `SYT-010H` is actively being planned/routed; slow back toward 90 minutes or pause after the hardening lane is integrated or blocked on human QA
-- Next human QA gate: release-candidate lane or #8 visual/product-direction gate later
+- Heartbeat cadence target: paused while idle after `SYT-RC-001`; resume only when new scoped work or release work is requested
+- Next human QA gate: release candidate/release approval or #8 visual/product-direction gate later
 
 ## Context Hygiene
 
@@ -106,7 +106,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-RC-001` | Request or await human RC QA using the integrated checklist. Do not bump version, tag, release, close #10, or update Web Store assets. | Controller / Planner | `main` | Human QA pass/fail received |
+| 1 | `IDLE` | Wait for explicit release/version/tag/Web Store instruction or a new scoped issue. Do not bump version, tag, release, or update Web Store assets on heartbeat alone. | Controller | `main` | User request received |
 | 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
 
 ## Dynamic Notes
@@ -145,3 +145,4 @@ Heartbeat overlap rule:
 - 2026-06-11: `SYT-010H-F` integrated through PR #54 after focused checks and `npm run validate:all`. Next safe action is `SYT-RC-001` checklist / #10 completion decision; no release action is approved yet.
 - 2026-06-11: Controller prepared `SYT-RC-001` checklist branch. #10 remains open until checklist integration and RC pass/fail decision.
 - 2026-06-11: PR #55 merged the `SYT-RC-001` checklist at `82188cf`. `npm run validate:all` passed on clean `main`. Next safe action is human RC QA; do not close #10 or release until the checklist gate is passed.
+- 2026-06-11: User reported `Human QA passed for SYT-RC-001`; issue #10 was closed with a hardening summary. No release/version/tag/Web Store action was performed.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,7 +4,7 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening; `SYT-010H` implementation lanes are integrated and the repo is moving into `SYT-RC-001` release-candidate validation.
+- Status: existing repo, post-v0.3.0 hardening; `SYT-010H` implementation lanes are integrated, `SYT-RC-001` human QA passed, and #10 is closed.
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
 
 ## Current Focus
@@ -16,7 +16,7 @@
    - D: runtime video binding hardening, PR #48.
    - E: modern Search lockup selector fixture hardening, PR #50.
 2. `SYT-010H-F` integrated one-module `grid-hover.ts` watch-recommendation selector organization cleanup.
-3. Current controller step is `SYT-RC-001`: request/await human RC QA using the integrated checklist.
+3. `SYT-RC-001` human QA passed on 2026-06-11.
 4. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
 5. Keep version/tag/Web Store release actions out unless explicitly approved.
 
@@ -35,7 +35,7 @@
 - PR #54 organized grid-hover watch recommendation selector construction and added unit assertions.
 - PR #55 integrated the `SYT-RC-001` checklist and #10 completion criteria.
 - `npm run validate:all` passed on clean `main` after PR #55.
-- Issue #10 remains open for final-leg hardening; #8 remains a future gated research lane.
+- Issue #10 is closed after `SYT-RC-001` human QA passed; #8 remains a future gated research lane.
 
 ## Constraints And Risks
 
@@ -43,19 +43,18 @@
 - Settings are duplicated between `src/shared/settings.ts` and `src/content/settings.ts`; parity tests are the guardrail.
 - Live YouTube smoke can be noisy; fixture-first checks remain the normal gate.
 - Do not reintroduce Home/Search enhanced hover grow, synthetic hover, or forced preview playback.
-- Do not bump version, tag releases, edit Web Store assets, or close #10 from docs/test lanes.
-- #10 should remain open until the next controller/user RC pass confirms no new hardening defects.
+- Do not bump version, tag releases, edit Web Store assets, or restart #8 without explicit user approval.
 
 ## Verification Defaults
 
 - Runner focused checks: task-specific `npm run test:e2e`, `npm run test:unit`, `npm run lint`, `npm run typecheck`, or `git diff --check` as assigned.
 - Reviewer targeted checks: changed-risk checks plus PR body/handoff validation.
 - Integrator full gate for source/test PRs: `npm run validate:all`.
-- Human QA: required for `SYT-RC-001`, #8 visual hover implementation, or explicit high-risk live browser behavior.
+- Human QA: `SYT-RC-001` passed; future human QA is required for #8 visual hover implementation, release candidates, or explicit high-risk live browser behavior.
 
 ## Automation Notes
 
-- Controller heartbeat: active, id `simple-yt-tweaks-controller-heartbeat`.
+- Controller heartbeat: paused after `SYT-RC-001` became human-gated, id `simple-yt-tweaks-controller-heartbeat`.
 - Capacity: up to 3 only for planner-approved disjoint `SYT-010H` A/B/C work; review, integration, and runtime implementation stay serial.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry unless a handoff explicitly assigns them.
 - Registry: `docs/swarm/agent-registry.md`.
@@ -63,4 +62,4 @@
 ## Last Updated
 
 - Date: 2026-06-11
-- By: Controller heartbeat after `SYT-RC-001` checklist integration
+- By: Controller after `SYT-RC-001` human QA pass and #10 closure

--- a/docs/swarm/handoffs/SYT-RC-001.md
+++ b/docs/swarm/handoffs/SYT-RC-001.md
@@ -3,12 +3,12 @@
 ## Status
 
 - Task ID: `SYT-RC-001`
-- GitHub issue: #10 remains open
+- GitHub issue: #10 closed after RC QA pass
 - Branch: `main` after PR #55 integration
 - PR: #55 merged at `82188cf`
-- State: Ready for Human QA
+- State: Integrated / Human QA passed
 - Role: Controller / release-candidate planner
-- Last updated: 2026-06-11 00:45 EDT
+- Last updated: 2026-06-11 01:36 EDT
 
 ## Goal
 
@@ -27,7 +27,7 @@ Move the repo from post-v0.3.0 hardening into a release-candidate validation gat
 - No test fixture edits unless a later RC failure requires them.
 - No enhanced Home/Search hover grow, forced preview playback, or synthetic hover behavior.
 - No version bump, tag, GitHub release, package upload, or Web Store asset update.
-- Do not close #10 from this docs-only checklist PR.
+- The docs-only checklist PR did not close #10; #10 was closed only after human QA passed.
 
 ## #10 Completion Decision
 
@@ -40,7 +40,9 @@ Move the repo from post-v0.3.0 hardening into a release-candidate validation gat
 - E: modern Search lockup fixture coverage.
 - F: grid-hover watch recommendation selector organization.
 
-Decision: stop opening additional speculative #10 hardening lanes. Keep #10 open until the checklist PR is integrated and the next controller/user RC pass confirms no new hardening defects. If RC QA passes, #10 can be closed with a summary linking the merged hardening PRs and the RC checklist. If RC QA fails, file or route a new narrow issue for the concrete failure instead of reopening broad hardening.
+Decision: stop opening additional speculative #10 hardening lanes. The checklist PR was integrated, RC QA passed, and #10 was closed with a summary linking the merged hardening PRs and the RC checklist. If a later regression appears, file or route a new narrow issue for the concrete failure instead of reopening broad hardening.
+
+Final result: user reported `Human QA passed for SYT-RC-001` on 2026-06-11. Issue #10 was closed with the hardening summary. No release, version bump, tag, package upload, Web Store asset update, or #8 restart was performed.
 
 ## Automated Gate
 
@@ -68,6 +70,10 @@ Use a freshly reloaded unpacked extension or the intended packaged build. The ex
 or:
 
 `Human QA failed for SYT-RC-001: <steps and observed problem>`
+
+Current result:
+
+- 2026-06-11: Human QA passed. User note: "looks solid mate... all is working and is well it appears."
 
 ### Popup And Settings
 
@@ -125,9 +131,4 @@ or:
 
 ## Next Recommended Controller Action
 
-After this checklist PR is integrated:
-
-1. Run `npm run validate:all` on clean `main` if it was not already run during the checklist PR.
-2. Ask the user for `SYT-RC-001` human QA using the checklist above.
-3. If the user passes RC QA, comment on and close #10 with the hardening summary, then wait for explicit release approval.
-4. If the user fails RC QA, route only the concrete failing behavior as a new narrow issue or task lane.
+Wait for an explicit release/version/tag/Web Store instruction or a new scoped issue. Do not restart #8 unless the user asks for hover research.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -11,7 +11,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 - Project brief: Ready
 - Material questions: Deferred, not blocking
 - Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C/D/E/F are integrated through PR #54.
-- Implementation dispatch: no active hardening runner; current controller step is `SYT-RC-001` human QA.
+- Implementation dispatch: no active hardening runner; `SYT-RC-001` human QA passed and #10 is closed.
 
 ## Active Tasks
 
@@ -20,7 +20,6 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-A` | Settings, popup defaults, and persistence | Integrator | Integrated | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 merged |
 | `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
 | `SYT-010H-C` | Swarm docs and context compaction | Integrator | Integrated | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 merged |
-| `SYT-RC-001` | Next release-candidate checklist | Controller | Ready for Human QA | `main` | RC checklist and #10 completion criteria; no release action | serial-required | PR #55 integrated; `validate:all` passed | low docs, high if release attempted | `docs/swarm/handoffs/SYT-RC-001.md` | #55 merged |
 | `SYT-008A` | Enhanced Home/Search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | user/product gate | high | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Hold / Future Tasks
@@ -56,6 +55,7 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | `SYT-010H-D` | PR #48 merged; runtime video binding hardening |
 | `SYT-010H-E` | PR #50 merged; Search modern lockup selector fixture hardening |
 | `SYT-010H-F` | PR #54 merged; grid-hover watch recommendation selector organization |
+| `SYT-RC-001` | PR #55/#56 merged; `validate:all` passed; human QA passed; issue #10 closed |
 
 ## Review / Integration Queues
 
@@ -70,11 +70,11 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | Task ID | PR / URL | Status | Required Before Merge | Exact Pass/Fail Message |
 | --- | --- | --- | --- | --- |
 | `SYT-008A` | none | Not started | Yes before implementing visual hover behavior | `Human QA passed/failed for SYT-008A: <notes>` |
-| `SYT-RC-001` | #55 | Ready for Human QA | Yes before release | `Human QA passed/failed for SYT-RC-001: <notes>` |
+| `SYT-RC-001` | #55/#56 | Passed | Complete | `Human QA passed for SYT-RC-001: looks solid mate... all is working and is well it appears.` |
 
 ## Controller Notes
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: `SYT-RC-001` human QA gate; no source hardening lanes should launch unless RC QA finds a concrete failure.
+- Current controller phase: idle after `SYT-RC-001`; no source hardening lanes should launch unless the user reports a concrete failure or opens a new scoped request.
 - Do not route #8 unless the user explicitly reopens that gate.


### PR DESCRIPTION
## Summary

- Record the user-passed `SYT-RC-001` human QA gate.
- Record that issue #10 is now closed after the hardening summary comment.
- Leave release/version/tag/Web Store work blocked until an explicit release instruction.

## How to test / what to tell the controller

Human review requested: no for this docs-only state repair.

Commands run:
- `git diff --check` passed.

Expected result:
- Diff is docs-only under `docs/swarm/**`.
- Hot docs say `SYT-RC-001` passed and #10 is closed.
- Hot docs do not authorize release, version bump, tag, Web Store work, or #8 restart.

Controller feedback format:
- `Ready to Integrate` if the docs accurately reflect the QA pass and #10 closure.
- `Needs Fixes: <specific stale state>` if any current state is inaccurate.

Refs #10.