### PR TITLE
Codex: Close SYT-008A state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Notes
 
-- Enhanced home/search grid hover preview is deferred to GitHub issue #8.
+- Enhanced home/search grid hover preview was closed as not planned for this release path; Home/Search hover stays native to YouTube.
 
 ## 0.2.1
 

--- a/SWARM.md
+++ b/SWARM.md
@@ -52,7 +52,7 @@ The current goal is post-v0.3.0 hardening: make automated verification strong en
 - Default active capacity is 1 total active subagent.
 - Keep shared coordination files controller-owned during parallel work unless a handoff explicitly assigns them: `docs/swarm/task-board.md`, `docs/swarm/current-state.md`, `docs/swarm/controller-directives.md`, and `docs/swarm/agent-registry.md`.
 - Workers normally update only their handoff, scoped source/test files, and PR body.
-- Do not reintroduce enhanced home/search hover implementation under #10; #8 is the separate future enhancement lane.
+- Do not reintroduce enhanced home/search hover implementation under #10; #8 was closed as not planned after native YouTube Home/Search hover passed RC QA.
 - Do not bump version, tag, release, or update Web Store assets unless a release-candidate lane explicitly asks for it.
 
 ## Repo Swarm Files

--- a/docs/swarm/archive/README.md
+++ b/docs/swarm/archive/README.md
@@ -40,5 +40,5 @@ GitHub PR bodies, reviews, and issue comments remain the preferred public histor
 | --- | --- | --- |
 | `SYT-010H-D` | Ready serial runtime apply-loop/polling lane | `docs/swarm/handoffs/SYT-010H.md`, `docs/swarm/handoffs/SYT-010H-B.md` |
 | `SYT-010H-E/F` | Hold until D or selector-fixture decision | `docs/swarm/handoffs/SYT-010H.md` |
-| `SYT-008A` | Paused future research | `docs/swarm/handoffs/SYT-008A.md` |
+| `SYT-008A` | Closed as not planned; native Home/Search hover accepted | `docs/swarm/handoffs/SYT-008A.md` |
 | `SYT-RC-001` | Backlog release candidate checklist | `docs/swarm/task-board.md` |

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -14,9 +14,9 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
   - `SYT-010H-F`: grid-hover watch recommendation selector organization, PR #54.
 - Active serial lane: none after `SYT-RC-001` human QA pass.
-- GitHub issues: #10/#36/#38/#31 closed; #8 paused.
+- GitHub issues: #8/#10/#36/#38/#31 closed.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures, #54 grid-hover organization, #55 RC checklist.
-- Do not route next: #8 enhanced Home/Search hover grow research unless the user explicitly reopens that gate.
+- Do not route enhanced Home/Search hover grow research unless the user opens a fresh issue; #8 is closed as not planned.
 
 ## Hot Files
 
@@ -52,4 +52,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Wait for explicit release/version/tag/Web Store instruction or a new scoped issue. `SYT-RC-001` human QA passed and #10 is closed. Do not release, bump version, tag, or launch #8 hover research without explicit user approval.
+Wait for explicit release/version/tag/Web Store instruction or a new scoped issue. `SYT-RC-001` human QA passed; #8 and #10 are closed. Do not release, bump version, tag, or restart hover research without explicit user approval.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -15,7 +15,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Default branch: `main`
 - Current branch: `main`
 - Expected Git state: clean `main` synced with `origin/main`
-- Open PR expectation: PR #20 remains paused draft for #8 research; no active #10 PR after #10 closure
+- Open PR expectation: none after #8/#10 closure
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: idle after `SYT-RC-001` human QA pass and #10 closure
@@ -31,7 +31,7 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat pass budget: max 4 safe recovery/routing actions, then stop
 - Active capacity: max 3 active subagents total only for `SYT-010H` lanes that the planner marks disjoint and low/medium conflict; keep max 1 for runtime implementation touching the same content modules, review, integration, merge conflicts, live YouTube behavior, or release-candidate work
 - Heartbeat cadence target: paused while idle after `SYT-RC-001`; resume only when new scoped work or release work is requested
