### PR TITLE
Codex: Plan Web Store readiness push

### DIFF
--- a/SWARM.md
+++ b/SWARM.md
@@ -75,5 +75,5 @@ This repo should use a paced controller-led model:
 
 - The main repo chat acts as controller.
 - Controller passes should do only a few safe orchestration actions, then leave a clean recovery point.
-- A 30-minute active-pulse heartbeat is active while `SYT-021` is in review/fix/integration.
+- A 30-minute active-pulse heartbeat is active while `SYT-WS-001` / #60 Web Store readiness polish is moving.
 - The heartbeat prompt should stay generic and read `SWARM.md` plus `docs/swarm/controller-directives.md`; do not encode current PR lists or one-off task state in the automation prompt.

--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -5,11 +5,11 @@ Use this file to track who is working, where they are working, and whether the c
 ## Capacity
 
 - Max active planners: 1
-- Max active runners: 3 during planner-approved `SYT-010H` disjoint lanes; otherwise 1
+- Max active runners: 3 during planner-approved `SYT-WS-001` disjoint lanes; otherwise 1
 - Max active reviewers: 1
 - Max active integrators: 1
-- Max total active agents: 3 during planner-approved `SYT-010H` disjoint lanes; otherwise 1
-- Capacity note: user approved a supervised `SYT-010H` final-leg burst up to 3 subagents. Use it only for non-overlapping audit/test/docs/helper lanes with separate branches/worktrees and explicit path locks. Keep fragile runtime implementation, review, and integration serial.
+- Max total active agents: 3 during planner-approved `SYT-WS-001` disjoint lanes; otherwise 1
+- Capacity note: user approved a supervised final-leg push up to 3 subagents when useful. Use it only for non-overlapping audit/assets/docs/helper lanes with separate branches/worktrees and explicit path locks. Keep fragile runtime implementation, review, and integration serial.
 
 ## Controller Lease
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,7 +4,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active lane family: none; `SYT-RC-001` passed and #10 is closed.
+- Active lane family: `SYT-WS-001` / #60 Web Store readiness polish and asset refresh.
 - Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, runtime video binding PR #48, Search lockup fixture PR #50, grid-hover organization PR #54, and RC checklist PR #55 are merged.
 - Completed first burst:
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
@@ -13,8 +13,8 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
   - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
   - `SYT-010H-F`: grid-hover watch recommendation selector organization, PR #54.
-- Active serial lane: none after `SYT-RC-001` human QA pass.
-- GitHub issues: #8/#10/#36/#38/#31 closed.
+- Active serial lane: planning/docs setup on `swarm/syt-ws001-readiness-planning`; route implementation lanes only after planning is integrated.
+- GitHub issues: #8/#10/#36/#38/#31 closed; #60 open for final readiness polish.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures, #54 grid-hover organization, #55 RC checklist.
 - Do not route enhanced Home/Search hover grow research unless the user opens a fresh issue; #8 is closed as not planned.
 
@@ -25,7 +25,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 - Task queue: `docs/swarm/task-board.md`
 - Agent capacity: `docs/swarm/agent-registry.md`
 - GitHub policy/state: `docs/swarm/github.md`
-- Active lane handoff: `docs/swarm/handoffs/SYT-RC-001.md`
+- Active lane handoff: `docs/swarm/handoffs/SYT-WS-001.md`
 - User steering: `docs/swarm/user-feedback.md`
 
 ## Completed Lane References
@@ -52,4 +52,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Wait for explicit release/version/tag/Web Store instruction or a new scoped issue. `SYT-RC-001` human QA passed; #8 and #10 are closed. Do not release, bump version, tag, or restart hover research without explicit user approval.
+Finish integrating the `SYT-WS-001` planning docs, then route the first scoped #60 lane. Do not release, bump version, tag, submit Web Store assets, or restart Home/Search hover research without explicit user approval.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -8,17 +8,17 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Heartbeat mode: `active-pulse`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-06-11 01:36 EDT
+- Last reviewed by controller: 2026-06-11 02:45 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `main`
 - Expected Git state: clean `main` synced with `origin/main`
