### PR TITLE
Codex: Record final Web Store readiness

### DIFF
--- a/docs/swarm/context-map.md
+++ b/docs/swarm/context-map.md
@@ -4,7 +4,7 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
 
 ## Current Hot State
 
-- Active lane family: `SYT-WS-001` / #60 Web Store readiness polish and asset refresh.
+- Active lane family: none; `SYT-WS-001` / #60 Web Store readiness polish is complete pending user listing/upload approval.
 - Current routing: planning PR #43, batch registration PR #44, settings/popup coverage PR #45, selector/runtime audit PR #46, docs compaction PR #47, runtime video binding PR #48, Search lockup fixture PR #50, grid-hover organization PR #54, and RC checklist PR #55 are merged.
 - Completed first burst:
   - `SYT-010H-A`: settings/popup/defaults/persistence test coverage, PR #45, merge `ce09953`.
@@ -13,9 +13,9 @@ Use this file as the fast entrypoint after `SWARM.md` and `docs/swarm/controller
   - `SYT-010H-D`: runtime video binding hardening, PR #48.
   - `SYT-010H-E`: Search modern lockup selector fixture hardening, PR #50.
   - `SYT-010H-F`: grid-hover watch recommendation selector organization, PR #54.
-- Active serial lane: `SYT-WS-001A` is integrated through PR #63; decide `SYT-WS-001B` defer vs small cleanup, then route `SYT-WS-001C`.
-- GitHub issues: #8/#10/#36/#38/#31 closed; #60 open for final readiness polish.
-- Latest audit result: asset/listing refresh is integrated; code has no Web Store blocker and runtime behavior should stay stable.
+- Active serial lane: final notification and heartbeat shutdown.
+- GitHub issues: #8/#10/#36/#38/#31 closed; #60 ready to close after final readiness notification.
+- Latest audit result: asset/listing refresh is integrated; code has no Web Store blocker; `SYT-WS-001B` is deferred before submission.
 - Recent merged swarm docs/code PRs: #39 integration record, #40 context repair, #41 burst capacity, #42 planner registration, #43 SYT-010H lane plan, #44 batch registration, #45 settings tests, #46 selector/runtime audit, #47 docs compaction, #48 runtime video binding, #50 Search lockup fixtures, #54 grid-hover organization, #55 RC checklist.
 - Do not route enhanced Home/Search hover grow research unless the user opens a fresh issue; #8 is closed as not planned.
 
@@ -53,4 +53,4 @@ Completed lanes are intentionally compacted to stubs. Use PRs and `docs/swarm/ar
 
 ## Next Safe Controller Action
 
-Decide whether to defer `SYT-WS-001B` code polish, then route `SYT-WS-001C` final package/readiness handoff. Do not release, bump version, tag, submit Web Store assets, or restart Home/Search hover research without explicit user approval.
+Close #60, stop/delete the heartbeat automation, and give the user exact Web Store upload/release steps. Do not release, bump version, tag, submit Web Store assets, or restart Home/Search hover research without explicit user approval.

--- a/docs/swarm/controller-directives.md
+++ b/docs/swarm/controller-directives.md
@@ -5,20 +5,20 @@ This file is the repo-local dynamic control plane for the controller chat and an
 ## Mode
 
 - Controller mode: `AUTOPILOT_WITH_HEARTBEAT`
-- Heartbeat mode: `active-pulse`
+- Heartbeat mode: `complete-after-final-notification`
 - Heartbeat automation id: `simple-yt-tweaks-controller-heartbeat`
 - Main controller chat: Simple YT Tweaks controller in Codex workspace
-- Last reviewed by controller: 2026-06-12 02:44 EDT
+- Last reviewed by controller: 2026-06-12 03:09 EDT
 
 ## Current Source Of Truth
 
 - Default branch: `main`
 - Current branch: `main`
 - Expected Git state: clean `main` synced with `origin/main`
-- Open PR expectation: none after PR #63 integration
+- Open PR expectation: none after final #60 readiness docs integration
 - Active agents expectation: none
 - Controller lease expectation: none between bounded heartbeat passes
-- Current priority lane: `SYT-WS-001` / GitHub #60 Web Store readiness polish and asset refresh
+- Current priority lane: none; `SYT-WS-001` / GitHub #60 is ready to close after final docs integration
 
 ## Controller Lease And Pacing
 