-- Next human QA gate: release candidate/release approval or #8 visual/product-direction gate later
+- Next human QA gate: release candidate/release approval or a fresh high-risk visual/product-direction gate later
 
 ## Context Hygiene
 
@@ -107,14 +107,14 @@ Heartbeat overlap rule:
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
 | 1 | `IDLE` | Wait for explicit release/version/tag/Web Store instruction or a new scoped issue. Do not bump version, tag, release, or update Web Store assets on heartbeat alone. | Controller | `main` | User request received |
-| 2 | `SYT-008A` | Keep research gate paused until the user wants enhanced hover research again | Planner | `swarm/syt-008a-hover-research` | Decision to defer, prototype, or require human QA |
+| 2 | none | none | none | none | none |
 
 ## Dynamic Notes
 
 - `npm run validate:all` passed on 2026-04-29 during bootstrap.
 - Chrome-for-Testing-backed `agent-browser` wrapper opened and closed `about:blank` successfully.
 - The live YouTube test exists but should not be the normal gate.
-- Issue #8 is intentionally paused until #10 coverage and hardening reduce regression risk.
+- Issue #8 was closed as not planned after native Home/Search hover passed RC QA.
 - PR #11 merged; PR #12 squash-merged into `main` at `59ec975`.
 - `SYT-010A` remote and local task branches were cleaned after merge.
 - PR #14 squash-merged into `main` at `5675059`; remote and local task branch cleanup completed.
@@ -141,8 +141,9 @@ Heartbeat overlap rule:
 - 2026-06-11: User confirmed the desired #36/#38 behavior appears to be working and asked to proceed into final-leg polish/hardening. PR #37 still requires fresh review before integration; `SYT-010H` should follow only after PR #37 lands.
 - 2026-06-11: PR #37 was marked ready and squash-merged at `342854f` after `npm run validate:all` passed. Issues #36 and #38 are closed; route `SYT-010H` next.
 - 2026-06-11: User approved a supervised final-leg push with up to 3 subagents if useful. Apply that only to planner-approved disjoint `SYT-010H` lanes; do not parallelize overlapping runtime implementation.
-- 2026-06-11: `SYT-010H` A/B/C/D/E are integrated through PR #50. `npm run validate:all` passed before #48 and #50 merges. Next safe source lane is serial `SYT-010H-F`; keep #8 paused.
+- 2026-06-11: `SYT-010H` A/B/C/D/E are integrated through PR #50. `npm run validate:all` passed before #48 and #50 merges. Next safe source lane is serial `SYT-010H-F`; #8 stayed paused at that point and was later closed as not planned.
 - 2026-06-11: `SYT-010H-F` integrated through PR #54 after focused checks and `npm run validate:all`. Next safe action is `SYT-RC-001` checklist / #10 completion decision; no release action is approved yet.
 - 2026-06-11: Controller prepared `SYT-RC-001` checklist branch. #10 remains open until checklist integration and RC pass/fail decision.
 - 2026-06-11: PR #55 merged the `SYT-RC-001` checklist at `82188cf`. `npm run validate:all` passed on clean `main`. Next safe action is human RC QA; do not close #10 or release until the checklist gate is passed.
 - 2026-06-11: User reported `Human QA passed for SYT-RC-001`; issue #10 was closed with a hardening summary. No release/version/tag/Web Store action was performed.
+- 2026-06-11: User indicated issue #8 was effectively handled. PR #20 was closed, issue #8 was closed as not planned, and native YouTube Home/Search hover remains the accepted direction.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -17,7 +17,7 @@
    - E: modern Search lockup selector fixture hardening, PR #50.
 2. `SYT-010H-F` integrated one-module `grid-hover.ts` watch-recommendation selector organization cleanup.
 3. `SYT-RC-001` human QA passed on 2026-06-11.
-4. Keep #8 enhanced Home/Search hover grow research paused unless the user explicitly reopens it.
+4. #8 enhanced Home/Search hover grow research is closed as not planned; native YouTube Home/Search hover is the accepted behavior.
 5. Keep version/tag/Web Store release actions out unless explicitly approved.
 
 ## Recent State
@@ -35,7 +35,7 @@
 - PR #54 organized grid-hover watch recommendation selector construction and added unit assertions.
 - PR #55 integrated the `SYT-RC-001` checklist and #10 completion criteria.
 - `npm run validate:all` passed on clean `main` after PR #55.