-- Open PR expectation: none after #8/#10 closure
+- Open PR expectation: docs planning PR for `SYT-WS-001` until integrated
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: idle after `SYT-RC-001` human QA pass and #10 closure
+- Current priority lane: `SYT-WS-001` / GitHub #60 Web Store readiness polish and asset refresh
 
 ## Controller Lease And Pacing
 
@@ -29,9 +29,9 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Lease stale after: 90 minutes
 - Controller pass budget: max 10 safe orchestration actions or 90 minutes during the `SYT-010H` final-leg push
 - Heartbeat pass budget: max 4 safe recovery/routing actions, then stop
-- Active capacity: max 3 active subagents total only for `SYT-010H` lanes that the planner marks disjoint and low/medium conflict; keep max 1 for runtime implementation touching the same content modules, review, integration, merge conflicts, live YouTube behavior, or release-candidate work
-- Heartbeat cadence target: paused while idle after `SYT-RC-001`; resume only when new scoped work or release work is requested
-- Next human QA gate: release candidate/release approval or a fresh high-risk visual/product-direction gate later
+- Active capacity: max 3 active subagents total only for `SYT-WS-001` lanes that the planner marks disjoint and low/medium conflict; keep max 1 for runtime implementation touching the same content modules, review, integration, merge conflicts, live YouTube behavior, or release-candidate work
+- Heartbeat cadence target: 30 minutes while `SYT-WS-001` is active; pause when final readiness handoff is complete
+- Next human QA gate: final Web Store listing/assets acceptance and release approval after automation stops
 
 ## Context Hygiene
 
@@ -72,8 +72,8 @@ Heartbeat overlap rule:
 ## Spawn Strategy
 
 - Read `docs/swarm/agent-registry.md` before spawning.
-- Default to 1 active subagent at a time outside the supervised `SYT-010H` hardening burst.
-- For `SYT-010H`, capacity may rise to 3 total active subagents only after the planner produces non-overlapping lanes with explicit path scopes, branch/worktree names, verification commands, and conflict-risk labels.
+- Default to 1 active subagent at a time outside the supervised `SYT-WS-001` readiness push.
+- For `SYT-WS-001`, capacity may rise to 3 total active subagents only after the planner produces non-overlapping lanes with explicit path scopes, branch/worktree names, verification commands, and conflict-risk labels.
 - Good parallel candidates: read-only audit/planning, fixture coverage audit, popup/settings audit, docs compaction, and isolated unit-test/helper work.
 - Serial-only candidates: changes to `src/content/theater.ts`, `src/content/grid-hover.ts`, `src/content/sticky-player.ts`, shared settings contracts, live YouTube behavior, PR review, and integration.
 - Use low/medium effort for routine routing, docs, review, and fixture-test work.
@@ -106,8 +106,9 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `IDLE` | Wait for explicit release/version/tag/Web Store instruction or a new scoped issue. Do not bump version, tag, release, or update Web Store assets on heartbeat alone. | Controller | `main` | User request received |
-| 2 | none | none | none | none | none |
+| 1 | `SYT-WS-001` | Integrate the readiness planning docs, then route the first safe lane from `docs/swarm/handoffs/SYT-WS-001.md`. | Controller | `swarm/syt-ws001-readiness-planning` then task branches | Planning PR merged or blocked |
+| 2 | `SYT-WS-001A` | Audit Web Store/repo graphics, listing copy, and package collateral; produce concrete asset refresh tasks before editing assets. | Planner/Runner | task branch | Handoff ready for review |
+| 3 | `SYT-WS-001B` | Code polish audit focused on duplicate settings, polling/watchers, and large fragile modules; implement only low-risk cleanups with tests. | Planner/Runner | task branch | Handoff ready for review |
 
 ## Dynamic Notes
 