@@ -30,8 +30,8 @@ This file is the repo-local dynamic control plane for the controller chat and an
 - Controller pass budget: max 10 safe orchestration actions or 90 minutes during the `SYT-010H` final-leg push
 - Heartbeat pass budget: max 4 safe recovery/routing actions, then stop
 - Active capacity: max 3 active subagents total only for `SYT-WS-001` lanes that the planner marks disjoint and low/medium conflict; keep max 1 for runtime implementation touching the same content modules, review, integration, merge conflicts, live YouTube behavior, or release-candidate work
-- Heartbeat cadence target: 30 minutes while `SYT-WS-001` is active; pause when final readiness handoff is complete
-- Next human QA gate: final Web Store listing/assets acceptance and release approval after automation stops
+- Heartbeat cadence target: stop/delete after final readiness handoff is reported
+- Next human QA gate: final Web Store listing/assets acceptance and release/upload approval by the user
 
 ## Context Hygiene
 
@@ -106,8 +106,7 @@ Heartbeat overlap rule:
 
 | Priority | Task ID | Action | Owner | Branch / Worktree | Stop Condition |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `SYT-WS-001B` | Decide whether any safe-now code polish remains before Web Store handoff. Avoid runtime changes unless concrete and test-backed. | Controller/Planner | task branch if needed | Handoff ready or deferred |
-| 2 | `SYT-WS-001C` | Run final package/readiness handoff, pause automation, and give exact user Web Store steps. | Controller | `main` after prior lanes | Final handoff complete |
+| 1 | `SYT-WS-001C` | Close issue #60, stop/delete the heartbeat automation, and give exact user Web Store steps. | Controller | `main` after final docs PR | Final handoff complete |
 
 ## Dynamic Notes
 
@@ -150,3 +149,4 @@ Heartbeat overlap rule:
 - 2026-06-11: User requested final Web Store readiness polish, removal of local `.DS_Store` noise, new/refined graphics, and a 30-minute automation cadence. Controller opened #60 and started `SYT-WS-001`. No version bump, tag, release, or Web Store submission is approved yet.
 - 2026-06-12: `SYT-WS-001A` asset refresh implemented current popup captures, refreshed marketing assets, added marquee promo, updated validation, and refreshed private Web Store notes locally. `npm run assets:store`, `git diff --check`, `npm run validate:all`, and zip inspection passed before PR.
 - 2026-06-12: PR #63 squash-merged at `65a52f7`; no version bump, tag, release, Web Store submission, permission change, or runtime behavior change.
+- 2026-06-12: Final `npm run assets:store`, `npm run validate:all`, asset dimension checks, and zip inspection passed on clean `main`. `SYT-WS-001B` is deferred because the code audit found no Web Store blocker and broad runtime cleanup is higher risk than value before submission.

--- a/docs/swarm/current-state.md
+++ b/docs/swarm/current-state.md
@@ -4,7 +4,7 @@
 
 - Name: Simple YT Tweaks
 - Folder: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
-- Status: existing repo, post-v0.3.0 hardening; `SYT-RC-001` human QA passed, #8/#10 are closed, and `SYT-WS-001` is starting final Web Store readiness polish under #60.
+- Status: existing repo, post-v0.3.0 hardening; `SYT-RC-001` human QA passed, #8/#10 are closed, and `SYT-WS-001` Web Store readiness polish is complete pending user listing/upload approval.
 - GitHub: `https://github.com/cryptoteatime/simple-yt-tweaks`
 
 ## Current Focus
@@ -18,9 +18,10 @@
 2. `SYT-010H-F` integrated one-module `grid-hover.ts` watch-recommendation selector organization cleanup.
 3. `SYT-RC-001` human QA passed on 2026-06-11.
 4. #8 enhanced Home/Search hover grow research is closed as not planned; native YouTube Home/Search hover is the accepted behavior.
-5. New active lane: `SYT-WS-001` / #60 Web Store readiness polish and asset refresh.
+5. `SYT-WS-001` / #60 Web Store readiness polish and asset refresh is complete from the automation side.
 6. `SYT-WS-001A` asset refresh is integrated through PR #63 at `65a52f7`.
-7. Keep version/tag/Web Store release actions out unless explicitly approved.
+7. `SYT-WS-001B` code polish is deferred because the audit found no Web Store blocker and broad runtime cleanup is higher risk than value before submission.
+8. Keep version/tag/Web Store release/upload actions out unless explicitly approved.
 
 ## Recent State
 