-- Issue #10 is closed after `SYT-RC-001` human QA passed; #8 remains a future gated research lane.
+- Issues #8 and #10 are closed after `SYT-RC-001` human QA passed and the Home/Search hover direction was accepted as native-only.
 
 ## Constraints And Risks
 
@@ -43,14 +43,14 @@
 - Settings are duplicated between `src/shared/settings.ts` and `src/content/settings.ts`; parity tests are the guardrail.
 - Live YouTube smoke can be noisy; fixture-first checks remain the normal gate.
 - Do not reintroduce Home/Search enhanced hover grow, synthetic hover, or forced preview playback.
-- Do not bump version, tag releases, edit Web Store assets, or restart #8 without explicit user approval.
+- Do not bump version, tag releases, edit Web Store assets, or restart Home/Search hover research without explicit user approval and a fresh issue.
 
 ## Verification Defaults
 
 - Runner focused checks: task-specific `npm run test:e2e`, `npm run test:unit`, `npm run lint`, `npm run typecheck`, or `git diff --check` as assigned.
 - Reviewer targeted checks: changed-risk checks plus PR body/handoff validation.
 - Integrator full gate for source/test PRs: `npm run validate:all`.
-- Human QA: `SYT-RC-001` passed; future human QA is required for #8 visual hover implementation, release candidates, or explicit high-risk live browser behavior.
+- Human QA: `SYT-RC-001` passed; future human QA is required for release candidates, explicit high-risk live browser behavior, or any fresh visual hover implementation issue.
 
 ## Automation Notes
 

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -35,7 +35,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 ## Human Acceptance Gate
 
-- Required for: release candidate, high-risk live YouTube behavior, #8 visual hover preview implementation, or explicit reviewer request.
+- Required for: release candidate, high-risk live YouTube behavior, fresh visual hover preview implementation, or explicit reviewer request.
 - Required before merge: no for routine docs/test/hardening PRs; yes for release candidates and high-risk browser behavior.
 - Who can mark passed: user for human QA; reviewer/integrator for routine agent checks.
 - Pass message format: `Human QA passed for <TASK-ID or PR URL>: <notes>`
@@ -73,3 +73,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-06-10: Opened issue #38 for live streams being squeezed in enhanced Theater mode when live chat overlay is enabled. Patched PR #37 to cover #38 after the user confirmed #36 Home autoplay worked; follow-up patch made the overlay `X` minimize to a right-edge restore tab instead of leaving YouTube's collapsed opaque chat overlay.
 - 2026-06-11: User confirmed desired #36/#38 behavior is working and asked to proceed to polish/hardening. Keep PR #37 in review path, then integrate if clean before launching `SYT-010H` under #10.
 - 2026-06-11: PR #37 marked ready and squash-merged at `342854f` after `npm run validate:all` passed. Issues #36 and #38 closed. Next GitHub work should be a `SYT-010H` polish/hardening branch under #10.
+- 2026-06-11: PR #20 was closed and branch `swarm/syt-008a-hover-research` deleted. Issue #8 was closed as not planned because native YouTube Home/Search hover is the accepted direction.

--- a/docs/swarm/handoffs/SYT-008A.md
+++ b/docs/swarm/handoffs/SYT-008A.md
@@ -2,34 +2,33 @@
 
 ## State
 
-- Status: Paused
+- Status: Closed as not planned
 - Role: Planner
 - Repo: Simple YT Tweaks
-- Branch: `swarm/syt-008a-hover-research`
+- Branch: `swarm/syt-008a-hover-research` closed/deleted after PR #20 closure
 - Owner: Unassigned
 - Created: 2026-04-29
-- Updated: 2026-04-29
+- Updated: 2026-06-11
 
 ## Goal
 
-Research whether #8 can be safely revived in a future release without breaking native YouTube hover autoplay, preview overlays, or edge-card behavior.
+Record that #8 was closed as not planned after the native-only Home/Search hover direction passed RC QA. If enhanced hover is wanted later, open a fresh issue and prototype gate.
 
 ## Scope
 
