### PR TITLE
Codex: Record Web Store readiness audits

### DIFF
--- a/docs/swarm/agent-registry.md
+++ b/docs/swarm/agent-registry.md
@@ -19,7 +19,7 @@ Use this file to track who is working, where they are working, and whether the c
 
 ## Active Agents
 
-No active agents after `SYT-010H-F` integrated via PR #54.
+No active agents after the `SYT-WS-001A` and `SYT-WS-001B` read-only audits completed.
 
 | Agent / Thread | Task ID | Role | Status | Branch | Worktree | PR | Started | Last Seen | Expected Next Step | Heartbeat |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -63,6 +63,8 @@ Completed agent history is compacted here. Use `docs/swarm/archive/README.md`, t
 | `SYT-010H-E` / #50 | Search modern lockup selector fixture hardening integrated |
 | `SYT-010H-F` / #54 | grid-hover watch recommendation selector organization integrated |
 | `SYT-RC-001` / #55/#56 | release-candidate checklist integrated; human QA passed; #10 closed |
+| `SYT-WS-001A` audit / Tesla | store/listing graphics audit completed; assets stale and next lane should refresh marketing assets/screenshots/listing notes under #60 |
+| `SYT-WS-001B` audit / Feynman | code polish audit completed; no code/manifest no-go; keep watch-to-Home path stable for release; avoid broad module splits before submission |
 
 ## Pending Launch
 

--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -15,6 +15,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-F`: grid-hover watch recommendation selector organization, PR #54.
 - Active serial lane: planning/docs setup on `swarm/syt-ws001-readiness-planning`; route implementation lanes only after planning is integrated.
 - GitHub issues: #8/#10/#36/#38/#31 closed; #60 open for final readiness polish.
+- Latest audit result: asset/listing refresh is the next best lane; code has no Web Store blocker and runtime behavior should stay stable.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures, #54 grid-hover organization, #55 RC checklist.
 - Do not route enhanced Home/Search hover grow research unless the user opens a fresh issue; #8 is closed as not planned.
 
@@ -52,4 +53,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Finish integrating the `SYT-WS-001` planning docs, then route the first scoped #60 lane. Do not release, bump version, tag, submit Web Store assets, or restart Home/Search hover research without explicit user approval.
+Route `SYT-WS-001A` asset/listing refresh next. Do not release, bump version, tag, submit Web Store assets, or restart Home/Search hover research without explicit user approval.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -38,6 +38,8 @@
 - `npm run validate:all` passed on clean `main` after PR #55.
 - Issues #8 and #10 are closed after `SYT-RC-001` human QA passed and the Home/Search hover direction was accepted as native-only.
 - Issue #60 is open to coordinate final code polish, graphics/listing refresh, package readiness, and exact user handoff before Web Store submission.
+- `SYT-WS-001A` store/listing audit found stale marketing assets and private Web Store notes; asset refresh is the next best lane.
+- `SYT-WS-001B` code audit found no code/manifest no-go; defer broad runtime refactors and keep the watch-to-Home path stable before submission.
 
 ## Constraints And Risks
 

--- a/docs/swarm/handoffs/SYT-WS-001.md
+++ b/docs/swarm/handoffs/SYT-WS-001.md
@@ -63,6 +63,39 @@ Bring Simple YT Tweaks from RC-passed to nearly Web Store-ready without changing
 - Existing accepted behavior remains native YouTube Home/Search hover only.
 - The watch-to-Home watcher is allowed to remain if the audit confirms it is still the narrowest fix for Brave PWA / YouTube SPA behavior.
 
+## Audit Results
+
+### `SYT-WS-001A` Store/Listings
+
+- Assets present:
+  - `public/icons/icon16.png`, `icon32.png`, `icon48.png`, `icon128.png`.
+  - Five `1280x800` PNG screenshots in `store-assets/screenshots/`.
+  - Small promo tile `440x280` in `store-assets/promo/`.
+  - README banner and three repo feature cards in `store-assets/repo/`.
+  - `PRIVACY.md` exists; README points support to GitHub issues.
+  - Private listing notes exist at `.private/WEBSTORE.md` and remain ignored.
+- Gaps:
+  - Marketing assets are stale and still show older `v0.2.0` popup imagery while package/manifest are `0.3.0`.
+  - Marketing assets do not reflect the refreshed red play/settings icon.
+  - Optional marquee promo `1400x560` is missing.
+  - Current screenshots are partly marketing cards instead of clean full-bleed product screenshots.
+  - Some real YouTube captures are visually noisy; neutral deterministic captures are preferable where possible.
+  - `.private/WEBSTORE.md` needs local refresh for current version, package path, screenshot list, copy, privacy answers, and support URL.
+- Next safe lane: refresh marketing generation and assets first; use a distinct Simple YT Tweaks red play/settings mark rather than copying YouTube branding directly.
+
+### `SYT-WS-001B` Code Polish
+
+- No code/manifest Web Store no-go found.
+- Manifest remains narrow: `storage`, `https://www.youtube.com/*`, popup, and a single YouTube content script.
+- Keep the 250ms watch-to-Home watcher/reload path stable before Web Store submission unless a specific change gets fixture coverage plus Brave PWA live QA.
+- Safe-now candidates:
+  - Keep deleting ignored `.DS_Store` files from the working tree when they appear.
+  - Optional settings cleanup: make `src/content/settings.ts` thinner over `src/shared/settings.ts` only if it stays low-risk with existing parity tests.
+  - Optional tests-only coverage for the one-shot reload guard/sessionStorage behavior.
+- Defer:
+  - Broad splits of `theater.ts`, `grid-hover.ts`, `sidebar.ts`, `sticky-player.ts`, and `fullscreen.ts`.
+  - Selector rewrites without a concrete live regression.
+
 ## Next Recommended Role
 