@@ -147,3 +148,4 @@ Heartbeat overlap rule:
 - 2026-06-11: PR #55 merged the `SYT-RC-001` checklist at `82188cf`. `npm run validate:all` passed on clean `main`. Next safe action is human RC QA; do not close #10 or release until the checklist gate is passed.
 - 2026-06-11: User reported `Human QA passed for SYT-RC-001`; issue #10 was closed with a hardening summary. No release/version/tag/Web Store action was performed.
 - 2026-06-11: User indicated issue #8 was effectively handled. PR #20 was closed, issue #8 was closed as not planned, and native YouTube Home/Search hover remains the accepted direction.
+- 2026-06-11: User requested final Web Store readiness polish, removal of local `.DS_Store` noise, new/refined graphics, and a 30-minute automation cadence. Controller opened #60 and started `SYT-WS-001`. No version bump, tag, release, or Web Store submission is approved yet.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,7 +4,7 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening; `SYT-010H` implementation lanes are integrated, `SYT-RC-001` human QA passed, and #10 is closed.
+- Status: existing repo, post-v0.3.0 hardening; `SYT-RC-001` human QA passed, #8/#10 are closed, and `SYT-WS-001` is starting final Web Store readiness polish under #60.
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
 
 ## Current Focus
@@ -18,7 +18,8 @@
 2. `SYT-010H-F` integrated one-module `grid-hover.ts` watch-recommendation selector organization cleanup.
 3. `SYT-RC-001` human QA passed on 2026-06-11.
 4. #8 enhanced Home/Search hover grow research is closed as not planned; native YouTube Home/Search hover is the accepted behavior.
-5. Keep version/tag/Web Store release actions out unless explicitly approved.
+5. New active lane: `SYT-WS-001` / #60 Web Store readiness polish and asset refresh.
+6. Keep version/tag/Web Store release actions out unless explicitly approved.
 
 ## Recent State
 
@@ -36,6 +37,7 @@
 - PR #55 integrated the `SYT-RC-001` checklist and #10 completion criteria.
 - `npm run validate:all` passed on clean `main` after PR #55.
 - Issues #8 and #10 are closed after `SYT-RC-001` human QA passed and the Home/Search hover direction was accepted as native-only.
+- Issue #60 is open to coordinate final code polish, graphics/listing refresh, package readiness, and exact user handoff before Web Store submission.
 
 ## Constraints And Risks
 
@@ -44,6 +46,7 @@
 - Live YouTube smoke can be noisy; fixture-first checks remain the normal gate.
 - Do not reintroduce Home/Search enhanced hover grow, synthetic hover, or forced preview playback.
 - Do not bump version, tag releases, edit Web Store assets, or restart Home/Search hover research without explicit user approval and a fresh issue.
+- Store/repo graphics may be refreshed under #60, but submission/version/release actions still require explicit approval.
 
 ## Verification Defaults
 
@@ -54,12 +57,12 @@
 
 ## Automation Notes
 
-- Controller heartbeat: paused after `SYT-RC-001` became human-gated, id `simple-yt-tweaks-controller-heartbeat`.
-- Capacity: up to 3 only for planner-approved disjoint `SYT-010H` A/B/C work; review, integration, and runtime implementation stay serial.
+- Controller heartbeat: reactivated for #60 at a 30-minute cadence, id `simple-yt-tweaks-controller-heartbeat`.
+- Capacity: up to 3 only for planner-approved disjoint `SYT-WS-001` lanes; review, integration, and runtime implementation stay serial.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry unless a handoff explicitly assigns them.
 - Registry: `docs/swarm/agent-registry.md`.
 
 ## Last Updated
 
 - Date: 2026-06-11
-- By: Controller after `SYT-RC-001` human QA pass and #10 closure
+- By: Controller starting `SYT-WS-001` / #60