-- Read GitHub #8 and prior handoff notes.
-- Identify what fixture tests can prove and what requires live/manual validation.
-- Propose a prototype plan only after #10 test hardening is in place.
+- GitHub #8 closed as not planned.
+- PR #20 closed without merge.
+- Native YouTube Home/Search hover remains accepted behavior.
 
 ## Non-Scope
 
-- Do not implement enhanced home/search hover in the current hardening milestone.
+- Do not implement enhanced home/search hover from this closed lane.
 - Do not change current native home/search hover behavior.
 - Do not use live YouTube as the only validation path.
 
 ## Dependencies
 
-- `SYT-010A` coverage audit complete.
-- User/product-direction gate before implementation.
+- Fresh user/product-direction issue before any future implementation.
 
 ## Lane Metadata
 
@@ -43,31 +42,21 @@ Research whether #8 can be safely revived in a future release without breaking n
 
 | Check | Result | Notes |
 | --- | --- | --- |
-| `npm run test:e2e` | Not run for this lane yet | Required for any prototype. |
-| `npm run test:e2e:live` | Not run for this lane yet | Optional research smoke, not stable gate. |
-| Human QA | Not run for this lane yet | Required before merging any visual behavior change. |
+| PR #20 | Closed | Research gate closed without merge. |
+| GitHub #8 | Closed as not planned | Native-only Home/Search hover is the accepted direction. |
+| Human QA | Passed via `SYT-RC-001` | Current native-only behavior accepted. |
 
 ## Human Acceptance Checklist
 
-- Required before merge: Yes for any implementation.
-- URL(s): PR TBD
+- Required before merge: Yes for any fresh future implementation issue.
+- URL(s): none
 - Who should test: User for final visual/live YouTube behavior.
-- Expected result: no flicker, no autoplay breakage, no edge clipping, independently disableable.
-- If it passes, tell the controller: `Human QA passed for SYT-008A: <notes>`
-- If it fails, tell the controller: `Human QA failed for SYT-008A: <steps and observed problem>`
+- Expected result for current release path: native Home/Search hover only; no extension grow/highlight/synthetic preview behavior.
+- Fresh future issue required for any changed visual behavior.
 
 ## Next Handoff
 
-- Next role: Planner after #10 test hardening.
-- Next action: Research only; do not implement until controller explicitly unpauses #8.
-- Branch/worktree cleanup needed after merge: yes.
-- Copy-ready prompt:
-
-```text
-Plan Simple YT Tweaks SYT-008A only after SYT-010A is integrated.
-
-Repo: /Users/d4ngl/Git Repos/Codex/simple-yt-tweaks
-Branch: swarm/syt-008a-hover-research
-
-Read GitHub #8, the swarm docs, and docs/swarm/handoffs/SYT-008A.md. Produce a research plan for enhanced home/search hover that preserves native YouTube autoplay and defines fixture/live/manual gates. Do not implement runtime hover behavior unless the controller explicitly unpauses implementation.
-```
+- Next role: none.
+- Next action: none unless the user opens a fresh hover enhancement issue.
+- Branch/worktree cleanup needed after merge: complete; PR #20 branch deleted.
+- Copy-ready prompt: none; branch is deleted and issue is closed.

--- a/docs/swarm/project-brief.md
+++ b/docs/swarm/project-brief.md
@@ -4,7 +4,7 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, active post-v0.3.0 hardening
+- Status: existing repo, post-v0.3.0 hardening complete; release work requires explicit approval
 - Owner / GitHub Org: `cryptoteatime`
 - Primary Controller Chat: Simple YT Tweaks Codex controller
 
@@ -20,7 +20,7 @@ Make Simple YT Tweaks a small, dependable Chrome/Brave extension with enough aut
 ## First Useful Milestone
 
 - Goal: post-v0.3.0 hardening and autonomous controller setup.
-- Success looks like: fixture tests cover current regression-prone behavior, #8/#10 are decomposed into scoped lanes, PRs include controller test instructions, and `npm run validate:all` is the normal gate.
+- Success looks like: fixture tests cover current regression-prone behavior, #8/#10 are closed, PRs include controller test instructions, and `npm run validate:all` is the normal gate.
 - Human QA required before merge: no for routine docs/test/hardening PRs; yes for release-candidate behavior and high-risk live YouTube behavior.
 
 ## Non-Goals And Constraints