-Controller should integrate this planning docs branch, reactivate the heartbeat at 30 minutes, then route `SYT-WS-001A` or `SYT-WS-001B` depending on capacity and risk. Keep runtime work serial.
+Controller should route `SYT-WS-001A` implementation next: refresh marketing generation/assets and private Web Store notes. Keep code cleanup conservative; do not touch runtime behavior unless a concrete low-risk test-backed change is selected.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -20,7 +20,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-A` | Settings, popup defaults, and persistence | Integrator | Integrated | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 merged |
 | `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
 | `SYT-010H-C` | Swarm docs and context compaction | Integrator | Integrated | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 merged |
-| `SYT-WS-001` | Web Store readiness polish and asset refresh | Controller | In Progress | `swarm/syt-ws001-readiness-planning` | plan #60 lanes, docs, cadence | serial-required for planning/integration | user request / #60 | low docs, medium follow-up | `docs/swarm/handoffs/SYT-WS-001.md` | pending |
+| `SYT-WS-001` | Web Store readiness polish and asset refresh | Controller | In Progress | `main` plus scoped task branches | route #60 lanes, docs, cadence | serial-required for planning/integration | user request / #60 | low docs, medium follow-up | `docs/swarm/handoffs/SYT-WS-001.md` | #61 merged |
 
 ## Hold / Future Tasks
 
@@ -30,8 +30,8 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Integrated | PR #50; modern Search lockup fixture coverage. |
 | `SYT-010H-F` | Grid-hover watch recommendation selector organization cleanup | Integrated | PR #54; one-module selector organization and unit coverage. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
-| `SYT-WS-001A` | Store/repo graphics and listing collateral refresh | Ready after `SYT-WS-001` | Audit first, then update generated assets/copy on a scoped branch. |
-| `SYT-WS-001B` | Final code polish audit and low-risk cleanup | Ready after `SYT-WS-001` | Focus on settings duplication, polling/watchers, and large fragile modules without behavior churn. |
+| `SYT-WS-001A` | Store/repo graphics and listing collateral refresh | Ready | Refresh stale marketing assets, add marquee promo if useful, update private Web Store notes, and align screenshots with current extension. |
+| `SYT-WS-001B` | Final code polish audit and low-risk cleanup | Ready, lower priority | No code/manifest no-go; only pursue low-risk settings/test cleanup. Do not change watch-to-Home behavior before submission without live QA. |
 | `SYT-WS-001C` | Final package/release handoff | Backlog | After assets/code polish pass and `npm run validate:all`; stop automation and give user exact next steps. |
 
 ## Completed / Archived
@@ -80,4 +80,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
 - Current controller phase: #60 readiness polish. Keep first pass docs/planning-only, then route scoped lanes. No version/release/Web Store submission until explicit approval.
+- `SYT-WS-001A` asset/listing refresh is the next best lane because audits found stale store graphics and listing notes; code audit found no blocker.
 - Do not route Home/Search hover research unless the user opens a fresh issue.


### PR DESCRIPTION
## Summary
- Record the completed `SYT-WS-001A` store/listing and `SYT-WS-001B` code polish audits.
- Clear active audit agents from the registry and capture their findings in the handoff.
- Route the next #60 lane to asset/listing refresh because code/manifest audit found no Web Store blocker.

## How to test / what to tell the controller
Human review requested: no for this docs-only state update.

Commands run:
- `git diff --check`
- local `.DS_Store` cleanup before staging

Expected result:
- Controller docs point to `SYT-WS-001A` as the next safe lane.
- No runtime source, extension package, version, tag, release, or Web Store submission changes are included.

Controller feedback:
- Ready to Integrate if audit findings are captured accurately and the branch remains docs-only.
- Needs Fixes: `<specific stale routing or missing audit detail>` otherwise.