--- a/docs/swarm/handoffs/SYT-WS-001.md
+++ b/docs/swarm/handoffs/SYT-WS-001.md
@@ -1,0 +1,68 @@
+# SYT-WS-001 - Web Store Readiness Polish And Asset Refresh
+
+## Task
+
+- Task ID: `SYT-WS-001`
+- GitHub issue: #60
+- Role: Controller / Planner first, then scoped Runners
+- State: In Progress
+- Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
+- Current branch: `swarm/syt-ws001-readiness-planning`
+
+## Goal
+
+Bring Simple YT Tweaks from RC-passed to nearly Web Store-ready without changing release/version state yet.
+
+## Scope
+
+- Remove local `.DS_Store` noise and keep junk out of source/package artifacts.
+- Audit and refresh Web Store/repo graphics and listing collateral.
+- Audit code polish targets before editing runtime:
+  - duplicated settings definitions in `src/shared/settings.ts` and `src/content/settings.ts`
+  - watch-to-Home watcher/polling behavior
+  - large fragile modules: `theater.ts`, `grid-hover.ts`, `sidebar.ts`, `sticky-player.ts`, `fullscreen.ts`
+- Implement only low-risk polish with focused tests and full final validation.
+- Stop the automation when ready and give the user exact remaining Web Store/release steps.
+
+## Non-Scope
+
+- No version bump.
+- No tag or GitHub release.
+- No Chrome Web Store submission or asset upload.
+- Do not reintroduce enhanced Home/Search hover grow, synthetic hover, or forced preview playback.
+- Do not broaden extension permissions or add remote code.
+
+## Parallelization
+
+- `parallel-safe`: audit/docs/assets planning can run in parallel after this setup PR if path scopes are explicit.
+- `serial-required`: runtime implementation, review, integration, release handoff.
+- `depends-on`: user request on 2026-06-11 and GitHub issue #60.
+- `conflict-risk`: medium overall; high for runtime content modules.
+
+## Proposed Lanes
+
+1. `SYT-WS-001A` - Store/repo graphics and listing collateral audit/refresh.
+   - Scope: `store-assets/`, asset generation scripts, README/listing copy if needed.
+   - First output: concrete asset inventory and refresh plan.
+2. `SYT-WS-001B` - Final code polish audit and low-risk cleanup.
+   - Scope: settings duplication, targeted watchers, large content modules.
+   - First output: audit with recommended changes split into safe-now vs defer.
+3. `SYT-WS-001C` - Final package/release handoff.
+   - Scope: run full validation/package, confirm artifact contents, pause automation, provide exact user steps.
+
+## Verification
+
+- Focused lane checks for Runner PRs.
+- `npm run validate:all` before integration of runtime/source/test changes.
+- Supplemental Chrome/Brave live checks only when behavior cannot be proved by fixtures.
+- Final package inspection before Web Store handoff.
+
+## Decisions
+
+- `.DS_Store` is ignored and should not be tracked or packaged.
+- Existing accepted behavior remains native YouTube Home/Search hover only.
+- The watch-to-Home watcher is allowed to remain if the audit confirms it is still the narrowest fix for Brave PWA / YouTube SPA behavior.
+
+## Next Recommended Role
+
+Controller should integrate this planning docs branch, reactivate the heartbeat at 30 minutes, then route `SYT-WS-001A` or `SYT-WS-001B` depending on capacity and risk. Keep runtime work serial.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -10,8 +10,8 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 - Project brief: Ready
 - Material questions: Deferred, not blocking
-- Current milestone plan: `SYT-010H` lane map integrated in PR #43; A/B/C/D/E/F are integrated through PR #54.
-- Implementation dispatch: no active hardening runner; `SYT-RC-001` human QA passed and #10 is closed.
+- Current milestone plan: `SYT-WS-001` Web Store readiness polish under #60.
+- Implementation dispatch: planning/docs setup first, then scoped code/assets lanes.
 
 ## Active Tasks
 
@@ -20,6 +20,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-A` | Settings, popup defaults, and persistence | Integrator | Integrated | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 merged |
 | `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
 | `SYT-010H-C` | Swarm docs and context compaction | Integrator | Integrated | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 merged |
+| `SYT-WS-001` | Web Store readiness polish and asset refresh | Controller | In Progress | `swarm/syt-ws001-readiness-planning` | plan #60 lanes, docs, cadence | serial-required for planning/integration | user request / #60 | low docs, medium follow-up | `docs/swarm/handoffs/SYT-WS-001.md` | pending |
 
 ## Hold / Future Tasks
 