@@ -51,7 +51,7 @@ Make Simple YT Tweaks a small, dependable Chrome/Brave extension with enough aut
 - Git status at discovery: clean `main...origin/main`.
 - Remote: `https://github.com/cryptoteatime/simple-yt-tweaks.git`.
 - GitHub repository: `cryptoteatime/simple-yt-tweaks`, public, default branch `main`.
-- Open issues at discovery:
+- Issues at discovery, now closed:
   - #8 `Revisit enhanced home/search grid hover preview`
   - #10 `Post-harness code hardening pass`
 - Browser tooling:
@@ -81,10 +81,10 @@ No blocking material questions for the current setup. Defaults are safe:
 | Milestone | Goal | Human QA Gate | Notes |
 | --- | --- | --- | --- |
 | M0 | Land repo-local swarm packet | No | Docs-only PR, validates with `git diff --check`. |
-| M1 | Test harness coverage audit | No | Ensure fixtures catch #10 hardening risks and guard #8 prerequisites. |
-| M2 | Code hardening slices under #10 | No by default | Start with settings parity/source-of-truth and pure helper tests. |
-| M3 | Release-candidate workflow smoothing | Yes at final RC | Make validation/package/release checklist controller-friendly. |
-| M4 | Future #8 hover research | Yes before implementation merge | Treat as research/prototype because live YouTube preview behavior is high risk. |
+| M1 | Test harness coverage audit | No | Integrated; fixture coverage guards current native hover behavior and hardening risks. |
+| M2 | Code hardening slices under #10 | No by default | Integrated; #10 closed after `SYT-RC-001` passed. |
+| M3 | Release-candidate workflow smoothing | Yes at final RC | Checklist integrated and human QA passed; release still requires explicit approval. |
+| M4 | Future hover research | Yes before implementation merge | Closed as not planned under #8; open a fresh issue for any future prototype. |
 
 ## Candidate Parallel Lanes
 
@@ -94,7 +94,7 @@ No blocking material questions for the current setup. Defaults are safe:
 | `SYT-010A` | Planner/Runner | `tests/e2e/**`, `DEVELOPMENT.md`, handoff | Yes with docs-only lanes if capacity raised | No | `SYT-CTL-001` merged | Medium: fixture contracts | none by default |
 | `SYT-010B` | Senior Runner | `src/shared/settings.ts`, `src/content/settings.ts`, `scripts/validate-extension.mjs`, tests | No while settings contracts change | Yes | `SYT-010A` coverage decision | High: shared settings contracts | none |
 | `SYT-010C` | Planner/Runner | `DEVELOPMENT.md`, `docs/swarm/**`, package scripts if needed | Yes with source-free docs if capacity raised | No | `SYT-CTL-001`; ideally after `SYT-010A` | Low/Medium | none by default |
-| `SYT-008A` | Planner | issue #8 research notes, fixtures/prototype branch only | No with #10 source work | Yes until research gate passes | `SYT-010A`; user/product gate before implementation | High: live YouTube preview lifecycle | none |
+| `SYT-008A` | Planner | closed issue #8 notes only | No | Yes if a fresh hover prototype is opened later | fresh user/product gate | High: live YouTube preview lifecycle | none |
 
 ## Verification Strategy
 
@@ -104,11 +104,11 @@ No blocking material questions for the current setup. Defaults are safe:
 - Full gate: `npm run validate:all`.
 - Optional live smoke: `npm run test:e2e:live` for RC or live-site risk only.
 - Browser QA: Playwright fixtures first; Browser Use or `agent-browser` only for supplemental visual/live inspection.
-- Human milestone QA: release candidates and #8 visual behavior.
+- Human milestone QA: release candidates and any fresh visual hover behavior issue.
 - Runner verification tier: focused task checks.
 - Reviewer verification tier: targeted checks based on changed risk.
 - Integrator verification tier: full `npm run validate:all` before merge for non-docs/checkpoint work.
 
 ## Next Controller Decision
 
