### PR TITLE
Codex: Record asset refresh integration

### DIFF
--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -13,9 +13,9 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
   - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
   - `SYT-010H-F`: grid-hover watch recommendation selector organization, PR #54.
-- Active serial lane: `SYT-WS-001A` asset refresh on `swarm/syt-ws001a-assets-refresh`; review/PR is next.
+- Active serial lane: `SYT-WS-001A` is integrated through PR #63; decide `SYT-WS-001B` defer vs small cleanup, then route `SYT-WS-001C`.
 - GitHub issues: #8/#10/#36/#38/#31 closed; #60 open for final readiness polish.
-- Latest audit result: asset/listing refresh is implemented; code has no Web Store blocker and runtime behavior should stay stable.
+- Latest audit result: asset/listing refresh is integrated; code has no Web Store blocker and runtime behavior should stay stable.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures, #54 grid-hover organization, #55 RC checklist.
 - Do not route enhanced Home/Search hover grow research unless the user opens a fresh issue; #8 is closed as not planned.
 
@@ -53,4 +53,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Review and integrate `SYT-WS-001A` asset/listing refresh next. Do not release, bump version, tag, submit Web Store assets, or restart Home/Search hover research without explicit user approval.
+Decide whether to defer `SYT-WS-001B` code polish, then route `SYT-WS-001C` final package/readiness handoff. Do not release, bump version, tag, submit Web Store assets, or restart Home/Search hover research without explicit user approval.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -13,9 +13,9 @@ This file is the repo-local dynamic control plane for the controller chat and an
 ## Current Source Of Truth
 
 - Default branch: `main`
-- Current branch: `swarm/syt-ws001a-assets-refresh`
-- Expected Git state: `SYT-WS-001A` asset refresh branch ready for review/PR, then clean `main` after integration
-- Open PR expectation: PR #63 for `SYT-WS-001A` until integrated
+- Current branch: `main`
+- Expected Git state: clean `main` synced with `origin/main`
+- Open PR expectation: none after PR #63 integration
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
 - Current priority lane: `SYT-WS-001` / GitHub #60 Web Store readiness polish and asset refresh