@@ -43,6 +44,11 @@
 - `SYT-WS-001B` code audit found no code/manifest no-go; defer broad runtime refactors and keep the watch-to-Home path stable before submission.
 - `SYT-WS-001A` implementation refreshed popup captures, store/repo graphics, asset generation scripts, validation for marquee promo, and local private Web Store notes. `npm run assets:store`, `git diff --check`, `npm run validate:all`, and packaged zip inspection passed.
 - PR #63 merged the asset refresh at `65a52f7`; no runtime behavior, version, tag, release, Web Store submission, or permission changes were made.
+- Final clean-main readiness checks passed on 2026-06-12:
+  - `npm run assets:store`
+  - `npm run validate:all`
+  - store asset dimension check
+  - packaged zip inspection
 
 ## Constraints And Risks
 
@@ -62,7 +68,7 @@
 
 ## Automation Notes
 
-- Controller heartbeat: reactivated for #60 at a 30-minute cadence, id `simple-yt-tweaks-controller-heartbeat`.
+- Controller heartbeat: should be stopped/deleted after the final readiness notification, id `simple-yt-tweaks-controller-heartbeat`.
 - Capacity: up to 3 only for planner-approved disjoint `SYT-WS-001` lanes; review, integration, and runtime implementation stay serial.
 - Shared docs lock: controller owns task-board, current-state, controller-directives, and agent-registry unless a handoff explicitly assigns them.
 - Registry: `docs/swarm/agent-registry.md`.
@@ -70,4 +76,4 @@
 ## Last Updated
 
 - Date: 2026-06-12
-- By: Controller integrating `SYT-WS-001A` / #60 asset refresh
+- By: Controller completing `SYT-WS-001` / #60 Web Store readiness

--- a/docs/swarm/handoffs/SYT-WS-001.md
+++ b/docs/swarm/handoffs/SYT-WS-001.md
@@ -5,7 +5,7 @@
 - Task ID: `SYT-WS-001`
 - GitHub issue: #60
 - Role: Controller / Planner first, then scoped Runners
-- State: `SYT-WS-001A` integrated; `SYT-WS-001B` defer/cleanup decision next
+- State: Complete from automation side; final user Web Store approval/upload remains
 - Repo: `/Users/d4ngl/Git Repos/Codex/simple-yt-tweaks`
 - Current branch: `swarm/syt-ws001a-assets-refresh`
 
@@ -98,7 +98,7 @@ Bring Simple YT Tweaks from RC-passed to nearly Web Store-ready without changing
 
 ## Next Recommended Role
 
-Controller should decide whether to defer `SYT-WS-001B` and route `SYT-WS-001C` final package/readiness handoff. Keep code cleanup conservative; do not touch runtime behavior unless a concrete low-risk test-backed change is selected.
+Controller should close #60, stop/delete the heartbeat automation, and give the user exact final Web Store/release steps. Keep runtime behavior stable until after submission unless the user reports a concrete regression.
 
 ## `SYT-WS-001A` Implementation
 
@@ -149,9 +149,15 @@ Controller should decide whether to defer `SYT-WS-001B` and route `SYT-WS-001C` 
 - Store assets are refreshed in-repo so final Web Store submission can use current collateral after user approval.
 - The final Web Store listing/assets acceptance remains a user gate before submission.
 - PR #63 merged at `65a52f7`.
+- `SYT-WS-001B` is deferred because the audit found no Web Store blocker and broad runtime cleanup is higher risk than value before submission.
+- Final clean-main readiness checks passed:
+  - `npm run assets:store`
+  - `npm run validate:all`
+  - store asset dimension check
+  - packaged zip inspection
 
 ### Next Exact Action
 
-1. Decide whether `SYT-WS-001B` has any low-risk code polish worth doing now.
-2. If not, route `SYT-WS-001C`.
-3. In `SYT-WS-001C`, run final validation/package inspection, pause automation, and give the user exact Web Store/release steps.
+1. Close #60 with the readiness summary.
+2. Stop/delete `simple-yt-tweaks-controller-heartbeat`.
+3. Tell the user the exact remaining Web Store/release steps.

--- a/docs/swarm/task-board.md
+++ b/docs/swarm/task-board.md
@@ -17,10 +17,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 
 | Task ID | Title | Role | Status | Branch | Scope | Parallel | Depends On | Conflict Risk | Handoff | PR |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `SYT-010H-A` | Settings, popup defaults, and persistence | Integrator | Integrated | `swarm/syt-010h-settings-popup` | settings/popup/defaults tests | parallel-safe with B/C while test-only | `SYT-010H` plan | medium | `docs/swarm/handoffs/SYT-010H.md` | #45 merged |