@@ -29,6 +30,9 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Integrated | PR #50; modern Search lockup fixture coverage. |
 | `SYT-010H-F` | Grid-hover watch recommendation selector organization cleanup | Integrated | PR #54; one-module selector organization and unit coverage. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
+| `SYT-WS-001A` | Store/repo graphics and listing collateral refresh | Ready after `SYT-WS-001` | Audit first, then update generated assets/copy on a scoped branch. |
+| `SYT-WS-001B` | Final code polish audit and low-risk cleanup | Ready after `SYT-WS-001` | Focus on settings duplication, polling/watchers, and large fragile modules without behavior churn. |
+| `SYT-WS-001C` | Final package/release handoff | Backlog | After assets/code polish pass and `npm run validate:all`; stop automation and give user exact next steps. |
 
 ## Completed / Archived
 
@@ -75,5 +79,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
-- Current controller phase: idle after `SYT-RC-001` and #8/#10 closure; no source hardening lanes should launch unless the user reports a concrete failure or opens a new scoped request.
+- Current controller phase: #60 readiness polish. Keep first pass docs/planning-only, then route scoped lanes. No version/release/Web Store submission until explicit approval.
 - Do not route Home/Search hover research unless the user opens a fresh issue.

--- a/docs/swarm/user-feedback.md
+++ b/docs/swarm/user-feedback.md
@@ -19,6 +19,7 @@ Use this file for durable human steering that should survive across controller t
 - 2026-06-10: First `SYT-036` human QA failed. User reported autoplay on hover still does not work when going from a video back to Home, while it works on first YouTube load. Treat stricter advancing-preview validation and live signed-in Chrome inspection as required supporting evidence.
 - 2026-06-10: User clarified `SYT-036` is specifically watch video -> click YouTube logo/top-left Home or sidebar Home -> Home hover autoplay fails. Visiting profile and returning Home works. Do not substitute browser Back/profile navigation as proof for this bug.
 - 2026-06-10: User clarified the real app surface is the Brave YouTube PWA, not Chrome, and that the watch-page header must be hovered to expose the YouTube logo before clicking Home. Use that exact path for supplemental live verification of #36-style regressions.
+- 2026-06-11: User wants `.DS_Store` noise removed, a 30-minute controller automation cadence, final code polish toward Web Store readiness, and refreshed graphics/listing collateral. Automation should stop when Codex believes the repo is ready and then provide exact remaining user/Web Store steps.
 
 ## Product Ideas
 
@@ -28,6 +29,7 @@ Use this file for durable human steering that should survive across controller t
 | Strengthen fixture tests before hardening code | User | Planned | `SYT-010A` |
 | Smooth release-candidate validation/package flow | User | Planned | `SYT-010C` |
 | Keep native Home/Search hover only, with no enhanced grow/highlight | User / #8 decision | Active constraint | `SYT-021`, `SYT-008A` closed |
+| Final Web Store readiness polish and asset refresh | User | Active | `SYT-WS-001` / #60 |
 
 ## Human QA Notes
 


### PR DESCRIPTION
## Summary
- Open the `SYT-WS-001` Web Store readiness lane for GitHub issue #60.
- Update controller docs, task board, feedback, and capacity rules for a 30-minute active-pulse final polish push.
- Add a handoff that splits follow-up into graphics/listing collateral, final code polish, and final package/release handoff lanes.

## How to test / what to tell the controller
Human review requested: no for this docs-only routing update.

Commands run:
- `find . -name .DS_Store -type f -delete` / local junk cleanup
- `git diff --check`

Expected result:
- Docs route the heartbeat/controller to #60 and do not approve version bump, release, tag, or Web Store submission.
- Runtime source, package version, generated extension assets, and Web Store submissions are unchanged.

Controller feedback:
- Ready to Integrate if the docs accurately route `SYT-WS-001` and the branch remains docs-only.
- Needs Fixes: `<specific stale routing or policy problem>` otherwise.