@@ -106,9 +106,8 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-WS-001A` | Review and integrate PR #63 if checks are clean. | Reviewer/Integrator | `swarm/syt-ws001a-assets-refresh` | PR merged or blocked |
-| 2 | `SYT-WS-001B` | Decide whether any safe-now code polish remains before Web Store handoff. Avoid runtime changes unless concrete and test-backed. | Controller/Planner | task branch if needed | Handoff ready or deferred |
-| 3 | `SYT-WS-001C` | Run final package/readiness handoff, pause automation, and give exact user Web Store steps. | Controller | `main` after prior lanes | Final handoff complete |
+| 1 | `SYT-WS-001B` | Decide whether any safe-now code polish remains before Web Store handoff. Avoid runtime changes unless concrete and test-backed. | Controller/Planner | task branch if needed | Handoff ready or deferred |
+| 2 | `SYT-WS-001C` | Run final package/readiness handoff, pause automation, and give exact user Web Store steps. | Controller | `main` after prior lanes | Final handoff complete |
 
 ## Dynamic Notes
 
@@ -150,3 +149,4 @@ Heartbeat overlap rule:
 - 2026-06-11: User indicated issue #8 was effectively handled. PR #20 was closed, issue #8 was closed as not planned, and native YouTube Home/Search hover remains the accepted direction.
 - 2026-06-11: User requested final Web Store readiness polish, removal of local `.DS_Store` noise, new/refined graphics, and a 30-minute automation cadence. Controller opened #60 and started `SYT-WS-001`. No version bump, tag, release, or Web Store submission is approved yet.
 - 2026-06-12: `SYT-WS-001A` asset refresh implemented current popup captures, refreshed marketing assets, added marquee promo, updated validation, and refreshed private Web Store notes locally. `npm run assets:store`, `git diff --check`, `npm run validate:all`, and zip inspection passed before PR.
+- 2026-06-12: PR #63 squash-merged at `65a52f7`; no version bump, tag, release, Web Store submission, permission change, or runtime behavior change.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -19,7 +19,7 @@
 3. `SYT-RC-001` human QA passed on 2026-06-11.
 4. #8 enhanced Home/Search hover grow research is closed as not planned; native YouTube Home/Search hover is the accepted behavior.
 5. New active lane: `SYT-WS-001` / #60 Web Store readiness polish and asset refresh.
-6. `SYT-WS-001A` asset refresh is implemented on `swarm/syt-ws001a-assets-refresh` and ready for review/PR.
+6. `SYT-WS-001A` asset refresh is integrated through PR #63 at `65a52f7`.
 7. Keep version/tag/Web Store release actions out unless explicitly approved.
 
 ## Recent State
@@ -42,6 +42,7 @@
 - `SYT-WS-001A` store/listing audit found stale marketing assets and private Web Store notes; asset refresh is the next best lane.
 - `SYT-WS-001B` code audit found no code/manifest no-go; defer broad runtime refactors and keep the watch-to-Home path stable before submission.
 - `SYT-WS-001A` implementation refreshed popup captures, store/repo graphics, asset generation scripts, validation for marquee promo, and local private Web Store notes. `npm run assets:store`, `git diff --check`, `npm run validate:all`, and packaged zip inspection passed.
+- PR #63 merged the asset refresh at `65a52f7`; no runtime behavior, version, tag, release, Web Store submission, or permission changes were made.
 
 ## Constraints And Risks
 
@@ -69,4 +70,4 @@
 ## Last Updated
 
 - Date: 2026-06-12
-- By: Controller implementing `SYT-WS-001A` / #60 asset refresh
+- By: Controller integrating `SYT-WS-001A` / #60 asset refresh

--- a/docs/swarm/github.md
+++ b/docs/swarm/github.md
@@ -45,7 +45,7 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 
 | Task ID | Branch | PR | Status | Owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `SYT-WS-001A` | `swarm/syt-ws001a-assets-refresh` | #63 | Open, needs review | Controller | Refs #60; refreshed store/repo graphics and asset scripts. |
+| none | none | none | none | none | none |
 
 ## Setup Log
 
@@ -74,3 +74,4 @@ Use this file to record the repo's GitHub status and autonomous PR policy.
 - 2026-06-11: User confirmed desired #36/#38 behavior is working and asked to proceed to polish/hardening. Keep PR #37 in review path, then integrate if clean before launching `SYT-010H` under #10.
 - 2026-06-11: PR #37 marked ready and squash-merged at `342854f` after `npm run validate:all` passed. Issues #36 and #38 closed. Next GitHub work should be a `SYT-010H` polish/hardening branch under #10.
 - 2026-06-11: PR #20 was closed and branch `swarm/syt-008a-hover-research` deleted. Issue #8 was closed as not planned because native YouTube Home/Search hover is the accepted direction.
+- 2026-06-12: PR #63 squash-merged at `65a52f7` for `SYT-WS-001A`; remote branch cleanup completed by merge.

--- a/docs/swarm/handoffs/SYT-WS-001.md
+++ b/docs/swarm/handoffs/SYT-WS-001.md
@@ -5,7 +5,7 @@
 - Task ID: `SYT-WS-001`
 - GitHub issue: #60
 - Role: Controller / Planner first, then scoped Runners
-- State: `SYT-WS-001A` implementation ready for review
+- State: `SYT-WS-001A` integrated; `SYT-WS-001B` defer/cleanup decision next
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Current branch: `swarm/syt-ws001a-assets-refresh`
 
@@ -98,7 +98,7 @@ Bring Simple YT Tweaks from RC-passed to nearly Web Store-ready without changing
 
 ## Next Recommended Role
 
-Reviewer should review `SYT-WS-001A` asset refresh, then Integrator can merge if clean. Keep code cleanup conservative; do not touch runtime behavior unless a concrete low-risk test-backed change is selected.
+Controller should decide whether to defer `SYT-WS-001B` and route `SYT-WS-001C` final package/readiness handoff. Keep code cleanup conservative; do not touch runtime behavior unless a concrete low-risk test-backed change is selected.
 
 ## `SYT-WS-001A` Implementation
 
@@ -148,9 +148,10 @@ Reviewer should review `SYT-WS-001A` asset refresh, then Integrator can merge if
 - No version bump, tag, release, Web Store upload, or permission change.
 - Store assets are refreshed in-repo so final Web Store submission can use current collateral after user approval.
 - The final Web Store listing/assets acceptance remains a user gate before submission.
+- PR #63 merged at `65a52f7`.
 
 ### Next Exact Action
 
-1. Review PR #63.
-2. Integrate PR #63 if clean.
-3. Continue to `SYT-WS-001B` only if there is a low-risk code polish task worth doing before final handoff; otherwise route `SYT-WS-001C`.
+1. Decide whether `SYT-WS-001B` has any low-risk code polish worth doing now.
+2. If not, route `SYT-WS-001C`.
+3. In `SYT-WS-001C`, run final validation/package inspection, pause automation, and give the user exact Web Store/release steps.

--- a/docs/swarm/integration-log.md
+++ b/docs/swarm/integration-log.md
@@ -12,6 +12,32 @@ Use this file for merge decisions, conflict history, final checks, and release n
 
 ## Entries
 
+### 2026-06-12: SYT-WS-001A Web Store Asset Refresh Integration
+
+- Integrator: Codex
+- Target branch: `main`
+- Candidate branch(es): `swarm/syt-ws001a-assets-refresh`
+- PR(s): https://github.com/cryptoteatime/simple-yt-tweaks/pull/63
+- Issue(s): https://github.com/cryptoteatime/simple-yt-tweaks/issues/60
+- Decision: Integrated
+- Merge: squash merge commit `65a52f7b0b0eb8f40dfa40ce68195206604551aa`
+- Reason: Asset audit found stale popup and marketing imagery. PR #63 refreshed current popup captures, store/repo graphics, asset generation scripts, and validation for the new marquee promo without touching runtime behavior.
+- Conflicts: none; PR #63 was mergeable before merge.
+- Checks:
+  - `npm run assets:store`: PASS.
+  - `git diff --check`: PASS.
+  - `npm run validate:all`: PASS, including typecheck, lint, package validation, packaged validation, 25 unit tests, and 21 fixture tests.
+  - `unzip -l release/simple-yt-tweaks-v0.3.0.zip`: PASS; packaged zip contains only extension runtime files.
+- Human acceptance: NOT_REQUIRED before merge
+- Human acceptance evidence: PR changes were generated assets/docs/scripts only. Final Web Store listing/assets acceptance remains a user gate before submission.
+- Branch cleanup: GitHub deleted the remote task branch during merge.
+- Worktree cleanup: local `main` synced to `origin/main`; this docs repair records the integration and clears active PR state.
+- Notes:
+  - No runtime behavior, version bump, tag, release, Web Store submission, or permission change was performed.
+  - `.private/WEBSTORE.md` was refreshed locally but remains ignored and untracked.
+- Follow-ups:
+  - Decide whether to defer `SYT-WS-001B` code polish, then route `SYT-WS-001C` final package/readiness handoff.
+
 ### 2026-06-11: SYT-036 / SYT-038 Home Hover And Live Theater Chat Integration
 
 - Integrator: Codex

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -21,7 +21,6 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
 | `SYT-010H-C` | Swarm docs and context compaction | Integrator | Integrated | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 merged |
 | `SYT-WS-001` | Web Store readiness polish and asset refresh | Controller | In Progress | `main` plus scoped task branches | route #60 lanes, docs, cadence | serial-required for planning/integration | user request / #60 | low docs, medium follow-up | `docs/swarm/handoffs/SYT-WS-001.md` | #61/#62 merged |
-| `SYT-WS-001A` | Store/repo graphics and listing collateral refresh | Runner | Needs Review | `swarm/syt-ws001a-assets-refresh` | refreshed popup captures, store/repo graphics, asset scripts, private notes | serial-required for review/integration | `SYT-WS-001` audits | medium visual/product assets | `docs/swarm/handoffs/SYT-WS-001.md` | #63 |
 
 ## Hold / Future Tasks
 
@@ -60,6 +59,7 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | `SYT-010H-F` | PR #54 merged; grid-hover watch recommendation selector organization |
 | `SYT-RC-001` | PR #55/#56 merged; `validate:all` passed; human QA passed; issue #10 closed |
 | `SYT-008A` | PR #20 closed; issue #8 closed as not planned; native Home/Search hover remains accepted |
+| `SYT-WS-001A` | PR #63 merged at `65a52f7`; refreshed current store/repo graphics, popup captures, asset scripts, and validation |
 
 ## Review / Integration Queues
 
@@ -80,5 +80,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
 - Current controller phase: #60 readiness polish. Keep first pass docs/planning-only, then route scoped lanes. No version/release/Web Store submission until explicit approval.
-- `SYT-WS-001A` asset/listing refresh is implemented on `swarm/syt-ws001a-assets-refresh`; review the branch/PR next.
+- `SYT-WS-001A` asset/listing refresh is integrated. Decide whether to defer `SYT-WS-001B`; otherwise route `SYT-WS-001C` final handoff.
 - Do not route Home/Search hover research unless the user opens a fresh issue.


### PR DESCRIPTION
## Summary
- record PR #63 / `SYT-WS-001A` as integrated
- clear active PR state and point the controller at the next #60 decision
- add the asset refresh merge to the integration log

Refs #60.

## How to test / what to tell the controller
- human review requested: no
- commands run:
  - `git diff --check`
- expected result:
  - docs-only diff has no whitespace errors
  - controller docs no longer treat PR #63 as open
  - next safe action is deciding whether to defer `SYT-WS-001B` or route `SYT-WS-001C`
- controller feedback format:
  - `PR #<number> Ready to Integrate: <notes>`
  - or `PR #<number> Needs Fixes: <file/line and observed problem>`