-| `SYT-010H-B` | Selector accuracy and runtime churn audit | Integrator | Integrated | `swarm/syt-010h-selector-runtime-audit` | docs/audit; no production runtime edits | parallel-safe as audit-only | `SYT-010H` plan | low for audit, high for implementation | `docs/swarm/handoffs/SYT-010H-B.md` | #46 merged |
-| `SYT-010H-C` | Swarm docs and context compaction | Integrator | Integrated | `swarm/syt-010h-docs-compaction` | compact hot swarm docs and completed handoff stubs | parallel-safe | `SYT-010H` plan | low/medium docs state | `docs/swarm/handoffs/SYT-010H.md` | #47 merged |
-| `SYT-WS-001` | Web Store readiness polish and asset refresh | Controller | In Progress | `main` plus scoped task branches | route #60 lanes, docs, cadence | serial-required for planning/integration | user request / #60 | low docs, medium follow-up | `docs/swarm/handoffs/SYT-WS-001.md` | #61/#62 merged |
+| none | none | none | none | none | none | none | none | none | none |
 
 ## Hold / Future Tasks
 
@@ -30,8 +27,7 @@ Use this file as the repo-local queue. Keep entries short and route details to h
 | `SYT-010H-E` | Selector helper and fixture gap hardening | Integrated | PR #50; modern Search lockup fixture coverage. |
 | `SYT-010H-F` | Grid-hover watch recommendation selector organization cleanup | Integrated | PR #54; one-module selector organization and unit coverage. |
 | `SYT-RC-002` | Release-candidate polish after #10 hardening | Backlog | After `SYT-010H` and follow-up fixes are integrated. |
-| `SYT-WS-001B` | Final code polish audit and low-risk cleanup | Ready, lower priority | No code/manifest no-go; only pursue low-risk settings/test cleanup. Do not change watch-to-Home behavior before submission without live QA. |
-| `SYT-WS-001C` | Final package/release handoff | Backlog | After assets/code polish pass and `npm run validate:all`; stop automation and give user exact next steps. |
+| `SYT-WS-001B` | Final code polish audit and low-risk cleanup | Deferred | Code audit found no Web Store blocker; broad runtime cleanup is deferred until after submission because behavior is stable. |
 
 ## Completed / Archived
 
@@ -60,6 +56,7 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 | `SYT-RC-001` | PR #55/#56 merged; `validate:all` passed; human QA passed; issue #10 closed |
 | `SYT-008A` | PR #20 closed; issue #8 closed as not planned; native Home/Search hover remains accepted |
 | `SYT-WS-001A` | PR #63 merged at `65a52f7`; refreshed current store/repo graphics, popup captures, asset scripts, and validation |
+| `SYT-WS-001C` | Final readiness checks passed on clean `main`; heartbeat should stop after user-facing final handoff |
 
 ## Review / Integration Queues
 
@@ -80,5 +77,5 @@ Completed lanes are stubs in `docs/swarm/handoffs/` and indexed in `docs/swarm/a
 - Capacity returns to serial for runtime implementation after the A/B/C burst.
 - Runtime source changes, review, integration, merge conflicts, and release-candidate work stay serial.
 - Current controller phase: #60 readiness polish. Keep first pass docs/planning-only, then route scoped lanes. No version/release/Web Store submission until explicit approval.
-- `SYT-WS-001A` asset/listing refresh is integrated. Decide whether to defer `SYT-WS-001B`; otherwise route `SYT-WS-001C` final handoff.
+- `SYT-WS-001` is complete from the automation side. Close #60, stop/delete the heartbeat, and give the user final Web Store/release steps.
 - Do not route Home/Search hover research unless the user opens a fresh issue.


### PR DESCRIPTION
## Summary
- mark `SYT-WS-001` complete from the automation side
- record `SYT-WS-001B` as deferred before submission because the audit found no Web Store blocker
- point the controller at closing #60, stopping the heartbeat, and handing final Web Store steps to the user

Refs #60.

## How to test / what to tell the controller
- human review requested: no
- commands run:
  - `git diff --check`
  - `npm run assets:store`
  - `npm run validate:all`
  - `unzip -l release/simple-yt-tweaks-v0.3.0.zip`
- expected result:
  - final docs describe no active tasks and a user approval/upload gate only
  - final clean-main validation and package inspection are recorded
  - no version bump, tag, release, permission change, or Web Store submission occurs
- controller feedback format:
  - `PR #<number> Ready to Integrate: <notes>`
  - or `PR #<number> Needs Fixes: <file/line and observed problem>`