-`SYT-010C` is integrated. The next safe controller action is to route or defer `SYT-010D` pure helper tests when capacity is available.
+Post-v0.3.0 hardening is complete, #8/#10 are closed, and `SYT-RC-001` passed. The next safe controller action is to wait for explicit release/version/tag/Web Store instructions or a new scoped issue.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -20,7 +20,6 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-A` | Settings, popup defaults, and persistence | Integrator | Integrated | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 merged |
 | `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
 | `SYT-010H-C` | Swarm docs and context compaction | Integrator | Integrated | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 merged |
-| `SYT-008A` | Enhanced Home/Search hover research gate | Planner | Paused | `swarm/syt-008a-hover-research` | #8 research, fixtures/prototype only | serial-required | user/product gate | high | `docs/swarm/handoffs/SYT-008A.md` | none |
 
 ## Hold / Future Tasks
 
@@ -56,6 +55,7 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | `SYT-010H-E` | PR #50 merged; Search modern lockup selector fixture hardening |
 | `SYT-010H-F` | PR #54 merged; grid-hover watch recommendation selector organization |
 | `SYT-RC-001` | PR #55/#56 merged; `validate:all` passed; human QA passed; issue #10 closed |
+| `SYT-008A` | PR #20 closed; issue #8 closed as not planned; native Home/Search hover remains accepted |
 
 ## Review / Integration Queues
 
@@ -69,12 +69,11 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 | Task ID | PR / URL | Status | Required Before Merge | Exact Pass/Fail Message |
 | --- | --- | --- | --- | --- |
-| `SYT-008A` | none | Not started | Yes before implementing visual hover behavior | `Human QA passed/failed for SYT-008A: <notes>` |
 | `SYT-RC-001` | #55/#56 | Passed | Complete | `Human QA passed for SYT-RC-001: looks solid mate... all is working and is well it appears.` |
 
 ## Controller Notes
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: idle after `SYT-RC-001`; no source hardening lanes should launch unless the user reports a concrete failure or opens a new scoped request.
-- Do not route #8 unless the user explicitly reopens that gate.
+- Current controller phase: idle after `SYT-RC-001` and #8/#10 closure; no source hardening lanes should launch unless the user reports a concrete failure or opens a new scoped request.
+- Do not route Home/Search hover research unless the user opens a fresh issue.

--- a/docs/swarm/user-feedback.md
+++ b/docs/swarm/user-feedback.md
@@ -24,10 +24,10 @@ Use this file for durable human steering that should survive across controller t
 
 | Idea | Source | Status | Routed Task |
 | --- | --- | --- | --- |
-| Revisit enhanced home/search grid hover preview | GitHub #8 / prior manual testing | Deferred | `SYT-008A` |
+| Revisit enhanced home/search grid hover preview | GitHub #8 / prior manual testing | Closed as not planned | `SYT-008A` |
 | Strengthen fixture tests before hardening code | User | Planned | `SYT-010A` |
 | Smooth release-candidate validation/package flow | User | Planned | `SYT-010C` |
-| Keep native Home/Search hover only, with no enhanced grow/highlight | User / #8 decision | Active constraint | `SYT-021`, `SYT-008A` deferred |
+| Keep native Home/Search hover only, with no enhanced grow/highlight | User / #8 decision | Active constraint | `SYT-021`, `SYT-008A` closed |
 
 ## Human QA Notes
 


### PR DESCRIPTION
## Summary

- Record issue #8 as closed/not planned and PR #20 as closed/deleted.
- Update hot swarm docs, project brief, and changelog so native YouTube Home/Search hover remains the accepted direction.
- Remove stale paused-lane routing for `SYT-008A`.

## How to test / what to tell the controller

Human review requested: no for this docs-only state repair.

Commands run:
- `git diff --check` passed.
- GitHub confirmed #8 closed and PR #20 closed.

Expected result:
- Diff is docs-only plus `CHANGELOG.md`/`SWARM.md`.
- Hot docs no longer route #8/`SYT-008A` as paused work.
- No release, version bump, tag, Web Store work, or runtime source change is included.

Controller feedback format:
- `Ready to Integrate` if docs correctly show #8/#20 closed.
- `Needs Fixes: <specific stale state>` if any current routing still points to #8 as active.

Refs #8.